### PR TITLE
Ensure that all tests have go:build headers

### DIFF
--- a/.gitprecommit/go_test_build_header.sh
+++ b/.gitprecommit/go_test_build_header.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Exit on error. Append || true if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+# Turn on traces, useful while debugging but commented out by default
+#set -o xtrace
+
+files_without_header=$(grep --include '*_test.go' -lR 'func Test[A-Z].*(t \*testing.T' ./* | xargs grep --files-without-match -e '//go:build integration' -e '//go:build unit || !integration' --)
+
+if [[ -n "${files_without_header}"  ]]; then
+  printf "Test files missing '//go:build integration' or '//go:build unit || !integration':\n%s\n" "${files_without_header}"
+  exit 1
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,7 @@ repos:
         name: make modtidy check-diff
         entry: .gitprecommit/go_mod_tidy_check.sh
         language: script
+      - id: "go-test-build-header"
+        name: "Go test '//go:build' header present"
+        entry: ".gitprecommit/go_test_build_header.sh"
+        language: "script"

--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -43,7 +43,7 @@ func TestServeSuite(t *testing.T) {
 // Before each test
 func (s *ServeSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
-	s.Require().NoError(system.InitConfigForTesting(s.T()))
+	system.InitConfigForTesting(s.T())
 
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), maxTestTime)
 

--- a/cmd/bacalhau/utils_test.go
+++ b/cmd/bacalhau/utils_test.go
@@ -52,7 +52,7 @@ func (s *UtilsSuite) TestSafeRegex() {
 }
 
 func (s *UtilsSuite) TestVersionCheck() {
-	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
+	system.InitConfigForTesting(s.T())
 
 	// OK: Normal operation
 	err := ensureValidVersion(context.TODO(), &model.BuildVersionInfo{

--- a/cmd/bacalhau/wasm_run_test.go
+++ b/cmd/bacalhau/wasm_run_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package bacalhau
 
 import (

--- a/pkg/compute/capacity/parser_test.go
+++ b/pkg/compute/capacity/parser_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package capacity
 
 import (

--- a/pkg/compute/store/inmemory/store_test.go
+++ b/pkg/compute/store/inmemory/store_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package inmemory
 
 import (

--- a/pkg/compute/store/test/active_executions_test.go
+++ b/pkg/compute/store/test/active_executions_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package test
 
 import (

--- a/pkg/compute/store/utils_test.go
+++ b/pkg/compute/store/utils_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package store
 
 import (

--- a/pkg/downloader/download_test.go
+++ b/pkg/downloader/download_test.go
@@ -5,6 +5,7 @@ package downloader
 import (
 	"context"
 	"crypto/rand"
+	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +36,7 @@ type DownloaderSuite struct {
 
 func (ds *DownloaderSuite) SetupSuite() {
 	logger.ConfigureTestLogging(ds.T())
-	require.NoError(ds.T(), system.InitConfigForTesting(ds.T()))
+	system.InitConfigForTesting(ds.T())
 }
 
 // Before each test
@@ -78,7 +79,7 @@ func generateFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer closer.CloseWithLogOnError("file", file)
 
 	b := make([]byte, 128)
 	_, err = rand.Read(b)

--- a/pkg/executor/docker/bid_strategy_test.go
+++ b/pkg/executor/docker/bid_strategy_test.go
@@ -1,4 +1,4 @@
-//go:build !unit || integration
+//go:build integration
 
 package docker
 

--- a/pkg/ipfs/node_test.go
+++ b/pkg/ipfs/node_test.go
@@ -23,7 +23,7 @@ type NodeSuite struct {
 
 func (s *NodeSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
-	s.Require().NoError(system.InitConfigForTesting(s.T()))
+	system.InitConfigForTesting(s.T())
 }
 
 // TestFunctionality tests the in-process IPFS node/client as follows:

--- a/pkg/job/sharding.go
+++ b/pkg/job/sharding.go
@@ -36,7 +36,7 @@ the following is how different patterns would group:
 /* = [/a/, /b/]
 /**\/*.txt = [/a/file1.txt, /a/file2.txt, /b/file1.txt, /b/file2.txt]
 */
-func ApplyGlobPattern(
+func applyGlobPattern(
 	files []model.StorageSpec,
 	pattern string,
 	basePath string,
@@ -123,7 +123,7 @@ func ExplodeShardedVolumes(
 		allVolumes = append(allVolumes, explodedVolumes...)
 	}
 	// let's filter all of the combined volumes down using the glob pattern
-	return ApplyGlobPattern(allVolumes, config.GlobPattern, config.BasePath)
+	return applyGlobPattern(allVolumes, config.GlobPattern, config.BasePath)
 }
 
 // given an exploded set of volumes - we now group them based on batch size

--- a/pkg/job/sharding_test.go
+++ b/pkg/job/sharding_test.go
@@ -155,7 +155,7 @@ func (suite *JobShardingSuite) TestApplyGlobPattern() {
 	}
 
 	for _, testCase := range testCases {
-		results, err := ApplyGlobPattern(explodeStringArray(testCase.files), testCase.pattern, testCase.basePath)
+		results, err := applyGlobPattern(explodeStringArray(testCase.files), testCase.pattern, testCase.basePath)
 		require.NoError(suite.T(), err)
 		require.Equal(
 			suite.T(),

--- a/pkg/libp2p/rcmgr/metrics_test.go
+++ b/pkg/libp2p/rcmgr/metrics_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package rcmgr
 
 import (

--- a/pkg/localdb/shared/test_utils.go
+++ b/pkg/localdb/shared/test_utils.go
@@ -26,7 +26,7 @@ type GenericSQLSuite struct {
 }
 
 func (suite *GenericSQLSuite) SetupTest() {
-	suite.Require().NoError(system.InitConfigForTesting(suite.T()))
+	system.InitConfigForTesting(suite.T())
 	logger.ConfigureTestLogging(suite.T())
 	datastore := suite.SetupHandler()
 	suite.datastore = datastore

--- a/pkg/logger/buffering_test.go
+++ b/pkg/logger/buffering_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package logger
 
 import (

--- a/pkg/model/docker_task_test.go
+++ b/pkg/model/docker_task_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package model
 
 import (

--- a/pkg/model/millicores.go
+++ b/pkg/model/millicores.go
@@ -2,7 +2,7 @@ package model
 
 import "fmt"
 
-// A Millicore represents a thousandth of a CPU core, which is a unit of measure
+// A Millicores represents a thousandth of a CPU core, which is a unit of measure
 // used by Kubernetes. See also https://github.com/BTBurke/k8sresource.
 type Millicores int
 

--- a/pkg/model/millicores_test.go
+++ b/pkg/model/millicores_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package model
 
 import (

--- a/pkg/model/network_test.go
+++ b/pkg/model/network_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package model
 
 import (

--- a/pkg/model/task_test.go
+++ b/pkg/model/task_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package model
 
 import (

--- a/pkg/model/v1beta1/apiversion_convert_v1alpha1_test.go
+++ b/pkg/model/v1beta1/apiversion_convert_v1alpha1_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package v1beta1
 
 import (

--- a/pkg/model/v1beta1/docker_task_test.go
+++ b/pkg/model/v1beta1/docker_task_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package v1beta1
 
 import (

--- a/pkg/model/v1beta1/millicores_test.go
+++ b/pkg/model/v1beta1/millicores_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package v1beta1
 
 import (

--- a/pkg/model/v1beta1/network_test.go
+++ b/pkg/model/v1beta1/network_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package v1beta1
 
 import (

--- a/pkg/model/v1beta1/task_test.go
+++ b/pkg/model/v1beta1/task_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package v1beta1
 
 import (

--- a/pkg/model/v1beta1/wasm_task_test.go
+++ b/pkg/model/v1beta1/wasm_task_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package v1beta1
 
 import (

--- a/pkg/model/wasm_task_test.go
+++ b/pkg/model/wasm_task_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package model
 
 import (

--- a/pkg/publicapi/util_test.go
+++ b/pkg/publicapi/util_test.go
@@ -23,7 +23,7 @@ func setupNodeForTest(t *testing.T, cm *system.CleanupManager) *APIClient {
 
 //nolint:unused // used in tests
 func setupNodeForTestWithConfig(t *testing.T, cm *system.CleanupManager, serverConfig APIServerConfig) *APIClient {
-	require.NoError(t, system.InitConfigForTesting(t))
+	system.InitConfigForTesting(t)
 	ctx := context.Background()
 
 	libp2pPort, err := freeport.GetFreePort()

--- a/pkg/publisher/filecoin_lotus/publisher_test.go
+++ b/pkg/publisher/filecoin_lotus/publisher_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package filecoinlotus
 
 import (

--- a/pkg/pubsub/buffering_pubsub_test.go
+++ b/pkg/pubsub/buffering_pubsub_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package pubsub
 
 import (

--- a/pkg/pubsub/chained_subscriber_test.go
+++ b/pkg/pubsub/chained_subscriber_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package pubsub
 
 import (

--- a/pkg/pubsub/libp2p/pubsub_test.go
+++ b/pkg/pubsub/libp2p/pubsub_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package libp2p
 
 import (

--- a/pkg/requester/discovery/chained_test.go
+++ b/pkg/requester/discovery/chained_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package discovery
 
 import (
@@ -82,7 +84,7 @@ func newFixedDiscoverer(peerIDs ...model.NodeInfo) *fixedDiscoverer {
 	}
 }
 
-func (f *fixedDiscoverer) FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo, error) {
+func (f *fixedDiscoverer) FindNodes(context.Context, model.Job) ([]model.NodeInfo, error) {
 	return f.peerIDs, nil
 }
 
@@ -93,6 +95,6 @@ func newBadDiscoverer() *badDiscoverer {
 	return &badDiscoverer{}
 }
 
-func (b *badDiscoverer) FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo, error) {
+func (b *badDiscoverer) FindNodes(context.Context, model.Job) ([]model.NodeInfo, error) {
 	return nil, errors.New("bad discoverer")
 }

--- a/pkg/requester/discovery/identity_test.go
+++ b/pkg/requester/discovery/identity_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package discovery
 
 import (

--- a/pkg/requester/discovery/store_test.go
+++ b/pkg/requester/discovery/store_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package discovery
 
 import (

--- a/pkg/requester/endpoint_test.go
+++ b/pkg/requester/endpoint_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package requester
 
 import (
@@ -17,12 +19,12 @@ import (
 type mockBidStrategy bool
 
 // ShouldBid implements bidstrategy.BidStrategy
-func (m *mockBidStrategy) ShouldBid(ctx context.Context, request bidstrategy.BidStrategyRequest) (bidstrategy.BidStrategyResponse, error) {
+func (m *mockBidStrategy) ShouldBid(context.Context, bidstrategy.BidStrategyRequest) (bidstrategy.BidStrategyResponse, error) {
 	return bidstrategy.BidStrategyResponse{ShouldBid: bool(*m)}, nil
 }
 
 // ShouldBidBasedOnUsage implements bidstrategy.BidStrategy
-func (m *mockBidStrategy) ShouldBidBasedOnUsage(ctx context.Context, request bidstrategy.BidStrategyRequest, resourceUsage model.ResourceUsageData) (bidstrategy.BidStrategyResponse, error) {
+func (m *mockBidStrategy) ShouldBidBasedOnUsage(context.Context, bidstrategy.BidStrategyRequest, model.ResourceUsageData) (bidstrategy.BidStrategyResponse, error) {
 	return bidstrategy.BidStrategyResponse{ShouldBid: bool(*m)}, nil
 }
 

--- a/pkg/requester/ranking/chain_test.go
+++ b/pkg/requester/ranking/chain_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package ranking
 
 import (
@@ -82,7 +84,7 @@ func newFixedRanker(ranks ...int) *fixedRanker {
 	}
 }
 
-func (f *fixedRanker) RankNodes(ctx context.Context, job model.Job, nodes []model.NodeInfo) ([]requester.NodeRank, error) {
+func (f *fixedRanker) RankNodes(_ context.Context, _ model.Job, nodes []model.NodeInfo) ([]requester.NodeRank, error) {
 	ranks := make([]requester.NodeRank, len(nodes))
 	for i, rank := range f.ranks {
 		ranks[i] = requester.NodeRank{

--- a/pkg/requester/ranking/engines_test.go
+++ b/pkg/requester/ranking/engines_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package ranking
 
 import (

--- a/pkg/requester/ranking/max_usage_test.go
+++ b/pkg/requester/ranking/max_usage_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package ranking
 
 import (

--- a/pkg/requester/ranking/min_version_test.go
+++ b/pkg/requester/ranking/min_version_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package ranking
 
 import (

--- a/pkg/requester/ranking/random_test.go
+++ b/pkg/requester/ranking/random_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package ranking
 
 import (

--- a/pkg/routing/inmemory/inmemory_test.go
+++ b/pkg/routing/inmemory/inmemory_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package inmemory
 
 import (

--- a/pkg/storage/copy/copy_test.go
+++ b/pkg/storage/copy/copy_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package copy
 
 import (
@@ -8,7 +10,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/noop"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 )
@@ -83,11 +84,6 @@ func preserveSlice[T any](slice []*T) []T {
 func TestCopyOversize(t *testing.T) {
 	for _, testCase := range copyOversizeTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			cm := system.NewCleanupManager()
-			t.Cleanup(func() {
-				cm.Cleanup(context.Background())
-			})
-
 			originals := preserveSlice(testCase.specs)
 
 			didUpload := false

--- a/pkg/storage/inline/storage_test.go
+++ b/pkg/storage/inline/storage_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package inline
 
 import (

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -33,7 +33,7 @@ func TestStorageSuite(t *testing.T) {
 // Before each test
 func (s *StorageSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
-	s.Require().NoError(system.InitConfigForTesting(s.T()))
+	system.InitConfigForTesting(s.T())
 }
 
 func (s *StorageSuite) TestNewStorageProvider() {

--- a/pkg/system/cleanup_test.go
+++ b/pkg/system/cleanup_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,7 +20,7 @@ func TestSystemCleanupSuite(t *testing.T) {
 
 func (s *SystemCleanupSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
-	require.NoError(s.T(), InitConfigForTesting(s.T()))
+	InitConfigForTesting(s.T())
 }
 
 func (s *SystemCleanupSuite) TestCleanupManager() {

--- a/pkg/system/config.go
+++ b/pkg/system/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -79,22 +80,21 @@ func InitConfig() error {
 type testingT interface {
 	TempDir() string
 	Setenv(key string, value string)
+	Errorf(format string, args ...interface{})
+	FailNow()
 }
 
 // InitConfigForTesting creates a fresh config setup in a temporary directory
 // for testing config-related stuff and user ID message signing.
-func InitConfigForTesting(t testingT) error {
+func InitConfigForTesting(t testingT) {
 	if _, ok := os.LookupEnv("__InitConfigForTestingHasAlreadyBeenRunSoCanBeSkipped__"); ok {
-		return nil
+		return
 	}
 	t.Setenv("__InitConfigForTestingHasAlreadyBeenRunSoCanBeSkipped__", "set")
 	configDir := t.TempDir()
 	t.Setenv("BACALHAU_DIR", configDir)
 	err := InitConfig()
-	if err != nil {
-		return err
-	}
-	return nil
+	require.NoError(t, err)
 }
 
 // SignForClient signs a message with the user's private ID key.

--- a/pkg/system/config_test.go
+++ b/pkg/system/config_test.go
@@ -33,7 +33,7 @@ func (s *SystemConfigSuite) TestMessageSigning() {
 		}
 	}()
 
-	s.NoError(InitConfigForTesting(s.T()))
+	InitConfigForTesting(s.T())
 
 	msg := []byte("Hello, world!")
 	sig, err := SignForClient(msg)
@@ -57,14 +57,14 @@ func (s *SystemConfigSuite) TestGetClientID() {
 
 	var firstId string
 	s.Run("first", func() {
-		s.Require().NoError(InitConfigForTesting(s.T()))
+		InitConfigForTesting(s.T())
 		firstId = GetClientID()
 		s.Require().NotEmpty(firstId)
 	})
 
 	var secondId string
 	s.Run("second", func() {
-		s.Require().NoError(InitConfigForTesting(s.T()))
+		InitConfigForTesting(s.T())
 		secondId = GetClientID()
 		s.Require().NotEmpty(secondId)
 
@@ -74,7 +74,7 @@ func (s *SystemConfigSuite) TestGetClientID() {
 }
 
 func (s *SystemConfigSuite) TestPublicKeyMatchesID() {
-	s.NoError(InitConfigForTesting(s.T()))
+	InitConfigForTesting(s.T())
 
 	id := GetClientID()
 	publicKey := GetClientPublicKey()

--- a/pkg/system/script_checker_test.go
+++ b/pkg/system/script_checker_test.go
@@ -24,7 +24,7 @@ func TestSystemScriptCheckerSuite(t *testing.T) {
 // Before each test
 func (suite *SystemScriptCheckerSuite) SetupTest() {
 	logger.ConfigureTestLogging(suite.T())
-	require.NoError(suite.T(), InitConfigForTesting(suite.T()))
+	InitConfigForTesting(suite.T())
 }
 
 func (suite *SystemScriptCheckerSuite) TestValidateWorkingDir() {

--- a/pkg/test/compute/ask_for_bid_test.go
+++ b/pkg/test/compute/ask_for_bid_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package compute
 
 import (

--- a/pkg/test/compute/bid_accepted_test.go
+++ b/pkg/test/compute/bid_accepted_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package compute
 
 import (

--- a/pkg/test/compute/bid_rejected_test.go
+++ b/pkg/test/compute/bid_rejected_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package compute
 
 import (

--- a/pkg/test/compute/resourcelimits_test.go
+++ b/pkg/test/compute/resourcelimits_test.go
@@ -35,8 +35,7 @@ func TestComputeNodeResourceLimitsSuite(t *testing.T) {
 
 func (suite *ComputeNodeResourceLimitsSuite) SetupTest() {
 	logger.ConfigureTestLogging(suite.T())
-	err := system.InitConfigForTesting(suite.T())
-	require.NoError(suite.T(), err)
+	system.InitConfigForTesting(suite.T())
 }
 
 type SeenJobRecord struct {

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package compute
 
 import (

--- a/pkg/test/compute/utils_test.go
+++ b/pkg/test/compute/utils_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package compute
 
 import (
@@ -41,7 +43,6 @@ func addResourceUsage(job model.Job, usage model.ResourceUsageData) model.Job {
 	return job
 }
 
-//nolint:unused
 func getResources(c, m, d string) model.ResourceUsageConfig {
 	return model.ResourceUsageConfig{
 		CPU:    c,
@@ -50,7 +51,6 @@ func getResources(c, m, d string) model.ResourceUsageConfig {
 	}
 }
 
-//nolint:unused
 func getResourcesArray(data [][]string) []model.ResourceUsageConfig {
 	var res []model.ResourceUsageConfig
 	for _, d := range data {

--- a/pkg/test/devstack/lotus_test.go
+++ b/pkg/test/devstack/lotus_test.go
@@ -37,7 +37,7 @@ func (s *lotusNodeSuite) SetupTest() {
 	docker.MustHaveDocker(s.T())
 
 	logger.ConfigureTestLogging(s.T())
-	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
+	system.InitConfigForTesting(s.T())
 }
 
 func (s *lotusNodeSuite) TestLotusNode() {

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -43,8 +43,7 @@ func (s *DevstackPythonWASMSuite) SetupTest() {
 	docker.MustHaveDocker(s.T())
 
 	logger.ConfigureTestLogging(s.T())
-	err := system.InitConfigForTesting(s.T())
-	require.NoError(s.T(), err)
+	system.InitConfigForTesting(s.T())
 }
 
 // full end-to-end test of python/wasm:

--- a/pkg/test/devstack/sharding_test.go
+++ b/pkg/test/devstack/sharding_test.go
@@ -66,8 +66,7 @@ func (suite *ShardingSuite) TestExplodeCid() {
 	ctx := context.Background()
 	cm := system.NewCleanupManager()
 
-	err := system.InitConfigForTesting(suite.T())
-	require.NoError(suite.T(), err)
+	system.InitConfigForTesting(suite.T())
 
 	stack, err := devstack.NewDevStackIPFS(ctx, cm, nodeCount)
 	require.NoError(suite.T(), err)

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -31,8 +31,7 @@ func TestDevstackSubmitSuite(t *testing.T) {
 // Before each test
 func (suite *DevstackSubmitSuite) SetupTest() {
 	logger.ConfigureTestLogging(suite.T())
-	err := system.InitConfigForTesting(suite.T())
-	require.NoError(suite.T(), err)
+	system.InitConfigForTesting(suite.T())
 }
 
 func (suite *DevstackSubmitSuite) TestEmptySpec() {

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -35,8 +35,7 @@ func TestIPFSHostStorageSuite(t *testing.T) {
 // Before each test
 func (suite *IPFSHostStorageSuite) SetupTest() {
 	logger.ConfigureTestLogging(suite.T())
-	err := system.InitConfigForTesting(suite.T())
-	require.NoError(suite.T(), err)
+	system.InitConfigForTesting(suite.T())
 }
 
 type getStorageFunc func(ctx context.Context, cm *system.CleanupManager, api ipfs.Client) (

--- a/pkg/test/requester/node_selection_test.go
+++ b/pkg/test/requester/node_selection_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package requester
 
 import (

--- a/pkg/test/requester/publicapi/util.go
+++ b/pkg/test/requester/publicapi/util.go
@@ -29,7 +29,7 @@ func setupNodeForTest(t *testing.T) (*node.Node, *requester_publicapi.RequesterA
 
 //nolint:unused // used in tests
 func setupNodeForTestWithConfig(t *testing.T, config publicapi.APIServerConfig) (*node.Node, *requester_publicapi.RequesterAPIClient) {
-	require.NoError(t, system.InitConfigForTesting(t))
+	system.InitConfigForTesting(t)
 	ctx := context.Background()
 
 	datastore := inmemory.NewJobStore()

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -44,7 +44,7 @@ type ScenarioRunner struct {
 }
 
 func (s *ScenarioRunner) SetupTest() {
-	require.NoError(s.T(), system.InitConfigForTesting(s.T()))
+	system.InitConfigForTesting(s.T())
 
 	s.Ctx = context.Background()
 

--- a/pkg/test/simulator/server_test.go
+++ b/pkg/test/simulator/server_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package simulator
 
 import (

--- a/pkg/test/utils/stack.go
+++ b/pkg/test/utils/stack.go
@@ -75,7 +75,7 @@ func SetupTestWithNoopExecutor(
 	executorConfig noop_executor.ExecutorConfig,
 	nodeOverrides ...node.NodeConfig,
 ) *devstack.DevStack {
-	require.NoError(t, system.InitConfigForTesting(t))
+	system.InitConfigForTesting(t)
 	// We will take the standard executors and add in the noop executor
 	executorFactory := &mixedExecutorFactory{
 		StandardExecutorsFactory: node.NewStandardExecutorsFactory(),

--- a/pkg/util/context_test.go
+++ b/pkg/util/context_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package util
 
 import (

--- a/pkg/util/reflection/reflection_test.go
+++ b/pkg/util/reflection/reflection_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package reflection
 
 import (

--- a/pkg/util/templates/normalizers_test.go
+++ b/pkg/util/templates/normalizers_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package templates
 
 import (


### PR DESCRIPTION
Make sure that all files containing tests have a 'go:build' header, so they run either as a unit test or an integration test and not both. This can help reduce the number of flakes by stopping some flaky tests from running twice.