### PR TITLE
Increase TestServeSuite timeout

### DIFF
--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -21,53 +21,47 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const maxTestTime time.Duration = 750 * time.Millisecond
+const maxServeTime = 750 * time.Millisecond
+const maxTestTime = 10 * time.Second
 
-// Define the suite, and absorb the built-in basic suite
-// functionality from testify - including a T() method which
-// returns the current testing context
 type ServeSuite struct {
 	suite.Suite
 
 	ipfsPort int
 	ctx      context.Context
-	cancel   context.CancelFunc
 }
 
-// In order for 'go test' to run this suite, we need to create
-// a normal test function and pass our suite to suite.Run
 func TestServeSuite(t *testing.T) {
 	suite.Run(t, new(ServeSuite))
 }
 
-// Before each test
 func (s *ServeSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
 	system.InitConfigForTesting(s.T())
 
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), maxTestTime)
+	var cancel context.CancelFunc
+	s.ctx, cancel = context.WithTimeout(context.Background(), maxTestTime)
+	s.T().Cleanup(func() {
+		cancel()
+	})
 
 	cm := system.NewCleanupManager()
 	s.T().Cleanup(func() {
-		cm.Cleanup(context.Background())
+		cm.Cleanup(s.ctx)
 	})
 
 	node, err := ipfs.NewLocalNode(s.ctx, cm, []string{})
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.ipfsPort = node.APIPort
 }
 
-func (s *ServeSuite) TearDownTest() {
-	s.cancel()
-}
-
-func (s *ServeSuite) Serve(extraArgs ...string) int {
+func (s *ServeSuite) serve(extraArgs ...string) int {
 	port, err := freeport.GetFreePort()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cmd := NewRootCmd()
 
-	// peer set to none to avoid accidentally talking to production endpoints
+	// peer set to "none" to avoid accidentally talking to production endpoints
 	args := []string{
 		"serve",
 		"--peer", "none",
@@ -77,18 +71,23 @@ func (s *ServeSuite) Serve(extraArgs ...string) int {
 	args = append(args, extraArgs...)
 
 	cmd.SetArgs(args)
-	s.T().Logf("Command to execute: %q", cmd.CalledAs())
+	s.T().Logf("Command to execute: %q", args)
+
+	ctx, cancel := context.WithTimeout(s.ctx, maxServeTime)
+	s.T().Cleanup(cancel)
 
 	go func() {
-		_, err := cmd.ExecuteContextC(s.ctx)
+		_, err := cmd.ExecuteContextC(ctx)
 		s.NoError(err)
 	}()
 
+	t := time.NewTicker(10 * time.Millisecond)
+	defer t.Stop()
 	for {
 		select {
-		case <-s.ctx.Done():
-			s.FailNow("Server did not start in time")
-		default:
+		case <-ctx.Done():
+			s.Fail("Server did not start in time")
+		case <-t.C:
 			livezText, _ := s.curlEndpoint(fmt.Sprintf("http://localhost:%d/livez", port))
 			if string(livezText) == "OK" {
 				return port
@@ -103,7 +102,6 @@ func (s *ServeSuite) curlEndpoint(URL string) ([]byte, error) {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -119,20 +117,20 @@ func (s *ServeSuite) curlEndpoint(URL string) ([]byte, error) {
 }
 
 func (s *ServeSuite) TestHealthcheck() {
-	port := s.Serve()
+	port := s.serve()
 	healthzText, err := s.curlEndpoint(fmt.Sprintf("http://localhost:%d/healthz", port))
-	s.NoError(err)
+	s.Require().NoError(err)
 	var healthzJSON types.HealthInfo
 	s.Require().NoError(model.JSONUnmarshalWithMax(healthzText, &healthzJSON), "Error unmarshalling healthz JSON.")
 	s.Require().Greater(int(healthzJSON.DiskFreeSpace.ROOT.All), 0, "Did not report DiskFreeSpace > 0.")
 }
 
 func (s *ServeSuite) TestCanSubmitJob() {
-	port := s.Serve("--node-type", "requester", "--node-type", "compute")
+	port := s.serve("--node-type", "requester", "--node-type", "compute")
 	client := publicapi.NewRequesterAPIClient(fmt.Sprintf("http://localhost:%d", port))
 
 	job, err := model.NewJobWithSaneProductionDefaults()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = client.Submit(s.ctx, job)
 	s.NoError(err)
@@ -141,11 +139,11 @@ func (s *ServeSuite) TestCanSubmitJob() {
 func (s *ServeSuite) TestAppliesJobSelectionPolicy() {
 	// Networking is disabled by default so we try to submit a networked job and
 	// expect it to be rejected.
-	port := s.Serve("--node-type", "requester")
+	port := s.serve("--node-type", "requester")
 	client := publicapi.NewRequesterAPIClient(fmt.Sprintf("http://localhost:%d", port))
 
 	job, err := model.NewJobWithSaneProductionDefaults()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	job.Spec.Network.Type = model.NetworkHTTP
 	_, err = client.Submit(s.ctx, job)

--- a/pkg/pubsub/libp2p/pubsub_test.go
+++ b/pkg/pubsub/libp2p/pubsub_test.go
@@ -46,10 +46,10 @@ func (s *PubSubSuite) SetupSuite() {
 		}
 	}
 	if s1 {
-		s.FailNow("subscriber 1 didn't receive initialization message")
+		s.Fail("subscriber 1 didn't receive initialization message")
 	}
 	if s2 {
-		s.FailNow("subscriber 2 didn't receive initialization message")
+		s.Fail("subscriber 2 didn't receive initialization message")
 	}
 	log.Debug().Msg("libp2p pubsub suite is ready")
 }

--- a/pkg/test/utils/utils.go
+++ b/pkg/test/utils/utils.go
@@ -95,7 +95,7 @@ func WaitForNodeDiscovery(t *testing.T, requesterNode *node.Node, expectedNodeCo
 	nodeInfos, err := requesterNode.NodeInfoStore.List(ctx)
 	require.NoError(t, err)
 	if len(nodeInfos) != expectedNodeCount {
-		require.FailNowf(t, fmt.Sprintf("requester node didn't read all node infos even after waiting for %s", waitDuration),
+		require.Failf(t, fmt.Sprintf("requester node didn't read all node infos even after waiting for %s", waitDuration),
 			"expected 4 node infos, got %d. %+v", len(nodeInfos), nodeInfos)
 	}
 }


### PR DESCRIPTION
Increase max test time to 10 seconds for TestServeSuite to avoid CI test flakes. The `serve` command is also given its own timeout rather than relying on the total test timeout.