### PR TITLE
Avoid multiple addresses when connecting nodes

### DIFF
--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -197,16 +197,13 @@ func NewDevStack(
 				libp2pPeer = append(libp2pPeer, peerAddr)
 			}
 		} else {
-			for _, addrs := range nodes[0].Host.Addrs() {
-				p2pAddr, p2pAddrErr := multiaddr.NewMultiaddr("/p2p/" + nodes[0].Host.ID().String())
-				if p2pAddrErr != nil {
-					return nil, p2pAddrErr
-				}
-				libp2pPeer = append(libp2pPeer, addrs.Encapsulate(p2pAddr))
-			}
+			p2pAddr, err := multiaddr.NewMultiaddr("/p2p/" + nodes[0].Host.ID().String()) //nolint:govet
 			if err != nil {
-				return nil, fmt.Errorf("failed to get libp2p addresses: %w", err)
+				return nil, err
 			}
+			// Only use a single address as libp2p seems to have concurrency issues, like two nodes not able to finish
+			// connecting/joining topics, when using multiple addresses for a single host.
+			libp2pPeer = append(libp2pPeer, nodes[0].Host.Addrs()[0].Encapsulate(p2pAddr))
 			log.Ctx(ctx).Debug().Msgf("Connecting to first libp2p requester node: %s", libp2pPeer)
 		}
 


### PR DESCRIPTION
libp2p seems to have a concurrency problem when attempting to connect to a node using multiple addresses. This change stops tests from breaking and only affects the devstack, but it's possible for the problem to persist in a real-world cluster.

Fixes #2129