### PR TITLE
Make sure Docker pull errors appear to the user

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -54,18 +54,18 @@ func (e *BaseExecutor) Run(ctx context.Context, execution store.Execution) (err 
 		Str("ExecutionID", execution.ID).
 		Logger().WithContext(ctx)
 
-	defer func() {
-		if err != nil {
-			e.handleFailure(ctx, execution, err, "Running")
-		}
-	}()
-
 	ctx, cancel := context.WithCancel(ctx)
 	e.cancellers.Put(execution, cancel)
 	defer func() {
 		if cancel, found := e.cancellers.Get(execution); found {
 			e.cancellers.Delete(execution)
 			cancel()
+		}
+	}()
+
+	defer func() {
+		if err != nil {
+			e.handleFailure(ctx, execution, err, "Running")
 		}
 	}()
 

--- a/pkg/transport/bprotocol/callback_proxy.go
+++ b/pkg/transport/bprotocol/callback_proxy.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -83,35 +85,35 @@ func proxyCallbackRequest(
 		targetPeerID := resultInfo.TargetPeerID
 		peerID, err := peer.Decode(targetPeerID)
 		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to decode peer ID %s", reflect.TypeOf(request), targetPeerID)
+			log.Ctx(ctx).Error().Err(errors.WithStack(err)).Msgf("%s: failed to decode peer ID %s", reflect.TypeOf(request), targetPeerID)
 			return
 		}
 
 		// deserialize the request object
 		data, err := json.Marshal(request)
 		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to marshal request", reflect.TypeOf(request))
+			log.Ctx(ctx).Error().Err(errors.WithStack(err)).Msgf("%s: failed to marshal request", reflect.TypeOf(request))
 			return
 		}
 
 		// opening a stream to the destination peer
 		stream, err := p.host.NewStream(ctx, peerID, protocolID)
 		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to open stream to peer %s", reflect.TypeOf(request), targetPeerID)
+			log.Ctx(ctx).Err(errors.WithStack(err)).Msgf("%s: failed to open stream to peer %s", reflect.TypeOf(request), targetPeerID)
 			return
 		}
-		defer stream.Close() //nolint:errcheck
+		defer closer.CloseWithLogOnError("stream", stream)
 		if scopingErr := stream.Scope().SetService(ComputeServiceName); scopingErr != nil {
-			log.Ctx(ctx).Error().Err(scopingErr).Msg("error attaching stream to requester service")
-			stream.Reset() //nolint:errcheck
+			log.Ctx(ctx).Error().Err(errors.WithStack(scopingErr)).Msg("error attaching stream to requester service")
+			_ = stream.Reset() //nolint:errcheck
 			return
 		}
 
 		// write the request to the stream
 		_, err = stream.Write(data)
 		if err != nil {
-			stream.Reset() //nolint:errcheck
-			log.Ctx(ctx).Error().Err(err).Msgf("%s: failed to write request to peer %s", reflect.TypeOf(request), targetPeerID)
+			_ = stream.Reset() //nolint:errcheck
+			log.Ctx(ctx).Error().Err(errors.WithStack(err)).Msgf("%s: failed to write request to peer %s", reflect.TypeOf(request), targetPeerID)
 			return
 		}
 	}


### PR DESCRIPTION
Ensure that any errors that occur while pulling a Docker image make their way to the end user.

Also add the stack to all errors in `proxyCallbackRequest` to make it more obvious where the error is coming from, as all proxy requests go through this method.

Fixes #2007