### PR TITLE
Avoid concurrent map write in the simulator

### DIFF
--- a/pkg/simulator/wallets_model.go
+++ b/pkg/simulator/wallets_model.go
@@ -18,6 +18,7 @@ import (
 // stake
 
 const MinWallet = 100 //nolint:gomnd
+const initialBalance = int64(1000)
 
 type walletsModel struct {
 	// keep track of which wallet address "owns" which job
@@ -26,7 +27,7 @@ type walletsModel struct {
 	jobOwners generic.SyncMap[string, string]
 
 	// keep track of wallet balances - STUB (for Luke to fill in)
-	balances map[string]int64
+	balances generic.SyncMap[string, int64]
 
 	// keep track of a payment channel balance PER JOB, a.k.a per-job escrow
 	// NB: in the real implementation, this would be indexed on (client, server,
@@ -46,7 +47,7 @@ type walletsModel struct {
 func newWalletsModel() *walletsModel {
 	w := &walletsModel{
 		jobOwners: generic.SyncMap[string, string]{},
-		balances:  map[string]int64{},
+		balances:  generic.SyncMap[string, int64]{},
 		escrow:    map[string]int64{},
 		accepted:  generic.SyncMap[string, bool]{},
 	}
@@ -56,8 +57,7 @@ func newWalletsModel() *walletsModel {
 
 func (wallets *walletsModel) logWallets() {
 	for {
-		log.Info().Msg("======== WALLET BALANCES =========")
-		spew.Dump(wallets.balances)
+		log.Info().Str("balances", wallets.balances.String()).Msg("======== WALLET BALANCES =========")
 		log.Info().Msg("======== ESCROW BALANCES =========")
 		spew.Dump(wallets.escrow)
 		time.Sleep(10 * time.Second) //nolint:gomnd
@@ -173,16 +173,14 @@ func (wallets *walletsModel) checkWallet(event model.JobEvent) error {
 	log.Info().Msgf("--> SIM(%s): ClientID: %s, SourceNodeID: %s", event.EventName.String(), event.ClientID, event.SourceNodeID)
 	walletID := event.SourceNodeID
 	wallets.ensureWallet(walletID)
-	if wallets.balances[walletID] < MinWallet {
+	if v, _ := wallets.balances.Get(walletID); v < MinWallet {
 		return fmt.Errorf("wallet %s fell below min balance, sorry", walletID)
 	}
 	return nil
 }
 
 func (wallets *walletsModel) ensureWallet(wallet string) {
-	if _, ok := wallets.balances[wallet]; !ok {
-		wallets.balances[wallet] = 1000
-	}
+	wallets.balances.LoadOrStore(wallet, initialBalance)
 }
 
 func escrowID(client, server, jobID string) string {
@@ -197,7 +195,8 @@ func (wallets *walletsModel) escrowFunds(client, server, jobID string, amount in
 		return fmt.Errorf("job %s not found", jobID)
 	}
 	wallets.ensureWallet(wallet)
-	if wallets.balances[wallet]-MinWallet < amount {
+	v, _ := wallets.balances.Get(wallet)
+	if v-MinWallet < amount {
 		return fmt.Errorf(
 			"wallet %s has insufficient funds to escrow %d, "+
 				"taking into account minimum wallet balance of %d",
@@ -206,7 +205,7 @@ func (wallets *walletsModel) escrowFunds(client, server, jobID string, amount in
 			MinWallet,
 		)
 	}
-	wallets.balances[wallet] -= amount
+	wallets.balances.Swap(wallet, v-amount)
 	wallets.escrow[escrowID(client, server, jobID)] += amount
 	return nil
 }
@@ -220,7 +219,8 @@ func (wallets *walletsModel) releaseEscrow(client, server, jobID string) error {
 		return fmt.Errorf("no escrow found for %s", escrowID)
 	}
 	wallets.ensureWallet(server)
-	wallets.balances[server] += amount
+	v, _ := wallets.balances.Get(server)
+	wallets.balances.Swap(server, v+amount)
 	delete(wallets.escrow, escrowID)
 	return nil
 }
@@ -235,7 +235,8 @@ func (wallets *walletsModel) refundAndSlash(client, server, jobID string) error 
 	}
 	wallets.ensureWallet(client)
 	wallets.ensureWallet(server)
-	wallets.balances[client] += amount
+	v, _ := wallets.balances.Get(client)
+	wallets.balances.Swap(client, v+amount)
 	delete(wallets.escrow, escrowID)
 
 	// and slash!
@@ -250,7 +251,8 @@ func (wallets *walletsModel) refundAndSlash(client, server, jobID string) error 
                 ||     ||
 	`, server)
 	// NB: the following is slash and burn
-	wallets.balances[server] -= MinWallet
+	v, _ = wallets.balances.Get(server)
+	wallets.balances.Swap(server, v-MinWallet)
 	return nil
 }
 

--- a/pkg/util/generic/syncmap.go
+++ b/pkg/util/generic/syncmap.go
@@ -1,6 +1,10 @@
 package generic
 
-import "sync"
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
 
 // A SyncMap is a concurrency-safe sync.Map that uses strongly-typed
 // method signatures to ensure the types of its stored data are known.
@@ -36,4 +40,15 @@ func (m *SyncMap[K, V]) Iter(ranger func(key K, value V) bool) {
 		v := value.(V)
 		return ranger(k, v)
 	})
+}
+
+func (m *SyncMap[K, V]) String() string {
+	var sb strings.Builder
+	sb.Write([]byte(`{`))
+	m.Range(func(key, value any) bool {
+		sb.Write([]byte(fmt.Sprintf(`%s=%s`, key, value)))
+		return true
+	})
+	sb.Write([]byte(`}`))
+	return sb.String()
 }


### PR DESCRIPTION
Replace standard map with a sync.Map to avoid a concurrent map write in a test.

Fixes #2125