### PR TITLE
Mark a job as completed when executions finish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       GOOS: << parameters.target_os >>
       GOARCH: << parameters.target_arch >>
       GCS_TEST_RESULTS_BUCKET: bacalhau-global-storage/test-results
+      GOMAXPROCS: "2" # Avoid using all the allocated CPU, so tests don't get rate limited
     working_directory: ~/repo
     executor: << parameters.executor >>
     parameters:

--- a/pkg/model/job_state.go
+++ b/pkg/model/job_state.go
@@ -70,3 +70,13 @@ type JobState struct {
 	// TimeoutAt is the time when the job will be timed out if it is not completed.
 	TimeoutAt time.Time `json:"TimeoutAt,omitempty"`
 }
+
+func (j JobState) ExecutionsInTerminalState() bool {
+	for _, execution := range j.Executions {
+		if !execution.State.IsTerminal() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/requester/scheduler.go
+++ b/pkg/requester/scheduler.go
@@ -578,8 +578,8 @@ func (s *scheduler) OnPublishComplete(ctx context.Context, result compute.Publis
 		log.Ctx(ctx).Error().Err(err).Msg("[OnPublishComplete] failed to get job state")
 		return
 	}
-	if jobState.State == model.JobStateCompleted {
-		// result already published by another node
+	if !jobState.ExecutionsInTerminalState() {
+		// An execution is still being worked on, so the job isn't completed yet.
 		return
 	}
 	err = s.jobStore.UpdateJobState(ctx, jobstore.UpdateJobStateRequest{

--- a/pkg/test/compute/resourcelimits_test.go
+++ b/pkg/test/compute/resourcelimits_test.go
@@ -294,7 +294,7 @@ func (suite *ComputeNodeResourceLimitsSuite) TestParallelGPU() {
 	nodeOverrides := make([]node.NodeConfig, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeOverrides[i] = node.NodeConfig{
-			NodeInfoPublisherInterval: 10 * time.Millisecond, // publish node info quickly for requester node to be aware of compute node infos
+			NodeInfoPublisherInterval: 100 * time.Millisecond, // publish node info quickly for requester node to be aware of compute node infos
 		}
 	}
 	stack := testutils.SetupTestWithNoopExecutor(

--- a/pkg/test/requester/node_selection_test.go
+++ b/pkg/test/requester/node_selection_test.go
@@ -63,7 +63,7 @@ func (s *NodeSelectionSuite) SetupSuite() {
 		},
 	}
 	for i := 0; i < len(nodeOverrides); i++ {
-		nodeOverrides[i].NodeInfoPublisherInterval = 10 * time.Millisecond // publish node info quickly for requester node to be aware of compute node infos
+		nodeOverrides[i].NodeInfoPublisherInterval = 100 * time.Millisecond // publish node info quickly for requester node to be aware of compute node infos
 	}
 	stack := testutils.SetupTestWithNoopExecutor(ctx, s.T(), devstackOptions,
 		node.NewComputeConfigWithDefaults(),


### PR DESCRIPTION
Only mark a job as completed when all the executions have finished, rather than marking the job as completed as soon as the first execution has finished. Marking the job as completed early meant tests regularly fell into the trap of assuming all executions were done - something that users of the API would also fall into.

Also, some other small changes with the aim of improving test stability:
* Force Go to not use all the CPU so the tests don't get throttled
* Reduce the speed at which node info updates are published in tests. It seems like there may be lock contention occurring around the node info cache?

Fixes #2135