### PR TITLE
Reconnect devstack peers to avoid flakes

### DIFF
--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const maxServeTime = 750 * time.Millisecond
+const maxServeTime = 1 * time.Second
 const maxTestTime = 10 * time.Second
 
 type ServeSuite struct {

--- a/dashboard/api/cmd/dashboard/serve.go
+++ b/dashboard/api/cmd/dashboard/serve.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
 	"github.com/rs/zerolog/log"
-
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/i18n"
 )

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -308,7 +308,7 @@ func NewDevStack(
 		}
 
 		// Start transport layer
-		err = libp2p.ConnectToPeers(ctx, libp2pHost, libp2pPeer)
+		err = libp2p.ConnectToPeersContinuouslyWithRetryDuration(ctx, cm, libp2pHost, libp2pPeer, 2*time.Second)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
@@ -123,6 +124,29 @@ func (cl Client) SwarmAddresses(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// It's common for callers to this function to use the result to connect to another IPFS node.
+	// This sorts the addresses so IPv4 localhost is first, with the aim of using the localhost connection during tests
+	// and so avoid any unneeded network hops. Other callers to this either sort the list themselves or just output the
+	// full list.
+	preferLocalhost := func(m ma.Multiaddr) int {
+		count := 0
+		if _, err := m.ValueForProtocol(ma.P_TCP); err == nil {
+			count++
+		}
+		if ip, err := m.ValueForProtocol(ma.P_IP4); err == nil {
+			count++
+			if ip == "127.0.0.1" {
+				count++
+			}
+		} else if ip, err := m.ValueForProtocol(ma.P_IP6); err == nil && ip != "::1" {
+			count++
+		}
+		return count
+	}
+	sort.Slice(multiAddresses, func(i, j int) bool {
+		return preferLocalhost(multiAddresses[i]) > preferLocalhost(multiAddresses[j])
+	})
 
 	addresses := generic.Map(multiAddresses, func(f ma.Multiaddr) string {
 		return f.String()

--- a/pkg/libp2p/utils.go
+++ b/pkg/libp2p/utils.go
@@ -52,7 +52,7 @@ func connectToPeer(ctx context.Context, h host.Host, peer host.Host) error {
 		Stringer("peer", peer.ID()).
 		Int("addresses", len(peerAddresses)).
 		Msg("Connecting to peer")
-	if err := ConnectToPeers(ctx, h, peerAddresses); err != nil { //nolint:govet
+	if err := connectToPeers(ctx, h, peerAddresses); err != nil { //nolint:govet
 		return err
 	}
 

--- a/pkg/logger/stringer.go
+++ b/pkg/logger/stringer.go
@@ -1,0 +1,27 @@
+package logger
+
+import "fmt"
+
+func ToStringer[T any](t T, f func(t T) string) fmt.Stringer {
+	return stringerHelper[T]{
+		f: f,
+		t: t,
+	}
+}
+
+func ToSliceStringer[T any](ts []T, f func(t T) string) []fmt.Stringer {
+	stringers := make([]fmt.Stringer, 0, len(ts))
+	for _, t := range ts {
+		stringers = append(stringers, ToStringer(t, f))
+	}
+	return stringers
+}
+
+type stringerHelper[T any] struct {
+	t T
+	f func(t T) string
+}
+
+func (s stringerHelper[T]) String() string {
+	return s.f(s.t)
+}

--- a/pkg/pubsub/libp2p/pubsub.go
+++ b/pkg/pubsub/libp2p/pubsub.go
@@ -63,7 +63,7 @@ func (p *PubSub[T]) Publish(ctx context.Context, message T) error {
 	return p.topic.Publish(ctx, payload)
 }
 
-func (p *PubSub[T]) Subscribe(ctx context.Context, subscriber pubsub.Subscriber[T]) (err error) {
+func (p *PubSub[T]) Subscribe(_ context.Context, subscriber pubsub.Subscriber[T]) (err error) {
 	var firstSubscriber bool
 	p.subscriberOnce.Do(func() {
 		// register the subscriber

--- a/pkg/requester/discovery/identity_test.go
+++ b/pkg/requester/discovery/identity_test.go
@@ -4,14 +4,13 @@ package discovery
 
 import (
 	"context"
-	"testing"
-
 	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/transport/bprotocol"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/suite"
+	"testing"
 )
 
 type IdentityNodeDiscovererSuite struct {
@@ -61,8 +60,9 @@ func (s *IdentityNodeDiscovererSuite) TestFindNodes() {
 	discoverer := NewIdentityNodeDiscoverer(IdentityNodeDiscovererParams{
 		Host: s.node1,
 	})
+
 	peerIDs, err := discoverer.FindNodes(context.Background(), model.Job{})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	peerIDStrings := make([]string, len(peerIDs))
 	for i, p := range peerIDs {

--- a/pkg/test/compute/resourcelimits_test.go
+++ b/pkg/test/compute/resourcelimits_test.go
@@ -80,7 +80,7 @@ func (suite *ComputeNodeResourceLimitsSuite) TestTotalResourceLimits() {
 
 		epochSeconds := time.Now().Unix()
 
-		seenJobs := []SeenJobRecord{}
+		var seenJobs []SeenJobRecord
 		var seenJobsMutex sync.Mutex
 		seenJobsMutex.EnableTracerWithOpts(sync.Opts{
 			Threshold: 10 * time.Millisecond,
@@ -280,7 +280,7 @@ func (suite *ComputeNodeResourceLimitsSuite) TestParallelGPU() {
 	nodeCount := 2
 	jobsPerNode := 2
 	seenJobs := 0
-	jobIds := []string{}
+	var jobIds []string
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Improve test reliability by getting nodes within a devstack to reconnect to each other rather than assuming they connect and stay connected. Also reduce the dial timeout time to only a second rather than the default of 60 seconds.