### PR TITLE
 Async job selection hooks that allow human pre-moderation

### DIFF
--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -146,6 +146,10 @@ func (s *ServeSuite) TestAppliesJobSelectionPolicy() {
 	s.Require().NoError(err)
 
 	job.Spec.Network.Type = model.NetworkHTTP
-	_, err = client.Submit(s.ctx, job)
-	s.ErrorContains(err, "job is unacceptable")
+	job, err = client.Submit(s.ctx, job)
+	s.NoError(err)
+
+	state, err := client.GetJobState(s.ctx, job.Metadata.ID)
+	s.NoError(err)
+	s.Equal(model.JobStateCancelled, state.State, state.State.String())
 }

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -706,7 +706,8 @@ To get more information at any time, run:
 				// Send a signal to the goroutine that is waiting for Ctrl+C
 				finishedRunning = true
 
-				if event.JobState.New == model.JobStateError {
+				// If there was an unsuccessful job, print the reason why.
+				if event.JobState.New != model.JobStateCompleted {
 					err = errors.New(event.Comment)
 					spin.StopMessage(fullLineMessage.PrintError())
 				}

--- a/pkg/bidstrategy/type.go
+++ b/pkg/bidstrategy/type.go
@@ -12,8 +12,9 @@ type BidStrategyRequest struct {
 }
 
 type BidStrategyResponse struct {
-	ShouldBid bool
-	Reason    string
+	ShouldBid  bool   `json:"shouldBid"`
+	ShouldWait bool   `json:"shouldWait"`
+	Reason     string `json:"reason"`
 }
 
 func NewShouldBidResponse() BidStrategyResponse {

--- a/pkg/jobstore/types.go
+++ b/pkg/jobstore/types.go
@@ -28,6 +28,7 @@ type Store interface {
 	GetJobHistory(ctx context.Context, jobID string) ([]model.JobHistory, error)
 	GetJobsCount(ctx context.Context, query JobQuery) (int, error)
 	CreateJob(ctx context.Context, j model.Job) error
+	CreateShards(ctx context.Context, jobID string, count int) error
 	// UpdateJobState updates the Job state
 	UpdateJobState(ctx context.Context, request UpdateJobStateRequest) error
 	// GetShardState returns the shard for a given id

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -344,6 +344,10 @@ type JobCreatePayload struct {
 	Spec *Spec `json:"Spec,omitempty" validate:"required"`
 }
 
+func (j JobCreatePayload) GetClientID() string {
+	return j.ClientID
+}
+
 type JobCancelPayload struct {
 	// the id of the client that is submitting the job
 	ClientID string `json:"ClientID,omitempty" validate:"required"`
@@ -353,4 +357,8 @@ type JobCancelPayload struct {
 
 	// The reason that the job is being canceled
 	Reason string `json:"Reason,omitempty"`
+}
+
+func (j JobCancelPayload) GetClientID() string {
+	return j.ClientID
 }

--- a/pkg/model/job_state.go
+++ b/pkg/model/job_state.go
@@ -27,6 +27,9 @@ const (
 
 	// All shards have completed successfully
 	JobStateCompleted
+
+	// Job is waiting to be scheduled.
+	JobStateQueued
 )
 
 // IsTerminal returns true if the given job type signals the end of the lifecycle of

--- a/pkg/model/job_state_string.go
+++ b/pkg/model/job_state_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[JobStateError-3]
 	_ = x[JobStatePartialError-4]
 	_ = x[JobStateCompleted-5]
+	_ = x[JobStateQueued-6]
 }
 
-const _JobStateType_name = "NewInProgressCancelledErrorPartialErrorCompleted"
+const _JobStateType_name = "NewInProgressCancelledErrorPartialErrorCompletedQueued"
 
-var _JobStateType_index = [...]uint8{0, 3, 13, 22, 27, 39, 48}
+var _JobStateType_index = [...]uint8{0, 3, 13, 22, 27, 39, 48, 54}
 
 func (i JobStateType) String() string {
 	if i < 0 || i >= JobStateType(len(_JobStateType_index)-1) {

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -34,7 +34,7 @@ type Requester struct {
 	Endpoint           requester.Endpoint
 	JobStore           jobstore.Store
 	computeProxy       *bprotocol.ComputeProxy
-	localCallback      requester.Scheduler
+	localCallback      compute.Callback
 	requesterAPIServer *requester_publicapi.RequesterAPIServer
 	cleanupFunc        func(ctx context.Context)
 }
@@ -133,6 +133,7 @@ func NewRequesterNode(
 		ID:                         host.ID().String(),
 		PublicKey:                  marshaledPublicKey,
 		Selector:                   selectionStrategy,
+		Store:                      jobStore,
 		Scheduler:                  scheduler,
 		Verifiers:                  verifiers,
 		StorageProviders:           storageProviders,

--- a/pkg/requester/endpoint.go
+++ b/pkg/requester/endpoint.go
@@ -3,15 +3,18 @@ package requester
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/requester/jobtransform"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/verifier"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -21,6 +24,7 @@ type BaseEndpointParams struct {
 	PublicKey                  []byte
 	Scheduler                  Scheduler
 	Selector                   bidstrategy.BidStrategy
+	Store                      jobstore.Store
 	Verifiers                  verifier.VerifierProvider
 	StorageProviders           storage.StorageProvider
 	MinJobExecutionTimeout     time.Duration
@@ -30,8 +34,9 @@ type BaseEndpointParams struct {
 // BaseEndpoint base implementation of requester Endpoint
 type BaseEndpoint struct {
 	id         string
+	queue      Queue
+	store      jobstore.Store
 	selector   bidstrategy.BidStrategy
-	scheduler  Scheduler
 	transforms []jobtransform.Transformer
 }
 
@@ -43,10 +48,12 @@ func NewBaseEndpoint(params *BaseEndpointParams) *BaseEndpoint {
 		jobtransform.NewRequesterInfo(params.ID, params.PublicKey),
 	}
 
+	queue := NewQueue(params.Store, params.Scheduler)
 	return &BaseEndpoint{
 		id:         params.ID,
+		queue:      queue,
 		selector:   params.Selector,
-		scheduler:  params.Scheduler,
+		store:      params.Store,
 		transforms: transforms,
 	}
 }
@@ -61,7 +68,7 @@ func (node *BaseEndpoint) SubmitJob(ctx context.Context, data model.JobCreatePay
 	// Creates a new root context to track a job's lifecycle for tracing. This
 	// should be fine as only one node will call SubmitJob(...) - the other
 	// nodes will hear about the job via events on the transport.
-	jobCtx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester.BaseEndpoint.SubmitJob",
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/requester.BaseEndpoint.SubmitJob",
 		// job lifecycle spans go in their own, dedicated trace
 		trace.WithNewRoot(),
 		trace.WithLinks(trace.LinkFromContext(ctx)), // link to any api traces
@@ -95,25 +102,61 @@ func (node *BaseEndpoint) SubmitJob(ctx context.Context, data model.JobCreatePay
 		}
 	}
 
-	request := bidstrategy.BidStrategyRequest{NodeID: node.id, Job: *job}
-	if choice, bidErr := node.selector.ShouldBid(ctx, request); bidErr != nil {
-		return job, bidErr
-	} else if !choice.ShouldBid {
-		return job, fmt.Errorf("job is unacceptable: %s", choice.Reason)
-	}
-
-	err = node.scheduler.StartJob(jobCtx, StartJobRequest{
-		Job: *job,
-	})
+	err = node.store.CreateJob(ctx, *job)
 	if err != nil {
-		return &model.Job{}, fmt.Errorf("error starting job: %w", err)
+		return job, err
 	}
 
-	return job, nil
+	err = node.queue.EnqueueJob(ctx, *job)
+	if err != nil {
+		return job, err
+	}
+
+	selectRequest := bidstrategy.BidStrategyRequest{NodeID: node.id, Job: *job}
+	response, err := node.selector.ShouldBid(ctx, selectRequest)
+	if err != nil {
+		return job, err
+	}
+
+	return job, node.handleBidResponse(ctx, *job, response)
+}
+
+func (node *BaseEndpoint) ApproveJob(ctx context.Context, approval ApproveJobRequest) error {
+	// We deliberately expect this to be the empty string if unset. This is so
+	// that if this env variable is (accidentally) left unset, no jobs can be
+	// approved because an empty ClientID is invalid.
+	approvingClient := os.Getenv("BACALHAU_JOB_APPROVER")
+	if approval.ClientID != approvingClient {
+		return errors.New("approval submitted by unknown client")
+	}
+
+	job, err := node.store.GetJob(ctx, approval.JobID)
+	if err != nil {
+		return err
+	}
+
+	return node.handleBidResponse(ctx, job, approval.Response)
 }
 
 func (node *BaseEndpoint) CancelJob(ctx context.Context, request CancelJobRequest) (CancelJobResult, error) {
-	return node.scheduler.CancelJob(ctx, request)
+	return node.queue.CancelJob(ctx, request)
+}
+
+func (node *BaseEndpoint) handleBidResponse(ctx context.Context, job model.Job, response bidstrategy.BidStrategyResponse) error {
+	if response.ShouldWait {
+		return nil
+	}
+
+	if response.ShouldBid {
+		return node.queue.StartJob(ctx, StartJobRequest{Job: job})
+	}
+
+	_, err := node.queue.CancelJob(ctx, CancelJobRequest{
+		JobID:         job.Metadata.ID,
+		Reason:        fmt.Sprintf("job rejected: %s", response.Reason),
+		UserTriggered: false,
+	})
+	return err
 }
 
 // Compile-time interface check:

--- a/pkg/requester/endpoint_test.go
+++ b/pkg/requester/endpoint_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore/inmemory"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	noop_storage "github.com/bacalhau-project/bacalhau/pkg/storage/noop"
@@ -16,38 +18,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockBidStrategy bool
+type mockBidStrategy struct {
+	response bidstrategy.BidStrategyResponse
+}
 
 // ShouldBid implements bidstrategy.BidStrategy
 func (m *mockBidStrategy) ShouldBid(context.Context, bidstrategy.BidStrategyRequest) (bidstrategy.BidStrategyResponse, error) {
-	return bidstrategy.BidStrategyResponse{ShouldBid: bool(*m)}, nil
+	return m.response, nil
 }
 
 // ShouldBidBasedOnUsage implements bidstrategy.BidStrategy
 func (m *mockBidStrategy) ShouldBidBasedOnUsage(context.Context, bidstrategy.BidStrategyRequest, model.ResourceUsageData) (bidstrategy.BidStrategyResponse, error) {
-	return bidstrategy.BidStrategyResponse{ShouldBid: bool(*m)}, nil
+	return m.response, nil
 }
 
 var _ bidstrategy.BidStrategy = (*mockBidStrategy)(nil)
 
-func TestEndpointAppliesJobSelectionPolicy(t *testing.T) {
-	type errRequire func(require.TestingT, error, ...interface{})
-
+func getTestEndpoint(t *testing.T, strategy bidstrategy.BidStrategy) (Endpoint, jobstore.Store) {
 	cm := system.NewCleanupManager()
+	t.Cleanup(func() { cm.Cleanup(context.Background()) })
+
 	verifier_mock, err := noop_verifier.NewNoopVerifier(context.Background(), cm)
 	require.NoError(t, err)
 	storage_mock := noop_storage.NewNoopStorage(noop_storage.StorageConfig{})
 	require.NoError(t, err)
+	store := inmemory.NewJobStore()
+	endpoint := NewBaseEndpoint(&BaseEndpointParams{
+		Scheduler: &mockScheduler{
+			handleStartJob: func(ctx context.Context, sjr StartJobRequest) error {
+				store.UpdateJobState(ctx, jobstore.UpdateJobStateRequest{
+					JobID:    sjr.Job.Metadata.ID,
+					NewState: model.JobStateInProgress,
+				})
+				return nil
+			},
+		},
+		Selector:         strategy,
+		Store:            store,
+		Verifiers:        model.NewNoopProvider[model.Verifier, verifier.Verifier](verifier_mock),
+		StorageProviders: model.NewNoopProvider[model.StorageSourceType, storage.Storage](storage_mock),
+	})
 
-	runTest := func(shouldBid bool, check errRequire) {
-		strategy := mockBidStrategy(shouldBid)
-		endpoint := NewBaseEndpoint(&BaseEndpointParams{
-			Scheduler:        &mockScheduler{},
-			Selector:         &strategy,
-			Verifiers:        model.NewNoopProvider[model.Verifier, verifier.Verifier](verifier_mock),
-			StorageProviders: model.NewNoopProvider[model.StorageSourceType, storage.Storage](storage_mock),
-		})
+	return endpoint, store
+}
 
+func TestEndpointAppliesJobSelectionPolicy(t *testing.T) {
+	runTest := func(t *testing.T, shouldBid, shouldWait bool, expected model.JobStateType) {
+		strategy := mockBidStrategy{
+			response: bidstrategy.BidStrategyResponse{
+				ShouldBid:  shouldBid,
+				ShouldWait: shouldWait,
+			},
+		}
+
+		endpoint, store := getTestEndpoint(t, &strategy)
 		job, err := endpoint.SubmitJob(context.Background(), model.JobCreatePayload{
 			Spec: &model.Spec{
 				Network: model.NetworkConfig{
@@ -55,11 +79,67 @@ func TestEndpointAppliesJobSelectionPolicy(t *testing.T) {
 				},
 			},
 		})
-
 		require.NotNil(t, job)
-		check(t, err)
+		require.NoError(t, err)
+
+		state, err := store.GetJobState(context.Background(), job.Metadata.ID)
+		require.NoError(t, err)
+		require.Equal(t, expected, state.State)
 	}
 
-	t.Run("should not accept when strategy returns false", func(t *testing.T) { runTest(false, require.Error) })
-	t.Run("should accept when strategy returns true", func(t *testing.T) { runTest(true, require.NoError) })
+	t.Run("cancels when strategy returns false", func(t *testing.T) {
+		runTest(t, false, false, model.JobStateCancelled)
+	})
+
+	t.Run("starts when strategy returns true", func(t *testing.T) {
+		runTest(t, true, false, model.JobStateInProgress)
+	})
+
+	t.Run("queues when strategy says to wait", func(t *testing.T) {
+		runTest(t, false, true, model.JobStateQueued)
+		runTest(t, true, true, model.JobStateQueued)
+	})
+}
+
+func TestEndpointAcceptsApprovals(t *testing.T) {
+	runTest := func(t *testing.T, shouldBid bool, expected model.JobStateType) {
+		strategy := mockBidStrategy{
+			response: bidstrategy.BidStrategyResponse{ShouldWait: true},
+		}
+		endpoint, store := getTestEndpoint(t, &strategy)
+
+		job, err := endpoint.SubmitJob(context.Background(), model.JobCreatePayload{
+			Spec: &model.Spec{},
+		})
+		require.NotNil(t, job)
+		require.NoError(t, err)
+
+		state, err := store.GetJobState(context.Background(), job.Metadata.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.JobStateQueued, state.State)
+
+		err = endpoint.ApproveJob(context.Background(), ApproveJobRequest{
+			ClientID: "",
+			JobID:    job.Metadata.ID,
+			Response: bidstrategy.BidStrategyResponse{ShouldBid: shouldBid},
+		})
+
+		state, err = store.GetJobState(context.Background(), job.Metadata.ID)
+		require.NoError(t, err)
+		require.Equal(t, expected, state.State)
+	}
+
+	t.Run("starts job when approving", func(t *testing.T) {
+		runTest(t, true, model.JobStateInProgress)
+	})
+
+	t.Run("cancels job when rejecting", func(t *testing.T) {
+		runTest(t, false, model.JobStateCancelled)
+	})
+
+	t.Run("rejects unknown client", func(t *testing.T) {
+		t.Setenv("BACALHAU_JOB_APPROVER", "hello")
+		runTest(t, false, model.JobStateQueued)
+		runTest(t, true, model.JobStateQueued)
+	})
 }

--- a/pkg/requester/publicapi/client.go
+++ b/pkg/requester/publicapi/client.go
@@ -119,10 +119,10 @@ func (apiClient *RequesterAPIClient) Cancel(ctx context.Context, jobID string, r
 	}
 	log.Ctx(ctx).Trace().Str("signature", signature).Msgf("signature")
 
-	req := cancelRequest{
-		JobCancelPayload: &rawPayloadJSON,
-		ClientSignature:  signature,
-		ClientPublicKey:  system.GetClientPublicKey(),
+	req := signedRequest{
+		Payload:         &rawPayloadJSON,
+		ClientSignature: signature,
+		ClientPublicKey: system.GetClientPublicKey(),
 	}
 
 	var res cancelResponse

--- a/pkg/requester/publicapi/endpoints_approve.go
+++ b/pkg/requester/publicapi/endpoints_approve.go
@@ -1,0 +1,32 @@
+package publicapi
+
+import (
+	"net/http"
+
+	"github.com/bacalhau-project/bacalhau/pkg/requester"
+	"github.com/rs/zerolog/log"
+)
+
+type JobApprovePayload struct {
+	requester.ApproveJobRequest
+}
+
+func (j JobApprovePayload) GetClientID() string {
+	return j.ApproveJobRequest.ClientID
+}
+
+func (s *RequesterAPIServer) approve(res http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	approval, err := unmarshalSignedJob[JobApprovePayload](ctx, req.Body)
+	if err != nil {
+		httpError(ctx, res, err, http.StatusBadRequest)
+		return
+	}
+
+	ctx = log.Ctx(ctx).With().Str("JobID", approval.ApproveJobRequest.JobID).Logger().WithContext(ctx)
+	err = s.requester.ApproveJob(ctx, approval.ApproveJobRequest)
+	if err != nil {
+		httpError(ctx, res, err, http.StatusBadRequest)
+		return
+	}
+}

--- a/pkg/requester/publicapi/endpoints_cancel.go
+++ b/pkg/requester/publicapi/endpoints_cancel.go
@@ -14,18 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type cancelRequest struct {
-	// The data needed to cancel a running job on the network
-	JobCancelPayload *json.RawMessage `json:"job_cancel_payload" validate:"required"`
-
-	// A base64-encoded signature of the data, signed by the client:
-	ClientSignature string `json:"signature" validate:"required"`
-
-	// The base64-encoded public key of the client:
-	ClientPublicKey string `json:"client_public_key" validate:"required"`
-}
-
-type CancelRequest = cancelRequest
+type cancelRequest = SignedRequest[model.JobCancelPayload]
 
 type cancelResponse struct {
 	State *model.JobState `json:"state"`
@@ -48,37 +37,13 @@ type cancelResponse struct {
 //	@Router					/requester/cancel [post]
 func (s *RequesterAPIServer) cancel(res http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	var cancelReq CancelRequest
-	if err := json.NewDecoder(req.Body).Decode(&cancelReq); err != nil {
-		log.Ctx(ctx).Debug().Msgf("====> Decode cancelRequest error: %s", err)
-		http.Error(res, bacerrors.ErrorToErrorResponse(err), http.StatusBadRequest)
+	jobCancelPayload, err := unmarshalSignedJob[model.JobCancelPayload](ctx, req.Body)
+	if err != nil {
+		httpError(ctx, res, err, http.StatusBadRequest)
 		return
 	}
 
-	// first verify the signature on the raw bytes
-	if err := verifyRequestSignature(*cancelReq.JobCancelPayload, cancelReq.ClientSignature, cancelReq.ClientPublicKey); err != nil {
-		log.Ctx(ctx).Debug().Msgf("====> VerifyRequestSignature error: %s", err)
-		errorResponse := bacerrors.ErrorToErrorResponse(err)
-		http.Error(res, errorResponse, http.StatusBadRequest)
-		return
-	}
-
-	// then decode the job create payload
-	var jobCancelPayload model.JobCancelPayload
-	if err := json.Unmarshal(*cancelReq.JobCancelPayload, &jobCancelPayload); err != nil {
-		log.Ctx(ctx).Debug().Msgf("====> Decode JobCancelPayload error: %s", err)
-		http.Error(res, bacerrors.ErrorToErrorResponse(err), http.StatusBadRequest)
-		return
-	}
 	res.Header().Set(handlerwrapper.HTTPHeaderClientID, jobCancelPayload.ClientID)
-
-	if err := verifySignedJobRequest(jobCancelPayload.ClientID, cancelReq.ClientSignature, cancelReq.ClientPublicKey); err != nil {
-		log.Ctx(ctx).Debug().Msgf("====> verifySignedJobRequest error: %s", err)
-		errorResponse := bacerrors.ErrorToErrorResponse(err)
-		http.Error(res, errorResponse, http.StatusUnauthorized)
-		return
-	}
-
 	ctx = system.AddJobIDToBaggage(ctx, jobCancelPayload.ClientID)
 
 	// Get the job, check it exists and check it belongs to the same client

--- a/pkg/requester/publicapi/server.go
+++ b/pkg/requester/publicapi/server.go
@@ -51,6 +51,7 @@ func (s *RequesterAPIServer) RegisterAllHandlers() error {
 		{URI: "/" + APIPrefix + "results", Handler: http.HandlerFunc(s.results)},
 		{URI: "/" + APIPrefix + "events", Handler: http.HandlerFunc(s.events)},
 		{URI: "/" + APIPrefix + "submit", Handler: http.HandlerFunc(s.submit)},
+		{URI: "/" + APIPrefix + "approve", Handler: http.HandlerFunc(s.approve)},
 		{URI: "/" + APIPrefix + "cancel", Handler: http.HandlerFunc(s.cancel)},
 		{URI: "/" + APIPrefix + "websocket/events", Handler: http.HandlerFunc(s.websocketJobEvents), Raw: true},
 		{URI: "/" + APIPrefix + "debug", Handler: http.HandlerFunc(s.debug)},

--- a/pkg/requester/publicapi/utils.go
+++ b/pkg/requester/publicapi/utils.go
@@ -1,17 +1,77 @@
 package publicapi
 
 import (
+	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
+	"io"
+	"net/http"
 
+	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
+
+// A weakly-typed signed request. We use this type only in our code
+// on both client and server to correctly validate signatures.
+type signedRequest struct {
+	// The data needed to cancel a running job on the network
+	Payload *json.RawMessage `json:"payload" validate:"required"`
+
+	// A base64-encoded signature of the data, signed by the client:
+	ClientSignature string `json:"signature" validate:"required"`
+
+	// The base64-encoded public key of the client:
+	ClientPublicKey string `json:"client_public_key" validate:"required"`
+}
+
+// A strongly-typed signed request. We use this type only in our documentation
+// to allow clients to understand the correct type of the payload.
+type SignedRequest[PayloadType ContainsClientID] struct {
+	// The data needed to cancel a running job on the network
+	Payload PayloadType `json:"payload" validate:"required"`
+
+	// A base64-encoded signature of the data, signed by the client:
+	ClientSignature string `json:"signature" validate:"required"`
+
+	// The base64-encoded public key of the client:
+	ClientPublicKey string `json:"client_public_key" validate:"required"`
+}
+
+type ContainsClientID interface {
+	GetClientID() string
+}
+
+func unmarshalSignedJob[PayloadType ContainsClientID](ctx context.Context, body io.Reader) (PayloadType, error) {
+	var cancelReq signedRequest
+	var payload PayloadType
+
+	if err := json.NewDecoder(body).Decode(&cancelReq); err != nil {
+		return payload, errors.Wrap(err, "error unmarshalling envelope")
+	}
+
+	// first verify the signature on the raw bytes
+	if err := verifyRequestSignature(*cancelReq.Payload, cancelReq.ClientSignature, cancelReq.ClientPublicKey); err != nil {
+		return payload, errors.Wrap(err, "error verifying request signature")
+	}
+
+	// then decode the job create payload
+	if err := json.Unmarshal(*cancelReq.Payload, &payload); err != nil {
+		return payload, errors.Wrap(err, "error unmarshalling payload")
+	}
+
+	// check that the client id in the payload actually matches the key
+	if err := verifySignedJobRequest(payload.GetClientID(), cancelReq.ClientSignature, cancelReq.ClientPublicKey); err != nil {
+		return payload, errors.Wrap(err, "error validating request")
+	}
+
+	return payload, nil
+}
 
 func verifyRequestSignature(msg json.RawMessage, clientSignature string, clientPubKey string) error {
 	err := system.Verify(msg, clientSignature, clientPubKey)
 	if err != nil {
-		return fmt.Errorf("client's signature is invalid: %w", err)
+		return errors.Wrap(err, "client's signature is invalid")
 	}
 
 	return nil
@@ -31,10 +91,15 @@ func verifySignedJobRequest(reqClientID string, clientSig string, clientPubKey s
 	// Check that the client's public key matches the client ID:
 	ok, err := system.PublicKeyMatchesID(clientPubKey, reqClientID)
 	if err != nil {
-		return fmt.Errorf("error verifying client ID: %w", err)
+		return errors.Wrap(err, "error verifying client ID")
 	}
 	if !ok {
 		return errors.New("client's public key does not match client ID")
 	}
 	return nil
+}
+
+func httpError(ctx context.Context, res http.ResponseWriter, err error, statusCode int) {
+	log.Ctx(ctx).Error().Err(err).Send()
+	http.Error(res, bacerrors.ErrorToErrorResponse(err), statusCode)
 }

--- a/pkg/requester/queue.go
+++ b/pkg/requester/queue.go
@@ -1,0 +1,62 @@
+package requester
+
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/pkg/errors"
+)
+
+type queue struct {
+	scheduler Scheduler
+	store     jobstore.Store
+}
+
+func NewQueue(store jobstore.Store, scheduler Scheduler) Queue {
+	return &queue{
+		scheduler: scheduler,
+		store:     store,
+	}
+}
+
+func (q *queue) EnqueueJob(ctx context.Context, job model.Job) error {
+	return q.store.UpdateJobState(ctx, jobstore.UpdateJobStateRequest{
+		JobID: job.Metadata.ID,
+		Condition: jobstore.UpdateJobCondition{
+			ExpectedState: model.JobStateNew,
+		},
+		NewState: model.JobStateQueued,
+	})
+}
+
+func (q *queue) StartJob(ctx context.Context, req StartJobRequest) error {
+	err := q.store.UpdateJobState(ctx, jobstore.UpdateJobStateRequest{
+		JobID: req.Job.Metadata.ID,
+		Condition: jobstore.UpdateJobCondition{
+			ExpectedState: model.JobStateQueued,
+		},
+		NewState: model.JobStateNew,
+	})
+	if err != nil {
+		return err
+	}
+
+	return q.scheduler.StartJob(ctx, req)
+}
+
+func (q *queue) CancelJob(ctx context.Context, req CancelJobRequest) (CancelJobResult, error) {
+	err := q.store.UpdateJobState(ctx, jobstore.UpdateJobStateRequest{
+		JobID: req.JobID,
+		Condition: jobstore.UpdateJobCondition{
+			ExpectedState: model.JobStateQueued,
+		},
+		NewState: model.JobStateCancelled,
+		Comment:  req.Reason,
+	})
+	var invalidJobErr jobstore.ErrInvalidJobState
+	if err != nil && errors.As(err, &invalidJobErr) {
+		return q.scheduler.CancelJob(ctx, req)
+	}
+	return CancelJobResult{}, err
+}


### PR DESCRIPTION
In https://github.com/bacalhau-project/bacalhau/issues/1961, we implemented hooks that can be used to filter submitted jobs. As per [the design doc](https://www.notion.so/pl-strflt/Insulated-jobs-demo-1494cbe031e9443a9219dac347f4ed9d?pvs=4#508b62f1b48342ab970670ca3c37274f), we now want to apply this to allow a human to approve the job.

Previously job selection was a synchronous affair and happened within the lifecycle of the job submission call. This PR makes job selection async. Job selectors can return a `ShouldWait` flag that signals that the request can't be fulfilled immediately, and the requester now queues jobs where the job selectors return this. There is a new `/approve` API endpoint to allow the job to be dequeued.

Our HTTP job selector has also had an upgrade and responses can now encode a full object to describe the bid or wait response required.

Resolves #1963.