### PR TITLE
Don't fetch GOPATH from env. var.

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go/build"
 	"io"
 	"math"
 	"os"
@@ -265,13 +266,13 @@ func findRepositoryRoot() string {
 }
 
 func marshalCaller(prefix string) func(uintptr, string, int) string {
-	goPath, goPathPresent := os.LookupEnv("GOPATH")
+	goPath := build.Default.GOPATH
 	// `file` will always use '/', even on Windows
 	goPath = fmt.Sprintf("%s/%s/%s/", filepath.ToSlash(goPath), "pkg", "mod")
 	return func(_ uintptr, file string, line int) string {
 		if strings.HasPrefix(file, prefix) {
 			file = strings.TrimPrefix(file, prefix+"/")
-		} else if goPathPresent {
+		} else {
 			file = strings.TrimPrefix(file, goPath)
 		}
 		return file + ":" + strconv.Itoa(line)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -122,9 +122,9 @@ func triggerIPFSLogging(t *testing.T) {
 	cfg.Swarm.RelayService.Enabled = config.False
 	cfg.Swarm.Transports.Network.Relay = config.False
 	cfg.Discovery.MDNS.Enabled = false
-	cfg.Addresses.Gateway = []string{"/ip4/0.0.0.0/tcp/0"}
-	cfg.Addresses.API = []string{"/ip4/0.0.0.0/tcp/0"}
-	cfg.Addresses.Swarm = []string{"/ip4/0.0.0.0/tcp/0"}
+	cfg.Addresses.Gateway = []string{"/ip4/127.0.0.1/tcp/0"}
+	cfg.Addresses.API = []string{"/ip4/127.0.0.1/tcp/0"}
+	cfg.Addresses.Swarm = []string{"/ip4/127.0.0.1/tcp/0"}
 	cfg.Peering = config.Peering{
 		Peers: nil,
 	}


### PR DESCRIPTION
Use the built-in functionality to fetch the `GOPATH` rather than relying on fetching from an environment variable, as this doesn't support the default value.