### PR TITLE
Uri storage spec

### DIFF
--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -3,6 +3,8 @@ package bacalhau
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/url"
 	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
@@ -11,6 +13,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
+	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -330,7 +333,50 @@ func CreateJob(ctx context.Context, cmdArgs []string, odr *DockerRunOptions) (*m
 	}
 
 	for _, i := range odr.Inputs {
-		odr.InputVolumes = append(odr.InputVolumes, fmt.Sprintf("%s:/inputs", i))
+		isValidCID := func(i string) bool {
+			c, err := cid.Decode(i)
+			if err != nil {
+				return false // invalid CID format
+			}
+			return c.Type() == cid.Raw || c.Type() == cid.DagProtobuf // check CID version
+		}(i)
+		isTheCIDValid := isValidCID
+		if isTheCIDValid {
+			odr.InputVolumes = append(odr.InputVolumes, fmt.Sprintf("%s:/inputs", i))
+		} else {
+			scheme := func(URI string) *url.URL {
+				parsed, err1 := url.Parse(URI)
+				if err1 != nil {
+					errMsg := fmt.Sprintf("Error parsing URI %s: %v", URI, err)
+					log.Fatal(errMsg)
+				}
+				return parsed
+			}(i)
+
+			switch scheme.Scheme {
+			case "http":
+				odr.InputUrls = append(odr.InputUrls, i)
+			case "https":
+				odr.InputUrls = append(odr.InputUrls, i)
+			case "ipfs":
+				odr.InputVolumes = append(odr.InputVolumes, fmt.Sprintf("%s:/inputs", scheme.Host))
+			// unimplemented schemes
+			// case "git":
+			//     // Handle git scheme
+			//     fmt.Println("Handling git scheme...")
+			// case "gitlfs":
+			//     // Handle git scheme
+			//     fmt.Println("Handling git scheme...")
+			// case "s3":
+			//     // Handle s3 scheme
+			//     fmt.Println("Handling s3 scheme...")
+			// case "file":
+			//     // Handle file scheme
+			//     fmt.Println("Handling file scheme...")
+			default:
+				fmt.Println("Unknown scheme or scheme not currently supported...")
+			}
+		}
 	}
 
 	if len(odr.WorkingDirectory) > 0 {

--- a/cmd/bacalhau/docker_run.go
+++ b/cmd/bacalhau/docker_run.go
@@ -300,7 +300,7 @@ func dockerRun(cmd *cobra.Command, cmdArgs []string, ODR *DockerRunOptions) erro
 	)
 }
 
-// CreateJob creates a job object from the given command line arguments and options.
+//nolint:funlen // CreateJob creates a job object from the given command line arguments and options.
 func CreateJob(ctx context.Context, cmdArgs []string, odr *DockerRunOptions) (*model.Job, error) {
 	odr.Image = cmdArgs[0]
 	odr.Entrypoint = cmdArgs[1:]
@@ -334,8 +334,8 @@ func CreateJob(ctx context.Context, cmdArgs []string, odr *DockerRunOptions) (*m
 
 	for _, i := range odr.Inputs {
 		isValidCID := func(i string) bool {
-			c, err := cid.Decode(i)
-			if err != nil {
+			c, er := cid.Decode(i)
+			if er != nil {
 				return false // invalid CID format
 			}
 			return c.Type() == cid.Raw || c.Type() == cid.DagProtobuf // check CID version

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -318,62 +318,62 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 	}
 }
 
-func (s *DockerRunSuite) TestRun_SubmitMountInputs() {
-	tests := []struct {
-		numberOfJobs int
-	}{
-		{numberOfJobs: 1},
-	}
+// func (s *DockerRunSuite) TestRun_SubmitMountInputs() {
+// 	tests := []struct {
+// 		numberOfJobs int
+// 	}{
+// 		{numberOfJobs: 1},
+// 	}
 
-	for i, tc := range tests {
-		type (
-			InputMount struct {
-				uri             string
-				pathInContainer string
-				flag            string
-				filename        string
-			}
-		)
+// 	for i, tc := range tests {
+// 		type (
+// 			InputMount struct {
+// 				uri             string
+// 				pathInContainer string
+// 				flag            string
+// 				filename        string
+// 			}
+// 		)
 
-		testURLs := []struct {
-			inputURI InputMount
-		}{
-			{inputURI: InputMount{uri: "https://gateway.ipfs.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
-			{inputURI: InputMount{uri: "ipfs://bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
-		}
+// 		testURLs := []struct {
+// 			inputURI InputMount
+// 		}{
+// 			{inputURI: InputMount{uri: "https://gateway.ipfs.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
+// 			{inputURI: InputMount{uri: "ipfs://bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
+// 		}
 
-		for _, turls := range testURLs {
-			func() {
-				ctx := context.Background()
-				flagsArray := []string{"docker", "run",
-					"--api-host", s.host,
-					"--api-port", s.port}
+// 		for _, turls := range testURLs {
+// 			func() {
+// 				ctx := context.Background()
+// 				flagsArray := []string{"docker", "run",
+// 					"--api-host", s.host,
+// 					"--api-port", s.port}
 
-				flagsArray = append(flagsArray, turls.inputURI.flag, turls.inputURI.uri)
-				flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", turls.inputURI.pathInContainer, turls.inputURI.filename))
+// 				flagsArray = append(flagsArray, turls.inputURI.flag, turls.inputURI.uri)
+// 				flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", turls.inputURI.pathInContainer, turls.inputURI.filename))
 
-				_, out, err := ExecuteTestCobraCommand(flagsArray...)
-				s.Require().NoError(err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
+// 				_, out, err := ExecuteTestCobraCommand(flagsArray...)
+// 				s.Require().NoError(err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
 
-				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
+// 				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
 
-				parsed, err := url.Parse(turls.inputURI.uri)
+// 				parsed, err := url.Parse(turls.inputURI.uri)
 
-				if parsed.Scheme == "http" || parsed.Scheme == "https" {
-					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job urls != # of test urls.")
-					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].URL, "Test URL not equal to URL from job.")
-					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
-				}
-				if parsed.Scheme == "ipfs" {
-					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job cids != # of test cids.")
-					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].CID, "Test CID not equal to CID from job.")
-					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
-				}
+// 				if parsed.Scheme == "http" || parsed.Scheme == "https" {
+// 					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job urls != # of test urls.")
+// 					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].URL, "Test URL not equal to URL from job.")
+// 					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
+// 				}
+// 				if parsed.Scheme == "ipfs" {
+// 					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job cids != # of test cids.")
+// 					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].CID, "Test CID not equal to CID from job.")
+// 					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
+// 				}
 
-			}()
-		}
-	}
-}
+// 			}()
+// 		}
+// 	}
+// }
 
 func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 	tests := []struct {

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -213,7 +213,8 @@ func (s *DockerRunSuite) TestRun_SubmitInputs() {
 			inputVolumes []InputVolume
 			err          error
 		}{
-			{inputVolumes: []InputVolume{{cid: "QmZUCdf9ZdpbHdr9pU8XjdUMKutKa1aVSrLZZWC4uY4pHA", path: "", flag: "-i"}}, err: nil}, // Fake CID, but well structured
+			{inputVolumes: []InputVolume{{cid: "QmZUCdf9ZdpbHdr9pU8XjdUMKutKa1aVSrLZZWC4uY4pHA", path: "", flag: "-i"}}, err: nil},        // Fake CID, but well structured
+			{inputVolumes: []InputVolume{{cid: "ipfs://QmZUCdf9ZdpbHdr9pU8XjdUMKutKa1aVSrLZZWC4uY4pHA", path: "", flag: "-i"}}, err: nil}, // Fake ipfs URI, but well structured
 			{inputVolumes: []InputVolume{
 				{cid: "QmZUCdf9ZdpbHdr9pU8XjdUMKutKa1aVSrLZZWC4uY4pHB", path: "", flag: "-i"},
 				{cid: "QmZUCdf9ZdpbHdr9pU8XjdUMKutKa1aVSrLZZWC4uY4pHC", path: "", flag: "-i"}}, err: nil}, // 2x Fake CID, but well structured
@@ -317,63 +318,6 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 		}
 	}
 }
-
-// func (s *DockerRunSuite) TestRun_SubmitMountInputs() {
-// 	tests := []struct {
-// 		numberOfJobs int
-// 	}{
-// 		{numberOfJobs: 1},
-// 	}
-
-// 	for i, tc := range tests {
-// 		type (
-// 			InputMount struct {
-// 				uri             string
-// 				pathInContainer string
-// 				flag            string
-// 				filename        string
-// 			}
-// 		)
-
-// 		testURLs := []struct {
-// 			inputURI InputMount
-// 		}{
-// 			{inputURI: InputMount{uri: "https://gateway.ipfs.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
-// 			{inputURI: InputMount{uri: "ipfs://bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
-// 		}
-
-// 		for _, turls := range testURLs {
-// 			func() {
-// 				ctx := context.Background()
-// 				flagsArray := []string{"docker", "run",
-// 					"--api-host", s.host,
-// 					"--api-port", s.port}
-
-// 				flagsArray = append(flagsArray, turls.inputURI.flag, turls.inputURI.uri)
-// 				flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", turls.inputURI.pathInContainer, turls.inputURI.filename))
-
-// 				_, out, err := ExecuteTestCobraCommand(flagsArray...)
-// 				s.Require().NoError(err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
-
-// 				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
-
-// 				parsed, err := url.Parse(turls.inputURI.uri)
-
-// 				if parsed.Scheme == "http" || parsed.Scheme == "https" {
-// 					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job urls != # of test urls.")
-// 					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].URL, "Test URL not equal to URL from job.")
-// 					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
-// 				}
-// 				if parsed.Scheme == "ipfs" {
-// 					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job cids != # of test cids.")
-// 					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].CID, "Test CID not equal to CID from job.")
-// 					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
-// 				}
-
-// 			}()
-// 		}
-// 	}
-// }
 
 func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 	tests := []struct {

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -318,6 +318,63 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 	}
 }
 
+func (s *DockerRunSuite) TestRun_SubmitMountInputs() {
+	tests := []struct {
+		numberOfJobs int
+	}{
+		{numberOfJobs: 1},
+	}
+
+	for i, tc := range tests {
+		type (
+			InputMount struct {
+				uri             string
+				pathInContainer string
+				flag            string
+				filename        string
+			}
+		)
+
+		testURLs := []struct {
+			inputURI InputMount
+		}{
+			{inputURI: InputMount{uri: "https://gateway.ipfs.io/ipfs/Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z", pathInContainer: "/inputs", filename: "hello.txt", flag: "-m"}},
+			{inputURI: InputMount{uri: "ipfs://Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z", pathInContainer: "/inputs", filename: "hello.txt", flag: "-m"}},
+		}
+
+		for _, turls := range testURLs {
+			func() {
+				ctx := context.Background()
+				flagsArray := []string{"docker", "run",
+					"--api-host", s.host,
+					"--api-port", s.port}
+
+				flagsArray = append(flagsArray, turls.inputURI.flag, turls.inputURI.uri)
+				flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", turls.inputURI.pathInContainer, turls.inputURI.filename))
+
+				_, out, err := ExecuteTestCobraCommand(flagsArray...)
+				s.Require().NoError(err, "Error submitting job. Run - Number of Jobs: %s. Job number: %s", tc.numberOfJobs, i)
+
+				j := testutils.GetJobFromTestOutput(ctx, s.T(), s.client, out)
+
+				parsed, err := url.Parse(turls.inputURI.uri)
+
+				if parsed.Scheme == "http" || parsed.Scheme == "https" {
+					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job urls != # of test urls.")
+					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].URL, "Test URL not equal to URL from job.")
+					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
+				}
+				if parsed.Scheme == "ipfs" {
+					s.Require().Equal(1, len(j.Spec.Inputs), "Number of job cids != # of test cids.")
+					s.Require().Equal(turls.inputURI.uri, j.Spec.Inputs[0].CID, "Test CID not equal to CID from job.")
+					s.Require().Equal(turls.inputURI.pathInContainer, j.Spec.Inputs[0].Path, "Test Path not equal to Path from job.")
+				}
+
+			}()
+		}
+	}
+}
+
 func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 	tests := []struct {
 		numberOfJobs int

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -338,8 +338,8 @@ func (s *DockerRunSuite) TestRun_SubmitMountInputs() {
 		testURLs := []struct {
 			inputURI InputMount
 		}{
-			{inputURI: InputMount{uri: "https://gateway.ipfs.io/ipfs/Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z", pathInContainer: "/inputs", filename: "hello.txt", flag: "-m"}},
-			{inputURI: InputMount{uri: "ipfs://Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z", pathInContainer: "/inputs", filename: "hello.txt", flag: "-m"}},
+			{inputURI: InputMount{uri: "https://gateway.ipfs.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
+			{inputURI: InputMount{uri: "ipfs://bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m", pathInContainer: "/inputs", filename: "hello.txt", flag: "-i"}},
 		}
 
 		for _, turls := range testURLs {


### PR DESCRIPTION
Instead of having separate flags for each storage type we use a single flag

Since currently we only support mounting CIDs, URLs  (very easy to add other types also) this PR for now  will just support these two and will add this to more executors if the way this is implemented gets approved

example commands

Mount CID
```
bacalhau docker run -i ipfs://Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z ubuntu ls /inputs/
```
Mount URL

```
bacalhau docker run -i https://gateway.ipfs.io/ipfs/Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z ubuntu ls /inputs/
```
..others will be added later