### PR TITLE
fix DevstackConcurrencySuite flakiness

### DIFF
--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -35,7 +35,9 @@ func (suite *DevstackConcurrencySuite) TestConcurrencyLimit() {
 		"Hello, world!\nHello, world!\n",
 	)
 	testCase.JobCheckers = []job.CheckStatesFunction{
-		job.WaitForSuccessfulCompletion(),
+		job.WaitForExecutionStates(map[model.ExecutionStateType]int{
+			model.ExecutionStateCompleted: testCase.Deal.Concurrency,
+		}),
 	}
 
 	suite.RunScenario(testCase)


### PR DESCRIPTION
a job is completed when at least one execution publishes the result. This test scenario however verifies that both executions eventually publish their results. The fix is by waiting for the two executiosn to complete and not for the job to be marked as completed