### PR TITLE
Only use a 'local' IPFS when running tests

### DIFF
--- a/pkg/downloader/ipfs/downloader.go
+++ b/pkg/downloader/ipfs/downloader.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"github.com/rs/zerolog/log"
 )
 
@@ -23,37 +24,39 @@ func NewIPFSDownloader(cm *system.CleanupManager, settings *model.DownloaderSett
 	}
 }
 
-func (ipfsDownloader *Downloader) IsInstalled(context.Context) (bool, error) {
+func (d *Downloader) IsInstalled(context.Context) (bool, error) {
 	return true, nil
 }
 
-func (ipfsDownloader *Downloader) FetchResult(ctx context.Context, result model.PublishedResult, downloadPath string) error {
+func (d *Downloader) FetchResult(ctx context.Context, result model.PublishedResult, downloadPath string) error {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/downloader/ipfs.Downloader.FetchResult")
 	defer span.End()
 
 	// NOTE: we have to spin up a temporary IPFS node as we don't
 	// generally have direct access to a remote node's API server.
-	n, err := spinUpIPFSNode(ctx, ipfsDownloader.cm, ipfsDownloader.settings.IPFSSwarmAddrs)
+
+	log.Ctx(ctx).Debug().Msg("Spinning up IPFS node")
+
+	newNode := ipfs.NewNode
+	if d.settings.LocalIPFS {
+		newNode = ipfs.NewLocalNode
+	}
+	n, err := newNode(ctx, d.cm, strings.Split(d.settings.IPFSSwarmAddrs, ","))
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if closeErr := n.Close(ctx); closeErr != nil {
-			log.Ctx(ctx).Error().Err(closeErr).Msg("Failed to close IPFS node")
-		}
-	}()
+	defer closer.ContextCloserWithLogOnError(ctx, "IPFS node", n)
 
-	log.Ctx(ctx).Debug().Msg("Connecting client to new IPFS node...")
 	ipfsClient := n.Client()
 
 	err = func() error {
-		log.Ctx(ctx).Debug().Msgf(
-			"Downloading result CID %s '%s' to '%s'...",
-			result.Data.Name,
-			result.Data.CID, downloadPath,
-		)
+		log.Ctx(ctx).Debug().
+			Str("cid", result.Data.CID).
+			Str("name", result.Data.Name).
+			Str("path", downloadPath).
+			Msg("Downloading result CID")
 
-		innerCtx, cancel := context.WithTimeout(ctx, ipfsDownloader.settings.Timeout)
+		innerCtx, cancel := context.WithTimeout(ctx, d.settings.Timeout)
 		defer cancel()
 
 		return ipfsClient.Get(innerCtx, result.Data.CID, downloadPath)
@@ -61,23 +64,10 @@ func (ipfsDownloader *Downloader) FetchResult(ctx context.Context, result model.
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Ctx(ctx).Error().Msg("Timed out while downloading result.")
+			log.Ctx(ctx).Error().Msg("Timed out while downloading result")
 		}
 
 		return err
 	}
 	return nil
-}
-
-func spinUpIPFSNode(
-	ctx context.Context,
-	cm *system.CleanupManager,
-	ipfsSwarmAddrs string,
-) (*ipfs.Node, error) {
-	log.Ctx(ctx).Debug().Msg("Spinning up IPFS node...")
-	n, err := ipfs.NewNode(ctx, cm, strings.Split(ipfsSwarmAddrs, ","))
-	if err != nil {
-		return nil, err
-	}
-	return n, nil
 }

--- a/pkg/model/downloader.go
+++ b/pkg/model/downloader.go
@@ -18,4 +18,5 @@ type DownloaderSettings struct {
 	Timeout        time.Duration
 	OutputDir      string
 	IPFSSwarmAddrs string
+	LocalIPFS      bool
 }


### PR DESCRIPTION
Using the 'real' IPFS runs the risk of connecting to other instances, either in the public or running within the same network. If this happens, then the code may try to download files from IPFS nodes that have been discovered rather than those it was configured to connect to.