### PR TITLE
use an allow list for local directory storage driver

### DIFF
--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -16,6 +16,7 @@ import (
 	filecoinunsealed "github.com/filecoin-project/bacalhau/pkg/storage/filecoin_unsealed"
 	"github.com/filecoin-project/bacalhau/pkg/storage/inline"
 	apicopy "github.com/filecoin-project/bacalhau/pkg/storage/ipfs_apicopy"
+	local_directory "github.com/filecoin-project/bacalhau/pkg/storage/local_directory"
 	noop_storage "github.com/filecoin-project/bacalhau/pkg/storage/noop"
 	"github.com/filecoin-project/bacalhau/pkg/storage/url/urldownload"
 	"github.com/filecoin-project/bacalhau/pkg/system"
@@ -48,6 +49,11 @@ func NewStandardStorageProvider(
 	}
 
 	filecoinUnsealedStorage, err := filecoinunsealed.NewStorage(cm, options.FilecoinUnsealedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	localDirectoryStorage, err := local_directory.NewStorage(cm)
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +102,7 @@ func NewStandardStorageProvider(
 		model.StorageSourceURLDownload:      urlDownloadStorage,
 		model.StorageSourceFilecoinUnsealed: filecoinUnsealedStorage,
 		model.StorageSourceInline:           inlineStorage,
+		model.StorageSourceLocalDirectory:   localDirectoryStorage,
 	}), nil
 }
 

--- a/pkg/storage/local_directory/storage_test.go
+++ b/pkg/storage/local_directory/storage_test.go
@@ -32,7 +32,7 @@ func (suite *LocalDirectorySuite) prepareStorageSpec(sourcePath string) model.St
 	return model.StorageSpec{
 		// source path is some kind of sub-path
 		// inside our local folder
-		SourcePath: sourcePath,
+		SourcePath: folderPath,
 		Path:       "/path/inside/the/container",
 	}
 }
@@ -50,7 +50,7 @@ func (suite *LocalDirectorySuite) SetupTest() {
 	cm = system.NewCleanupManager()
 	ctx = context.Background()
 	tempDir = suite.T().TempDir()
-	driver, setupErr = NewStorage(cm, tempDir)
+	driver, setupErr = NewStorage(cm)
 	require.NoError(suite.T(), setupErr)
 }
 
@@ -99,5 +99,5 @@ func (suite *LocalDirectorySuite) TestExplode() {
 	exploded, err := driver.Explode(ctx, spec)
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), len(exploded), 1, "the exploded list should be 1 item long")
-	require.Equal(suite.T(), exploded[0].SourcePath, subpath, "the subpath is correct")
+	require.Equal(suite.T(), exploded[0].SourcePath, filepath.Join(tempDir, subpath), "the subpath is correct")
 }


### PR DESCRIPTION
This removes the idea of a base folder for the local directory storage driver and reverts control to an "allow list" of local directories that is configured via an environment variable.

This allows compute providers to be specific about which local folders they are willing to offer to jobs.