### PR TITLE
Don't trace local activity when DO_NOT_TRACK

### DIFF
--- a/cmd/bacalhau/cancel_test.go
+++ b/cmd/bacalhau/cancel_test.go
@@ -33,7 +33,7 @@ func (suite *CancelSuite) TestCancelTerminalJob() {
 	testFile := "../../pkg/model/tasks/docker_task.json"
 
 	ctx := context.Background()
-	_, stdout, err := ExecuteTestCobraCommand(suite.T(), "create",
+	_, stdout, err := ExecuteTestCobraCommand("create",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
 		testFile,
@@ -43,7 +43,7 @@ func (suite *CancelSuite) TestCancelTerminalJob() {
 	job := testutils.GetJobFromTestOutput(ctx, suite.T(), suite.client, stdout)
 	suite.T().Logf("Created job %s", job.Metadata.ID)
 
-	_, stdout, err = ExecuteTestCobraCommand(suite.T(), "cancel",
+	_, stdout, err = ExecuteTestCobraCommand("cancel",
 		job.Metadata.ID,
 		"--api-host", suite.host,
 		"--api-port", suite.port,
@@ -57,7 +57,7 @@ func (suite *CancelSuite) TestCancelJob() {
 
 	ctx := context.Background()
 
-	_, stdout, err := ExecuteTestCobraCommand(suite.T(), "create",
+	_, stdout, err := ExecuteTestCobraCommand("create",
 		"--wait=false",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
@@ -72,7 +72,7 @@ func (suite *CancelSuite) TestCancelJob() {
 	jobInfo, _, err := suite.client.Get(ctx, stdout)
 	require.NoError(suite.T(), err, "Error finding newly created job")
 
-	_, stdout, err = ExecuteTestCobraCommand(suite.T(), "cancel",
+	_, stdout, err = ExecuteTestCobraCommand("cancel",
 		jobInfo.Job.Metadata.ID,
 		"--api-host", suite.host,
 		"--api-port", suite.port,

--- a/cmd/bacalhau/create_test.go
+++ b/cmd/bacalhau/create_test.go
@@ -53,7 +53,7 @@ func (s *CreateSuite) TestCreateGenericSubmit() {
 			}
 			s.Run(name, func() {
 				ctx := context.Background()
-				_, out, err := ExecuteTestCobraCommand(s.T(), "create",
+				_, out, err := ExecuteTestCobraCommand("create",
 					"--api-host", s.host,
 					"--api-port", s.port,
 					testFile,
@@ -72,7 +72,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 	testSpec, err := os.Open(testFile)
 	require.NoError(s.T(), err)
 
-	_, out, err := ExecuteTestCobraCommandWithStdin(s.T(), testSpec, "create",
+	_, out, err := ExecuteTestCobraCommandWithStdin(testSpec, "create",
 		"--api-host", s.host,
 		"--api-port", s.port,
 	)
@@ -81,7 +81,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 
 	// Now run describe on the ID we got back
 	job := testutils.GetJobFromTestOutput(context.Background(), s.T(), s.client, out)
-	_, _, err = ExecuteTestCobraCommand(s.T(), "describe",
+	_, _, err = ExecuteTestCobraCommand("describe",
 		"--api-host", s.host,
 		"--api-port", s.port,
 		job.Metadata.ID,
@@ -104,7 +104,7 @@ func (s *CreateSuite) TestCreateDontPanicOnNoInput() {
 	commandChan := make(chan commandReturn, 1)
 
 	go func() {
-		c, out, err := ExecuteTestCobraCommand(s.T(), "create")
+		c, out, err := ExecuteTestCobraCommand("create")
 
 		commandChan <- commandReturn{c: c, out: out, err: err}
 	}()
@@ -142,7 +142,7 @@ func (s *CreateSuite) TestCreateDontPanicOnEmptyFile() {
 	commandChan := make(chan commandReturn, 1)
 
 	go func() {
-		c, out, err := ExecuteTestCobraCommand(s.T(), "create", "../../testdata/empty.yaml")
+		c, out, err := ExecuteTestCobraCommand("create", "../../testdata/empty.yaml")
 
 		commandChan <- commandReturn{c: c, out: out, err: err}
 	}()

--- a/cmd/bacalhau/describe_test.go
+++ b/cmd/bacalhau/describe_test.go
@@ -22,7 +22,7 @@ type DescribeSuite struct {
 	BaseSuite
 }
 
-func (suite *DescribeSuite) TestDescribeJob() {
+func (s *DescribeSuite) TestDescribeJob() {
 	tests := []struct {
 		numberOfAcceptNodes int
 		numberOfRejectNodes int
@@ -50,65 +50,65 @@ func (suite *DescribeSuite) TestDescribeJob() {
 					for k := 0; k < n.numOfJobs; k++ {
 						j := testutils.MakeNoopJob()
 						j.Spec.Docker.Entrypoint = []string{"Entrypoint-Unique-Array", uuid.NewString()}
-						s, err := suite.client.Submit(ctx, j)
-						require.NoError(suite.T(), err)
-						submittedJob = s // Default to the last job submitted, should be fine?
+						job, err := s.client.Submit(ctx, j)
+						require.NoError(s.T(), err)
+						submittedJob = job // Default to the last job submitted, should be fine?
 					}
 				}
 				returnedJobDescription := &model.JobWithInfo{}
 
 				// No job id (should error)
-				_, out, err := ExecuteTestCobraCommand(suite.T(), "describe",
-					"--api-host", suite.host,
-					"--api-port", suite.port,
+				_, out, err := ExecuteTestCobraCommand("describe",
+					"--api-host", s.host,
+					"--api-port", s.port,
 				)
-				require.Error(suite.T(), err, "Submitting a describe request with no id should error.")
+				require.Error(s.T(), err, "Submitting a describe request with no id should error.")
 
 				// Job Id at the end
-				_, out, err = ExecuteTestCobraCommand(suite.T(), "describe",
-					"--api-host", suite.host,
-					"--api-port", suite.port,
+				_, out, err = ExecuteTestCobraCommand("describe",
+					"--api-host", s.host,
+					"--api-port", s.port,
 					submittedJob.Metadata.ID,
 				)
-				require.NoError(suite.T(), err, "Error in describing job: %+v", err)
+				require.NoError(s.T(), err, "Error in describing job: %+v", err)
 
 				err = model.YAMLUnmarshalWithMax([]byte(out), returnedJobDescription)
-				require.NoError(suite.T(), err, "Error in unmarshalling description: %+v", err)
+				require.NoError(s.T(), err, "Error in unmarshalling description: %+v", err)
 
-				require.Equal(suite.T(), submittedJob.Metadata.ID, returnedJobDescription.Job.Metadata.ID, "IDs do not match.")
-				require.Equal(suite.T(),
+				require.Equal(s.T(), submittedJob.Metadata.ID, returnedJobDescription.Job.Metadata.ID, "IDs do not match.")
+				require.Equal(s.T(),
 					submittedJob.Spec.Docker.Entrypoint[0],
 					returnedJobDescription.Job.Spec.Docker.Entrypoint[0],
 					fmt.Sprintf("Submitted job entrypoints not the same as the description. %d - %d - %s - %d", tc.numberOfAcceptNodes, tc.numberOfRejectNodes, tc.jobState, n.numOfJobs))
 
 				// Job Id in the middle
-				_, out, err = ExecuteTestCobraCommand(suite.T(), "describe",
-					"--api-host", suite.host,
+				_, out, err = ExecuteTestCobraCommand("describe",
+					"--api-host", s.host,
 					submittedJob.Metadata.ID,
-					"--api-port", suite.port,
+					"--api-port", s.port,
 				)
 
-				require.NoError(suite.T(), err, "Error in describing job: %+v", err)
+				require.NoError(s.T(), err, "Error in describing job: %+v", err)
 				err = model.YAMLUnmarshalWithMax([]byte(out), returnedJobDescription)
-				require.NoError(suite.T(), err, "Error in unmarshalling description: %+v", err)
-				require.Equal(suite.T(), submittedJob.Metadata.ID, returnedJobDescription.Job.Metadata.ID, "IDs do not match.")
-				require.Equal(suite.T(),
+				require.NoError(s.T(), err, "Error in unmarshalling description: %+v", err)
+				require.Equal(s.T(), submittedJob.Metadata.ID, returnedJobDescription.Job.Metadata.ID, "IDs do not match.")
+				require.Equal(s.T(),
 					submittedJob.Spec.Docker.Entrypoint[0],
 					returnedJobDescription.Job.Spec.Docker.Entrypoint[0],
 					fmt.Sprintf("Submitted job entrypoints not the same as the description. %d - %d - %s - %d", tc.numberOfAcceptNodes, tc.numberOfRejectNodes, tc.jobState, n.numOfJobs))
 
 				// Short job id
-				_, out, err = ExecuteTestCobraCommand(suite.T(), "describe",
-					"--api-host", suite.host,
+				_, out, err = ExecuteTestCobraCommand("describe",
+					"--api-host", s.host,
 					submittedJob.Metadata.ID[0:model.ShortIDLength],
-					"--api-port", suite.port,
+					"--api-port", s.port,
 				)
 
-				require.NoError(suite.T(), err, "Error in describing job: %+v", err)
+				require.NoError(s.T(), err, "Error in describing job: %+v", err)
 				err = model.YAMLUnmarshalWithMax([]byte(out), returnedJobDescription)
-				require.NoError(suite.T(), err, "Error in unmarshalling description: %+v", err)
-				require.Equal(suite.T(), submittedJob.Metadata.ID, returnedJobDescription.Job.Metadata.ID, "IDs do not match.")
-				require.Equal(suite.T(),
+				require.NoError(s.T(), err, "Error in unmarshalling description: %+v", err)
+				require.Equal(s.T(), submittedJob.Metadata.ID, returnedJobDescription.Job.Metadata.ID, "IDs do not match.")
+				require.Equal(s.T(),
 					submittedJob.Spec.Docker.Entrypoint[0],
 					returnedJobDescription.Job.Spec.Docker.Entrypoint[0],
 					fmt.Sprintf("Submitted job entrypoints not the same as the description. %d - %d - %s - %d", tc.numberOfAcceptNodes, tc.numberOfRejectNodes, tc.jobState, n.numOfJobs))
@@ -119,7 +119,7 @@ func (suite *DescribeSuite) TestDescribeJob() {
 
 }
 
-func (suite *DescribeSuite) TestDescribeJobIncludeEvents() {
+func (s *DescribeSuite) TestDescribeJobIncludeEvents() {
 	tests := []struct {
 		includeEvents bool
 	}{
@@ -133,31 +133,31 @@ func (suite *DescribeSuite) TestDescribeJobIncludeEvents() {
 			ctx := context.Background()
 
 			j := testutils.MakeNoopJob()
-			s, err := suite.client.Submit(ctx, j)
-			require.NoError(suite.T(), err)
-			submittedJob = s // Default to the last job submitted, should be fine?
+			job, err := s.client.Submit(ctx, j)
+			require.NoError(s.T(), err)
+			submittedJob = job // Default to the last job submitted, should be fine?
 
 			var returnedJob = &model.Job{}
 
 			var args []string
 
-			args = append(args, "describe", "--api-host", suite.host, "--api-port", suite.port, submittedJob.Metadata.ID)
+			args = append(args, "describe", "--api-host", s.host, "--api-port", s.port, submittedJob.Metadata.ID)
 			if tc.includeEvents {
 				args = append(args, "--include-events")
 			}
 
 			// Job Id at the end
-			_, out, err := ExecuteTestCobraCommand(suite.T(), args...)
-			require.NoError(suite.T(), err, "Error in describing job: %+v", err)
+			_, out, err := ExecuteTestCobraCommand(args...)
+			require.NoError(s.T(), err, "Error in describing job: %+v", err)
 
 			err = model.YAMLUnmarshalWithMax([]byte(out), &returnedJob)
-			require.NoError(suite.T(), err, "Error in unmarshalling description: %+v", err)
+			require.NoError(s.T(), err, "Error in unmarshalling description: %+v", err)
 
 			// TODO: #600 When we figure out how to add events to a noop job, uncomment the below
-			// require.True(suite.T(), eventsWereIncluded == tc.includeEvents,
+			// require.True(s.T(), eventsWereIncluded == tc.includeEvents,
 			// 	fmt.Sprintf("Events include: %v\nExpected: %v", eventsWereIncluded, tc.includeEvents))
 
-			// require.True(suite.T(), localEventsWereIncluded == tc.includeEvents,
+			// require.True(s.T(), localEventsWereIncluded == tc.includeEvents,
 			// 	fmt.Sprintf("Events included: %v\nExpected: %v", localEventsWereIncluded, tc.includeEvents))
 
 		}()
@@ -208,7 +208,7 @@ func (s *DescribeSuite) TestDescribeJobEdgeCases() {
 					jobID = tc.describeIDEdgecase
 				}
 
-				_, out, err = ExecuteTestCobraCommand(s.T(), "describe",
+				_, out, err = ExecuteTestCobraCommand("describe",
 					"--api-host", s.host,
 					"--api-port", s.port,
 					jobID,
@@ -225,7 +225,7 @@ func (s *DescribeSuite) TestDescribeJobEdgeCases() {
 						fmt.Sprintf("Submitted job entrypoints not the same as the description. Edgecase: %s", tc.describeIDEdgecase))
 				} else {
 					c := &model.TestFatalErrorHandlerContents{}
-					model.JSONUnmarshalWithMax([]byte(out), &c)
+					s.NoError(model.JSONUnmarshalWithMax([]byte(out), &c))
 					e := bacerrors.NewJobNotFound(tc.describeIDEdgecase)
 					require.Contains(s.T(), c.Message, e.GetMessage(), "Job not found error string not found.", err)
 				}

--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -397,7 +397,6 @@ func CreateJob(ctx context.Context, cmdArgs []string, odr *DockerRunOptions) (*m
 		odr.ShardingGlobPattern,
 		odr.ShardingBasePath,
 		odr.ShardingBatchSize,
-		doNotTrack,
 	)
 	if err != nil {
 		return &model.Job{}, errors.Wrap(err, "CreateJobSpecAndDeal")

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -67,10 +67,10 @@ func (s *DockerRunSuite) TestRun_GenericSubmit() {
 	}
 
 	for i, tc := range tests {
-		func() {
+		s.Run(fmt.Sprintf("job%d", tc.numberOfJobs), func() {
 			ctx := context.Background()
 			randomUUID := uuid.New()
-			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
+			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
 				"--api-port", s.port,
 				"ubuntu",
@@ -80,7 +80,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmit() {
 			require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %d. Job number: %d", tc.numberOfJobs, i)
 
 			_ = testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
-		}()
+		})
 	}
 }
 
@@ -95,7 +95,7 @@ func (s *DockerRunSuite) TestRun_DryRun() {
 		func() {
 			randomUUID := uuid.New()
 			entrypointCommand := fmt.Sprintf("echo %s", randomUUID.String())
-			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
+			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
 				"--api-port", s.port,
 				"ubuntu",
@@ -105,7 +105,7 @@ func (s *DockerRunSuite) TestRun_DryRun() {
 			require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %d. Job number: %d", tc.numberOfJobs, i)
 
 			require.NoError(s.T(), err)
-			require.Contains(s.T(), string(out), randomUUID.String(), "Dry run failed to contain UUID %s", randomUUID.String())
+			require.Contains(s.T(), out, randomUUID.String(), "Dry run failed to contain UUID %s", randomUUID.String())
 
 			var j *model.Job
 			require.NoError(s.T(), model.YAMLUnmarshalWithMax([]byte(out), &j))
@@ -141,7 +141,7 @@ func (s *DockerRunSuite) TestRun_GPURequests() {
 			ctx := context.Background()
 			allArgs := []string{"docker", "run", "--api-host", s.host, "--api-port", s.port}
 			allArgs = append(allArgs, tc.submitArgs...)
-			_, out, submitErr := ExecuteTestCobraCommand(s.T(), allArgs...)
+			_, out, submitErr := ExecuteTestCobraCommand(allArgs...)
 
 			if tc.fatalErr {
 				require.Contains(s.T(), out, tc.errString, "Did not find expected error message for fatalError in error string.\nExpected: %s\nActual: %s", tc.errString, out)
@@ -177,7 +177,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 			swarmAddresses, err := s.node.IPFSClient.SwarmAddresses(ctx)
 			require.NoError(s.T(), err)
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
+			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
 				"--api-port", s.port,
 				"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
@@ -242,7 +242,7 @@ func (s *DockerRunSuite) TestRun_SubmitInputs() {
 				}
 				flagsArray = append(flagsArray, "ubuntu", "cat", "/inputs/foo.txt") // This doesn't exist, but shouldn't error
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
+				_, out, err := ExecuteTestCobraCommand(flagsArray...)
 				require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
 
 				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
@@ -306,7 +306,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 				flagsArray = append(flagsArray, turls.inputURL.flag, turls.inputURL.url)
 				flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", turls.inputURL.pathInContainer, turls.inputURL.filename))
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
+				_, out, err := ExecuteTestCobraCommand(flagsArray...)
 				require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
 
 				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
@@ -367,7 +367,7 @@ func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 				}
 				flagsArray = append(flagsArray, "ubuntu", "echo", "'hello world'")
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
+				_, out, err := ExecuteTestCobraCommand(flagsArray...)
 
 				if tcids.err != "" {
 					firstFatalError, err := testutils.FirstFatalError(s.T(), out)
@@ -427,7 +427,7 @@ func (s *DockerRunSuite) TestRun_CreatedAt() {
 	for i, tc := range tests {
 		func() {
 			ctx := context.Background()
-			_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
+			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
 				"--api-port", s.port,
 				"ubuntu",
@@ -497,7 +497,7 @@ func (s *DockerRunSuite) TestRun_Annotations() {
 				randNum, _ := crand.Int(crand.Reader, big.NewInt(10000))
 				args = append(args, "ubuntu", "echo", fmt.Sprintf("'hello world - %s'", randNum.String()))
 
-				_, out, err := ExecuteTestCobraCommand(s.T(), args...)
+				_, out, err := ExecuteTestCobraCommand(args...)
 				require.NoError(s.T(), err, "Error submitting job. Run - Number of Jobs: %d. Job number: %d", tc.numberOfJobs, i)
 
 				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
@@ -547,7 +547,7 @@ func (s *DockerRunSuite) TestRun_EdgeCaseCLI() {
 			ctx := context.Background()
 			allArgs := []string{"docker", "run", "--api-host", s.host, "--api-port", s.port}
 			allArgs = append(allArgs, tc.submitArgs...)
-			_, out, submitErr := ExecuteTestCobraCommand(s.T(), allArgs...)
+			_, out, submitErr := ExecuteTestCobraCommand(allArgs...)
 
 			if tc.fatalErr {
 				require.Contains(s.T(), out, tc.errString, "Did not find expected error message for fatalError in error string.\nExpected: %s\nActual: %s", tc.errString, out)
@@ -591,7 +591,7 @@ func (s *DockerRunSuite) TestRun_SubmitWorkdir() {
 			flagsArray = append(flagsArray, "-w", tc.workdir)
 			flagsArray = append(flagsArray, "ubuntu", "pwd")
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
+			_, out, err := ExecuteTestCobraCommand(flagsArray...)
 
 			if tc.error_code != 0 {
 				fatalError, err := testutils.FirstFatalError(s.T(), out)
@@ -645,7 +645,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		"ubuntu", "echo", "hello",
 	}
 
-	_, _, submitErr := ExecuteTestCobraCommand(s.T(), allArgs...)
+	_, _, submitErr := ExecuteTestCobraCommand(allArgs...)
 	require.NoError(s.T(), submitErr)
 }
 
@@ -660,7 +660,7 @@ func (s *DockerRunSuite) TestRun_Deterministic_Verifier() {
 		parsedBasedURI, _ := url.Parse(apiClient.BaseURI)
 		host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
 
-		_, out, err := ExecuteTestCobraCommand(s.T(),
+		_, out, err := ExecuteTestCobraCommand(
 			"docker", "run",
 			"--api-host", host,
 			"--api-port", port,
@@ -783,7 +783,7 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 
 			flagsArray = append(flagsArray, "ubuntu", "--", "perl", fmt.Sprintf(`-e "print \"=\" x %d"`, tc.inputLength))
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), flagsArray...)
+			_, out, err := ExecuteTestCobraCommand(flagsArray...)
 			require.NoError(s.T(), err, "Error submitting job. Name: %s. Expected Length: %s", name, tc.expectedLength)
 
 			_ = testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
@@ -826,7 +826,7 @@ func (s *DockerRunSuite) TestRun_MutlipleURLs() {
 
 	for _, tc := range tests {
 		ctx := context.Background()
-		args := []string{}
+		var args []string
 
 		args = append(args, "docker", "run",
 			"--api-host", s.host,
@@ -835,7 +835,7 @@ func (s *DockerRunSuite) TestRun_MutlipleURLs() {
 		args = append(args, tc.inputFlags...)
 		args = append(args, "ubuntu", "--", "ls", "/input")
 
-		_, out, err := ExecuteTestCobraCommand(s.T(), args...)
+		_, out, err := ExecuteTestCobraCommand(args...)
 		require.NoError(s.T(), err, "Error submitting job")
 
 		j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
@@ -881,7 +881,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 	for name, tc := range tests {
 		s.Run(name, func() {
 
-			args := []string{}
+			var args []string
 
 			args = append(args, "docker", "run",
 				"--api-host", s.host,
@@ -889,7 +889,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 			)
 			args = append(args, tc.imageName, "--", tc.executable)
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), args...)
+			_, out, err := ExecuteTestCobraCommand(args...)
 			require.NoError(s.T(), err, "Error submitting job")
 
 			if !tc.isValid {
@@ -903,7 +903,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 
 func (s *DockerRunSuite) TestRun_Timeout_DefaultValue() {
 	ctx := context.Background()
-	_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
+	_, out, err := ExecuteTestCobraCommand("docker", "run",
 		"--api-host", s.host,
 		"--api-port", s.port,
 		"ubuntu",
@@ -920,7 +920,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 	var expectedTimeout float64 = 999
 
 	ctx := context.Background()
-	_, out, err := ExecuteTestCobraCommand(s.T(), "docker", "run",
+	_, out, err := ExecuteTestCobraCommand("docker", "run",
 		"--api-host", s.host,
 		"--api-port", s.port,
 		"--timeout", fmt.Sprintf("%f", expectedTimeout),

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -5,6 +5,7 @@ package bacalhau
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +39,7 @@ func (s *GetSuite) SetupTest() {
 }
 
 func testResultsFolderStructure(t *testing.T, baseFolder, hostID string) {
-	files := []string{}
+	var files []string
 	err := filepath.Walk(baseFolder, func(path string, _ os.FileInfo, _ error) error {
 		usePath := strings.Replace(path, baseFolder, "", 1)
 		if usePath != "" {
@@ -112,7 +113,7 @@ func setupTempWorkingDir(t *testing.T) (string, func()) {
 	newTempDir, err := os.Getwd()
 	require.NoError(t, err)
 	return newTempDir, func() {
-		os.Chdir(originalWd)
+		assert.NoError(t, os.Chdir(originalWd))
 	}
 }
 
@@ -148,7 +149,7 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderAutoDownload() {
 		"--wait",
 		"--download",
 	})
-	_, runOutput, err := ExecuteTestCobraCommand(s.T(), args...)
+	_, runOutput, err := ExecuteTestCobraCommand(args...)
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(runOutput)
 	hostID := s.node.Host.ID().String()
@@ -169,7 +170,7 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderNamedDownload() {
 		"--download",
 		"--output-dir", tempDir,
 	})
-	_, runOutput, err := ExecuteTestCobraCommand(s.T(), args...)
+	_, runOutput, err := ExecuteTestCobraCommand(args...)
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(runOutput)
 	hostID := s.node.Host.ID().String()
@@ -189,12 +190,12 @@ func (s *GetSuite) TestGetWriteToJobFolderAutoDownload() {
 	args := s.getDockerRunArgs([]string{
 		"--wait",
 	})
-	_, out, err := ExecuteTestCobraCommand(s.T(), args...)
+	_, out, err := ExecuteTestCobraCommand(args...)
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(out)
 	hostID := s.node.Host.ID().String()
 
-	_, getOutput, err := ExecuteTestCobraCommand(s.T(), "get",
+	_, getOutput, err := ExecuteTestCobraCommand("get",
 		"--api-host", s.node.APIServer.Address,
 		"--api-port", fmt.Sprintf("%d", s.node.APIServer.Port),
 		"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
@@ -219,13 +220,13 @@ func (s *GetSuite) TestGetWriteToJobFolderNamedDownload() {
 	args := s.getDockerRunArgs([]string{
 		"--wait",
 	})
-	_, out, err := ExecuteTestCobraCommand(s.T(), args...)
+	_, out, err := ExecuteTestCobraCommand(args...)
 
 	require.NoError(s.T(), err, "Error submitting job")
 	jobID := system.FindJobIDInTestOutput(out)
 	hostID := s.node.Host.ID().String()
 
-	_, getOutput, err := ExecuteTestCobraCommand(s.T(), "get",
+	_, getOutput, err := ExecuteTestCobraCommand("get",
 		"--api-host", s.node.APIServer.Address,
 		"--api-port", fmt.Sprintf("%d", s.node.APIServer.Port),
 		"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -54,7 +54,7 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 				require.NoError(suite.T(), err)
 			}
 
-			_, out, err := ExecuteTestCobraCommand(suite.T(), "list",
+			_, out, err := ExecuteTestCobraCommand("list",
 				"--hide-header",
 				"--api-host", suite.host,
 				"--api-port", suite.port,
@@ -72,8 +72,8 @@ func (suite *ListSuite) TestList_IdFilter() {
 	ctx := context.Background()
 
 	// submit 10 jobs
-	jobIds := []string{}
-	jobLongIds := []string{}
+	var jobIds []string
+	var jobLongIds []string
 	for i := 0; i < 10; i++ {
 		var err error
 		j := testutils.MakeNoopJob()
@@ -82,7 +82,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 		jobLongIds = append(jobIds, j.Metadata.ID)
 		require.NoError(suite.T(), err)
 	}
-	_, out, err := ExecuteTestCobraCommand(suite.T(), "list",
+	_, out, err := ExecuteTestCobraCommand("list",
 		"--hide-header",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
@@ -91,7 +91,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 	require.NoError(suite.T(), err)
 
 	// parse list output
-	seenIds := []string{}
+	var seenIds []string
 	for _, line := range strings.Split(out, "\n") {
 		parts := strings.Split(line, " ")
 		if len(parts) > 2 {
@@ -105,7 +105,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 	//// Test --output json
 
 	// _, out, err = ExecuteTestCobraCommand(suite.T(), suite.rootCmd, "list",
-	_, out, err = ExecuteTestCobraCommand(suite.T(), "list",
+	_, out, err = ExecuteTestCobraCommand("list",
 		"--hide-header",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
@@ -158,7 +158,7 @@ func (suite *ListSuite) TestList_AnnotationFilter() {
 		testCases = append(testCases, testCase{
 			fmt.Sprintf("%s excluded with other tags", string(tag)),
 			[]string{string(tag)},
-			[]string{string("test")},
+			[]string{"test"},
 			false,
 			false,
 			false,
@@ -185,7 +185,7 @@ func (suite *ListSuite) TestList_AnnotationFilter() {
 					"--output", "json",
 				}
 				args = append(args, flags...)
-				_, out, err := ExecuteTestCobraCommand(suite.T(), args...)
+				_, out, err := ExecuteTestCobraCommand(args...)
 				require.NoError(suite.T(), err)
 
 				response := publicapi.ListResponse{}
@@ -205,7 +205,7 @@ func (suite *ListSuite) TestList_AnnotationFilter() {
 
 			// list with label included
 			suite.Run("label_included", func() {
-				flags := []string{}
+				var flags []string
 				for _, label := range tc.ListLabels {
 					flags = append(flags, "--include-tag", label)
 				}
@@ -214,7 +214,7 @@ func (suite *ListSuite) TestList_AnnotationFilter() {
 
 			// list with label excluded
 			suite.Run("label_excluded", func() {
-				flags := []string{}
+				var flags []string
 				for _, label := range tc.ListLabels {
 					flags = append(flags, "--exclude-tag", label)
 				}
@@ -284,8 +284,7 @@ func (suite *ListSuite) TestList_SortFlags() {
 					reverseString = "--reverse"
 				}
 
-				_, out, err := ExecuteTestCobraCommand(suite.T(),
-					"list",
+				_, out, err := ExecuteTestCobraCommand("list",
 					"--hide-header",
 					"--no-style",
 					"--api-host", suite.host,
@@ -314,7 +313,7 @@ func (suite *ListSuite) TestList_SortFlags() {
 						}
 
 						compareIds := jobIDs[0:tc.numberOfJobsOutput]
-						seenIds := []string{}
+						var seenIds []string
 
 						for _, line := range strings.Split(out, "\n") {
 							parts := strings.Split(line, " ")

--- a/cmd/bacalhau/root.go
+++ b/cmd/bacalhau/root.go
@@ -21,7 +21,6 @@ import (
 
 var apiHost string
 var apiPort int
-var doNotTrack bool
 
 var loggingMode = logger.LogModeDefault
 
@@ -145,14 +144,6 @@ func Execute() {
 	ctx, cancel := signal.NotifyContext(context.Background(), ShutdownSignals...)
 	defer cancel()
 	rootCmd.SetContext(ctx)
-
-	doNotTrack = false
-	if doNotTrackValue, foundDoNotTrack := os.LookupEnv("DO_NOT_TRACK"); foundDoNotTrack {
-		doNotTrackInt, err := strconv.Atoi(doNotTrackValue)
-		if err == nil && doNotTrackInt == 1 {
-			doNotTrack = true
-		}
-	}
 
 	viper.SetEnvPrefix("BACALHAU")
 

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -208,7 +208,6 @@ func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) er
 		OLR.RequirementsPath,
 		OLR.Deterministic,
 		OLR.Labels,
-		doNotTrack,
 	)
 	if err != nil {
 		return err

--- a/cmd/bacalhau/test_utils.go
+++ b/cmd/bacalhau/test_utils.go
@@ -1,0 +1,35 @@
+package bacalhau
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+func ExecuteTestCobraCommand(args ...string) (c *cobra.Command, output string, err error) {
+	return ExecuteTestCobraCommandWithStdin(nil, args...)
+}
+
+func ExecuteTestCobraCommandWithStdin(stdin io.Reader, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	root := NewRootCmd()
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetIn(stdin)
+	root.SetArgs(args)
+
+	// Need to check if we're running in debug mode for VSCode
+	// Empty them if they exist
+	if (len(os.Args) > 2) && (os.Args[1] == "-test.run") {
+		os.Args[1] = ""
+		os.Args[2] = ""
+	}
+
+	log.Trace().Msgf("Command to execute: %v", root.CalledAs())
+
+	c, err = root.ExecuteC()
+	return c, buf.String(), err
+}

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -159,33 +158,6 @@ curl -sL https://get.bacalhau.org/install.sh | bash`,
 		)
 	}
 	return nil
-}
-
-func ExecuteTestCobraCommand(t *testing.T, args ...string) (c *cobra.Command, output string, err error) {
-	return ExecuteTestCobraCommandWithStdin(t, nil, args...)
-}
-
-func ExecuteTestCobraCommandWithStdin(_ *testing.T, stdin io.Reader, args ...string) (
-	c *cobra.Command, output string, err error,
-) { //nolint:unparam // use of t is valuable here
-	buf := new(bytes.Buffer)
-	root := NewRootCmd()
-	root.SetOut(buf)
-	root.SetErr(buf)
-	root.SetIn(stdin)
-	root.SetArgs(args)
-
-	// Need to check if we're running in debug mode for VSCode
-	// Empty them if they exist
-	if (len(os.Args) > 2) && (os.Args[1] == "-test.run") {
-		os.Args[1] = ""
-		os.Args[2] = ""
-	}
-
-	log.Trace().Msgf("Command to execute: %v", root.CalledAs())
-
-	c, err = root.ExecuteC()
-	return c, buf.String(), err
 }
 
 func NewIPFSDownloadFlags(settings *model.DownloaderSettings) *pflag.FlagSet {

--- a/cmd/bacalhau/validate_test.go
+++ b/cmd/bacalhau/validate_test.go
@@ -32,7 +32,7 @@ func (s *ValidateSuite) TestValidate() {
 		func() {
 			Fatal = FakeFatalErrorHandler
 
-			_, out, err := ExecuteTestCobraCommand(s.T(), "validate",
+			_, out, err := ExecuteTestCobraCommand("validate",
 				"--api-host", s.host,
 				"--api-port", s.port,
 				test.testFile,

--- a/cmd/bacalhau/version_test.go
+++ b/cmd/bacalhau/version_test.go
@@ -34,18 +34,18 @@ type VersionSuite struct {
 }
 
 func (suite *VersionSuite) Test_Version() {
-	_, out, err := ExecuteTestCobraCommand(suite.T(), "version",
+	_, out, err := ExecuteTestCobraCommand("version",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
 	)
 	require.NoError(suite.T(), err)
 
-	require.Contains(suite.T(), string(out), "Client Version", "Client version not in output")
-	require.Contains(suite.T(), string(out), "Server Version", "Server version not in output")
+	require.Contains(suite.T(), out, "Client Version", "Client version not in output")
+	require.Contains(suite.T(), out, "Server Version", "Server version not in output")
 }
 
 func (suite *VersionSuite) Test_VersionOutputs() {
-	_, out, err := ExecuteTestCobraCommand(suite.T(), "version",
+	_, out, err := ExecuteTestCobraCommand("version",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
 		"--output", JSONFormat,
@@ -57,7 +57,7 @@ func (suite *VersionSuite) Test_VersionOutputs() {
 	require.NoError(suite.T(), err, "Could not unmarshall the output into json - %+v", err)
 	require.Equal(suite.T(), jsonDoc.ClientVersion.GitCommit, jsonDoc.ServerVersion.GitCommit, "Client and Server do not match in json.")
 
-	_, out, err = ExecuteTestCobraCommand(suite.T(), "version",
+	_, out, err = ExecuteTestCobraCommand("version",
 		"--api-host", suite.host,
 		"--api-port", suite.port,
 		"--output", YAMLFormat,

--- a/cmd/bacalhau/wasm_run_test.go
+++ b/cmd/bacalhau/wasm_run_test.go
@@ -19,7 +19,7 @@ func TestWasmRunSuite(t *testing.T) {
 
 func (s *WasmRunSuite) Test_SupportsRelativeDirectory() {
 	ctx := context.Background()
-	_, out, err := ExecuteTestCobraCommand(s.T(), "wasm", "run",
+	_, out, err := ExecuteTestCobraCommand("wasm", "run",
 		"--api-host", s.host,
 		"--api-port", s.port,
 		"../../testdata/wasm/noop/main.wasm",

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -37,7 +37,6 @@ func ConstructDockerJob( //nolint:funlen
 	shardingGlobPattern string,
 	shardingBasePath string,
 	shardingBatchSize int,
-	doNotTrack bool,
 ) (*model.Job, error) {
 	jobResources := model.ResourceUsageConfig{
 		CPU:    cpu,
@@ -119,7 +118,6 @@ func ConstructDockerJob( //nolint:funlen
 		Annotations:   jobAnnotations,
 		NodeSelectors: nodeSelectorRequirements,
 		Sharding:      jobShardingConfig,
-		DoNotTrack:    doNotTrack,
 	}
 
 	// override working dir if provided
@@ -153,7 +151,6 @@ func ConstructLanguageJob(
 	requirementsPath string,
 	deterministic bool,
 	annotations []string,
-	doNotTrack bool,
 ) (*model.Job, error) {
 	// TODO refactor this wrt ConstructDockerJob
 	jobContexts := []model.StorageSpec{}
@@ -203,7 +200,6 @@ func ConstructLanguageJob(
 	j.Spec.Contexts = jobContexts
 	j.Spec.Outputs = jobOutputs
 	j.Spec.Annotations = jobAnnotations
-	j.Spec.DoNotTrack = doNotTrack
 
 	j.Spec.Deal = model.Deal{
 		Concurrency: concurrency,

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -63,7 +63,7 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 
 		for _, tcids := range testCids {
 			func() {
-				outputVolumes := []string{}
+				var outputVolumes []string
 				for _, tcidOV := range tcids.outputVolumes {
 					outputVolumes = append(outputVolumes, strings.Join([]string{tcidOV.name, tcidOV.path}, ":"))
 				}
@@ -95,7 +95,6 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 					"",         // sharding base path
 					"",         // sharding glob pattern
 					1,          // sharding batch size
-					true,       // do not track
 				)
 
 				if tcids.err != "" {

--- a/pkg/telemetry/constants.go
+++ b/pkg/telemetry/constants.go
@@ -2,6 +2,9 @@ package telemetry
 
 // Environment Variables
 const (
+	// environment variable to disable all local tracing
+	disableTracing = "DO_NOT_TRACK"
+
 	// environment variable that defines the endpoint for the oltp collector
 	// e.g. http://localhost:4318 for an insecure local collector
 	otlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -40,9 +40,17 @@ func newMeterProvider() {
 }
 
 func isMetricsEnabled() bool {
-	_, endpointDefined := os.LookupEnv(otlpEndpoint)
-	_, metricsEndpointDefined := os.LookupEnv(otlpMetricsEndpoint)
-	return endpointDefined || metricsEndpointDefined
+	if v, ok := os.LookupEnv(disableTracing); ok && v == "1" {
+		return false
+	}
+	if _, ok := os.LookupEnv(otlpEndpoint); ok {
+		return true
+	}
+	if _, ok := os.LookupEnv(otlpMetricsEndpoint); ok {
+		return true
+	}
+
+	return false
 }
 
 func getMetricsClient(ctx context.Context) (client sdkmetric.Exporter, err error) {

--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -75,9 +75,17 @@ func getTraceClient() (client otlptrace.Client, err error) {
 }
 
 func isTracingEnabled() bool {
-	_, endpointDefined := os.LookupEnv(otlpEndpoint)
-	_, tracingEndpointDefined := os.LookupEnv(otlpTracesEndpoint)
-	return endpointDefined || tracingEndpointDefined
+	if v, ok := os.LookupEnv(disableTracing); ok && v == "1" {
+		return false
+	}
+	if _, ok := os.LookupEnv(otlpEndpoint); ok {
+		return true
+	}
+	if _, ok := os.LookupEnv(otlpTracesEndpoint); ok {
+		return true
+	}
+
+	return false
 }
 
 func cleanupTraceProvider() error {

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -96,7 +96,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	err = os.WriteFile("main.py", mainPy, 0644)
 	require.NoError(s.T(), err)
 
-	_, out, err := cmd.ExecuteTestCobraCommand(s.T(),
+	_, out, err := cmd.ExecuteTestCobraCommand(
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",
@@ -111,8 +111,8 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	log.Debug().Msgf("jobId=%s", jobID)
 	time.Sleep(time.Second * 5)
 
-	node := stack.Nodes[0]
-	apiUri := node.APIServer.GetURI()
+	firstNode := stack.Nodes[0]
+	apiUri := firstNode.APIServer.GetURI()
 	apiClient := publicapi.NewRequesterAPIClient(apiUri)
 	resolver := apiClient.GetJobStateResolver()
 	require.NoError(s.T(), err)
@@ -129,7 +129,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	require.NotEmpty(s.T(), shard.PublishedResult.CID)
 
 	finalOutputPath := filepath.Join(outputDir, shard.PublishedResult.CID)
-	err = node.IPFSClient.Get(ctx, shard.PublishedResult.CID, finalOutputPath)
+	err = firstNode.IPFSClient.Get(ctx, shard.PublishedResult.CID, finalOutputPath)
 	require.NoError(s.T(), err)
 
 	err = filepath.Walk(finalOutputPath,
@@ -167,7 +167,7 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 
 	// TODO: see also list_test.go, maybe factor out a common way to do this cli
 	// setup
-	_, out, err := cmd.ExecuteTestCobraCommand(s.T(),
+	_, out, err := cmd.ExecuteTestCobraCommand(
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",
@@ -183,8 +183,7 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 	log.Debug().Msgf("jobId=%s", jobId)
 	time.Sleep(time.Second * 5)
 
-	node := stack.Nodes[0]
-	apiUri := node.APIServer.GetURI()
+	apiUri := stack.Nodes[0].APIServer.GetURI()
 	apiClient := publicapi.NewRequesterAPIClient(apiUri)
 	resolver := apiClient.GetJobStateResolver()
 	require.NoError(s.T(), err)
@@ -220,7 +219,7 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	err = os.WriteFile("main.py", mainPy, 0644)
 	require.NoError(s.T(), err)
 
-	_, out, err := cmd.ExecuteTestCobraCommand(s.T(),
+	_, out, err := cmd.ExecuteTestCobraCommand(
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",


### PR DESCRIPTION
Add support for the `DO_NO_TRACK` environment variable. This environment variable will ensure that no client-side activity is tracked, although any server-side activity would be tracked (e.g. rate limiting).

Fixes #94