### PR TITLE
Allow in-process IPFS to find a random port

### DIFF
--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -8,18 +8,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/config"
+	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore/inmemory"
 	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
-	filecoinlotus "github.com/bacalhau-project/bacalhau/pkg/publisher/filecoin_lotus"
-	"github.com/imdario/mergo"
-	"github.com/libp2p/go-libp2p/core/host"
-
-	"github.com/bacalhau-project/bacalhau/pkg/config"
-	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/node"
+	filecoinlotus "github.com/bacalhau-project/bacalhau/pkg/publisher/filecoin_lotus"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/util/multiaddresses"
+	"github.com/imdario/mergo"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/phayes/freeport"
 	"github.com/rs/zerolog/log"
@@ -201,9 +201,10 @@ func NewDevStack(
 			if err != nil {
 				return nil, err
 			}
+			addresses := multiaddresses.SortLocalhostFirst(nodes[0].Host.Addrs())
 			// Only use a single address as libp2p seems to have concurrency issues, like two nodes not able to finish
 			// connecting/joining topics, when using multiple addresses for a single host.
-			libp2pPeer = append(libp2pPeer, nodes[0].Host.Addrs()[0].Encapsulate(p2pAddr))
+			libp2pPeer = append(libp2pPeer, addresses[0].Encapsulate(p2pAddr))
 			log.Ctx(ctx).Debug().Msgf("Connecting to first libp2p requester node: %s", libp2pPeer)
 		}
 

--- a/pkg/ipfs/address_in_use_other.go
+++ b/pkg/ipfs/address_in_use_other.go
@@ -1,9 +1,0 @@
-//go:build !unix
-
-package ipfs
-
-import (
-	"errors"
-)
-
-var addressInUseError = errors.New("unsure what error other OSes give for this so have an error which won't match anything")

--- a/pkg/ipfs/address_in_use_unix.go
+++ b/pkg/ipfs/address_in_use_unix.go
@@ -1,7 +1,0 @@
-//go:build unix
-
-package ipfs
-
-import "syscall"
-
-var addressInUseError = syscall.EADDRINUSE

--- a/pkg/ipfs/node_test.go
+++ b/pkg/ipfs/node_test.go
@@ -83,9 +83,11 @@ func (s *NodeSuite) TestFunctionality() {
 	s.Require().Equal(testString, string(data))
 
 	s.Never(func() bool {
-		peers, err := n2.Client().API.Swarm().Peers(ctx)
+		peers, err := n2.Client().API.Swarm().KnownAddrs(ctx)
 		s.Require().NoError(err)
-
+		id, err := n2.Client().API.Key().Self(ctx)
+		s.Require().NoError(err)
+		delete(peers, id.ID())
 		return !s.Len(peers, 1)
 	}, 500*time.Millisecond, 10*time.Millisecond, "a local node should only connect to the passed in peers")
 

--- a/pkg/libp2p/host.go
+++ b/pkg/libp2p/host.go
@@ -29,23 +29,15 @@ func NewHost(port int, opts ...libp2p.Option) (host.Host, error) {
 	}
 
 	addrs := []string{
-		"/ip4/0.0.0.0/tcp/%d",
-		"/ip4/0.0.0.0/udp/%d/quic",
-		"/ip4/0.0.0.0/udp/%d/quic-v1",
-		"/ip6/::/tcp/%d",
-		"/ip6/::/udp/%d/quic",
-		"/ip6/::/udp/%d/quic-v1",
-	}
-	listenAddrs := make([]multiaddr.Multiaddr, 0, len(addrs))
-	for _, s := range addrs {
-		addr, addrErr := multiaddr.NewMultiaddr(fmt.Sprintf(s, port))
-		if addrErr != nil {
-			return nil, addrErr
-		}
-		listenAddrs = append(listenAddrs, addr)
+		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port),
+		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic", port),
+		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", port),
+		fmt.Sprintf("/ip6/::/tcp/%d", port),
+		fmt.Sprintf("/ip6/::/udp/%d/quic", port),
+		fmt.Sprintf("/ip6/::/udp/%d/quic-v1", port),
 	}
 
-	opts = append(opts, libp2p.ListenAddrs(listenAddrs...))
+	opts = append(opts, libp2p.ListenAddrStrings(addrs...))
 	opts = append(opts, libp2p.Identity(prvKey))
 	h, err := libp2p.New(opts...)
 	if err != nil {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -5,7 +5,6 @@ package logger
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"regexp"
@@ -20,7 +19,6 @@ import (
 	"github.com/ipfs/kubo/plugin/loader"
 	kuboRepo "github.com/ipfs/kubo/repo"
 	"github.com/ipfs/kubo/repo/fsrepo"
-	"github.com/phayes/freeport"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -117,13 +115,6 @@ func triggerIPFSLogging(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, config.Profiles["test"].Transform(cfg))
 
-	apiPort, err := freeport.GetFreePort()
-	require.NoError(t, err)
-	gatewayPort, err := freeport.GetFreePort()
-	require.NoError(t, err)
-	swarmPort, err := freeport.GetFreePort()
-	require.NoError(t, err)
-
 	cfg.AutoNAT.ServiceMode = config.AutoNATServiceDisabled
 	cfg.Swarm.EnableHolePunching = config.False
 	cfg.Swarm.DisableNatPortMap = true
@@ -131,15 +122,9 @@ func triggerIPFSLogging(t *testing.T) {
 	cfg.Swarm.RelayService.Enabled = config.False
 	cfg.Swarm.Transports.Network.Relay = config.False
 	cfg.Discovery.MDNS.Enabled = false
-	cfg.Addresses.Gateway = []string{
-		fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", gatewayPort),
-	}
-	cfg.Addresses.API = []string{
-		fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", apiPort),
-	}
-	cfg.Addresses.Swarm = []string{
-		fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", swarmPort),
-	}
+	cfg.Addresses.Gateway = []string{"/ip4/0.0.0.0/tcp/0"}
+	cfg.Addresses.API = []string{"/ip4/0.0.0.0/tcp/0"}
+	cfg.Addresses.Swarm = []string{"/ip4/0.0.0.0/tcp/0"}
 	cfg.Peering = config.Peering{
 		Peers: nil,
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -82,13 +82,7 @@ type Node struct {
 }
 
 func (n *Node) Start(ctx context.Context) error {
-	go func(ctx context.Context) {
-		if err := n.APIServer.ListenAndServe(ctx, n.CleanupManager); err != nil {
-			log.Ctx(ctx).Error().Msgf("Api server can't run. Cannot serve client requests!: %v", err)
-		}
-	}(ctx)
-
-	return nil
+	return n.APIServer.ListenAndServe(ctx, n.CleanupManager)
 }
 
 func NewStandardNode(

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -178,14 +178,17 @@ func (apiServer *APIServer) ListenAndServe(ctx context.Context, cm *system.Clean
 	// Cleanup resources when system is done:
 	cm.RegisterCallbackWithContext(srv.Shutdown)
 
-	err = srv.Serve(listener)
-	if err == http.ErrServerClosed {
-		log.Ctx(ctx).Debug().Msgf(
-			"API server closed for host %s on %s.", apiServer.Address, srv.Addr)
-		return nil // expected error if the server is shut down
-	}
+	go func() {
+		err := srv.Serve(listener)
+		if err == http.ErrServerClosed {
+			log.Ctx(ctx).Debug().Msgf(
+				"API server closed for host %s on %s.", apiServer.Address, srv.Addr)
+		} else if err != nil {
+			log.Ctx(ctx).Err(err).Msg("Api server can't run. Cannot serve client requests!")
+		}
+	}()
 
-	return err
+	return nil
 }
 
 func (apiServer *APIServer) RegisterHandlers(config ...HandlerConfig) error {

--- a/pkg/publicapi/util_test.go
+++ b/pkg/publicapi/util_test.go
@@ -15,21 +15,16 @@ import (
 const TimeToWaitForServerReply = 10
 const TimeToWaitForHealthy = 50
 
-//nolint:unused // used in tests
 func setupNodeForTest(t *testing.T, cm *system.CleanupManager) *APIClient {
 	// blank config should result in using defaults in node.Node constructor
 	return setupNodeForTestWithConfig(t, cm, APIServerConfig{})
 }
 
-//nolint:unused // used in tests
 func setupNodeForTestWithConfig(t *testing.T, cm *system.CleanupManager, serverConfig APIServerConfig) *APIClient {
 	system.InitConfigForTesting(t)
 	ctx := context.Background()
 
 	libp2pPort, err := freeport.GetFreePort()
-	require.NoError(t, err)
-
-	apiPort, err := freeport.GetFreePort()
 	require.NoError(t, err)
 
 	libp2pHost, err := libp2p.NewHost(libp2pPort)
@@ -38,22 +33,18 @@ func setupNodeForTestWithConfig(t *testing.T, cm *system.CleanupManager, serverC
 	apiServer, err := NewAPIServer(APIServerParams{
 		Host:    libp2pHost,
 		Address: "0.0.0.0",
-		Port:    apiPort,
+		Port:    0,
 		Config:  serverConfig,
 	})
 	require.NoError(t, err)
 
-	go func() {
-		err := apiServer.ListenAndServe(ctx, cm)
-		require.NoError(t, err)
-	}()
+	require.NoError(t, apiServer.ListenAndServe(ctx, cm))
 
 	client := NewAPIClient(apiServer.GetURI())
 	require.NoError(t, waitForHealthy(ctx, client))
 	return client
 }
 
-//nolint:unused // used in tests
 func waitForHealthy(ctx context.Context, c *APIClient) error {
 	ch := make(chan bool)
 	go func() {

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -60,12 +60,9 @@ func (s *ComputeSuite) setupNode() {
 	host, err := libp2p.NewHost(libp2pPort)
 	s.NoError(err)
 
-	apiPort, err := freeport.GetFreePort()
-	s.NoError(err)
-
 	apiServer, err := publicapi.NewAPIServer(publicapi.APIServerParams{
 		Address: "0.0.0.0",
-		Port:    apiPort,
+		Port:    0,
 		Host:    host,
 		Config:  publicapi.DefaultAPIServerConfig,
 	})

--- a/pkg/test/requester/publicapi/util.go
+++ b/pkg/test/requester/publicapi/util.go
@@ -36,9 +36,6 @@ func setupNodeForTestWithConfig(t *testing.T, config publicapi.APIServerConfig) 
 	libp2pPort, err := freeport.GetFreePort()
 	require.NoError(t, err)
 
-	apiPort, err := freeport.GetFreePort()
-	require.NoError(t, err)
-
 	libp2pHost, err := libp2p.NewHost(libp2pPort)
 	require.NoError(t, err)
 
@@ -46,7 +43,7 @@ func setupNodeForTestWithConfig(t *testing.T, config publicapi.APIServerConfig) 
 		CleanupManager:      system.NewCleanupManager(),
 		Host:                libp2pHost,
 		HostAddress:         "0.0.0.0",
-		APIPort:             apiPort,
+		APIPort:             0,
 		JobStore:            datastore,
 		ComputeConfig:       node.NewComputeConfigWithDefaults(),
 		RequesterNodeConfig: node.NewRequesterConfigWithDefaults(),

--- a/pkg/util/multiaddresses/multiaddresses.go
+++ b/pkg/util/multiaddresses/multiaddresses.go
@@ -1,0 +1,32 @@
+package multiaddresses
+
+import (
+	"sort"
+
+	"github.com/multiformats/go-multiaddr"
+	"golang.org/x/exp/slices"
+)
+
+func SortLocalhostFirst(multiAddresses []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	multiAddresses = slices.Clone(multiAddresses)
+	preferLocalhost := func(m multiaddr.Multiaddr) int {
+		count := 0
+		if _, err := m.ValueForProtocol(multiaddr.P_TCP); err == nil {
+			count++
+		}
+		if ip, err := m.ValueForProtocol(multiaddr.P_IP4); err == nil {
+			count++
+			if ip == "127.0.0.1" {
+				count++
+			}
+		} else if ip, err := m.ValueForProtocol(multiaddr.P_IP6); err == nil && ip != "::1" {
+			count++
+		}
+		return count
+	}
+	sort.Slice(multiAddresses, func(i, j int) bool {
+		return preferLocalhost(multiAddresses[i]) > preferLocalhost(multiAddresses[j])
+	})
+
+	return multiAddresses
+}


### PR DESCRIPTION
Use the built-in multiaddress functionality to find a random port rather than attempting to find a port before starting up IPFS and hoping the port stays free. The API server is also changed to allow the port to be set to 0 and so reduce the use of the `freeport` dependency.

Also fixes a flake in the `TestWebsocketSuite/TestWebsocketEverything` test where the websocket connected _after_ the first job had been submitted.

Fixes #2144