### PR TITLE
Removes cancelled task from logging sensor

### DIFF
--- a/pkg/compute/executor_buffer.go
+++ b/pkg/compute/executor_buffer.go
@@ -213,7 +213,14 @@ func (s *ExecutorBuffer) Cancel(_ context.Context, execution store.Execution) er
 		ctx = system.AddNodeIDToBaggage(ctx, s.ID)
 		ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Cancel")
 		defer span.End()
-		_ = s.delegateService.Cancel(ctx, execution)
+
+		err := s.delegateService.Cancel(ctx, execution)
+		if err == nil {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+
+			delete(s.running, execution.ID)
+		}
 	}()
 	return nil
 }


### PR DESCRIPTION
Currently the ActiveJobs logging_sensor will continue to report a job, even if it has been cancelled. The job is recorded as having the previous state to the cancellation.

This PR removes the job from the map of running/active jobs so that it does not continue to show as running.

Fixes #2073 