### PR TITLE
Implement a way to get output from a running job

### DIFF
--- a/pkg/executor/language/executor.go
+++ b/pkg/executor/language/executor.go
@@ -8,6 +8,7 @@ docker executor, depending on whether determinism is required.
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/rs/zerolog/log"
 
@@ -69,6 +70,14 @@ func (e *Executor) Run(
 		return nil, err
 	}
 	return executor.Run(ctx, job, jobResultsDir)
+}
+
+func (e *Executor) GetOutputStream(ctx context.Context, job model.Job) (io.ReadCloser, error) {
+	executor, err := e.getDelegateExecutor(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+	return executor.GetOutputStream(ctx, job)
 }
 
 func (e *Executor) getDelegateExecutor(ctx context.Context, job model.Job) (executor.Executor, error) {

--- a/pkg/executor/noop/executor.go
+++ b/pkg/executor/noop/executor.go
@@ -2,6 +2,8 @@ package noop
 
 import (
 	"context"
+	"fmt"
+	"io"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
@@ -87,6 +89,10 @@ func (e *NoopExecutor) Run(
 		return handler(ctx, job, jobResultsDir)
 	}
 	return &model.RunCommandResult{}, nil
+}
+
+func (e *NoopExecutor) GetOutputStream(ctx context.Context, job model.Job) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("not implemented for NoopExecutor")
 }
 
 // Compile-time check that Executor implements the Executor interface.

--- a/pkg/executor/python_wasm/executor.go
+++ b/pkg/executor/python_wasm/executor.go
@@ -9,6 +9,7 @@ ipfs so that it can be mounted into the wasm runtime container.
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/rs/zerolog/log"
 
@@ -86,6 +87,14 @@ func (e *Executor) Run(ctx context.Context, job model.Job, resultsDir string) (
 		return nil, err
 	}
 	return dockerExecutor.Run(ctx, job, resultsDir)
+}
+
+func (e *Executor) GetOutputStream(ctx context.Context, job model.Job) (io.ReadCloser, error) {
+	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
+	if err != nil {
+		return nil, err
+	}
+	return dockerExecutor.GetOutputStream(ctx, job)
 }
 
 // Compile-time check that Executor implements the Executor interface.

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"io"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -29,6 +30,9 @@ type Executor interface {
 	//    which we then use to calculate if there is capacity
 	//    alongside cpu & memory usage
 	GetVolumeSize(context.Context, model.StorageSpec) (uint64, error)
+
+	// GetOutputStream retrieves a muxed stream from the executor
+	GetOutputStream(ctx context.Context, job model.Job) (io.ReadCloser, error)
 
 	// run the given job - it's expected that we have already prepared the job
 	// this will return a local filesystem path to the jobs results

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -268,6 +269,10 @@ func (e *Executor) Run(
 	}
 
 	return executor.WriteJobResults(jobResultsDir, stdout, stderr, exitCode, wasmErr)
+}
+
+func (e *Executor) GetOutputStream(ctx context.Context, job model.Job) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("not implemented for wasm executor")
 }
 
 // Compile-time check that Executor implements the Executor interface.

--- a/pkg/util/logstream/dataframe.go
+++ b/pkg/util/logstream/dataframe.go
@@ -1,0 +1,85 @@
+// DataFrame wraps the byte framing used by docker to multiplex output
+// from a docker container when there is no TTY in use. Although docker
+// provides some functions to work with this stream, we want to keep
+// our data in this form as long as possible, as well as making it
+// implementable by other executors.
+//
+// Docker documents this as:
+//
+//	[8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
+//
+// STREAM_TYPE can be 1 for stdout and 2 for stderr
+//
+// SIZE1, SIZE2, SIZE3, and SIZE4 are four bytes of uint32 encoded as big endian.
+// This is the size of OUTPUT.
+package logstream
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type StreamTag byte
+
+const (
+	UnknownStreamTag StreamTag = iota
+	StdoutStreamTag
+	StderrStreamTag
+)
+
+const headerLength = 8
+
+type DataFrame struct {
+	Tag  StreamTag
+	Size int
+	Data []byte
+}
+
+func NewDataFrameFromReader(reader io.Reader) (DataFrame, error) {
+	header := make([]byte, headerLength)
+
+	n, err := reader.Read(header)
+	if err != nil {
+		return DataFrame{}, err
+	}
+	if n != headerLength {
+		return DataFrame{}, fmt.Errorf("unable to read dataframe header")
+	}
+
+	df := DataFrame{}
+	df.Tag = StreamTag(binary.LittleEndian.Uint32(header))
+	df.Size = int(binary.BigEndian.Uint32(header[4:]))
+	df.Data = make([]byte, df.Size)
+
+	n, err = reader.Read(df.Data)
+	if err != nil {
+		return DataFrame{}, err
+	}
+	if n != df.Size {
+		return DataFrame{}, fmt.Errorf("unable to read dataframe data")
+	}
+
+	return df, nil
+}
+
+// NewDataFrameFromBytes will compose a new data frame
+// wrapping the provided tag and data with the necessary
+// structure.
+func NewDataFrameFromData(tag StreamTag, data []byte) DataFrame {
+	return DataFrame{
+		Tag:  tag,
+		Size: len(data),
+		Data: append([]byte(nil), data...),
+	}
+}
+
+// ToBytes converts the data frame into a format suitable for
+// transmission across a Writer.
+func (df DataFrame) ToBytes() []byte {
+	output := make([]byte, headerLength+df.Size)
+	binary.LittleEndian.PutUint32(output, uint32(df.Tag))
+	binary.BigEndian.PutUint32(output[4:], uint32(df.Size))
+	copy(output[8:], df.Data)
+	return output
+}

--- a/pkg/util/logstream/dataframe_test.go
+++ b/pkg/util/logstream/dataframe_test.go
@@ -1,0 +1,36 @@
+//go:build unit || !integration
+
+package logstream
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DataFrameTestSuite struct {
+	suite.Suite
+}
+
+func TestDataFrameTestSuite(t *testing.T) {
+	suite.Run(t, new(DataFrameTestSuite))
+}
+
+func (s *DataFrameTestSuite) TestBasic() {
+
+	data := []byte("hello")
+
+	original := NewDataFrameFromData(StdoutStreamTag, data)
+
+	buf := bytes.Buffer{}
+	buf.Write(original.ToBytes())
+
+	df, err := NewDataFrameFromReader(&buf)
+	require.NoError(s.T(), err)
+
+	require.Equal(s.T(), original.Tag, df.Tag)
+	require.Equal(s.T(), original.Size, df.Size)
+	require.Equal(s.T(), original.Data, df.Data)
+}


### PR DESCRIPTION
As we require a mechanism to capture and transport an execution's stdout and stderr, this commit introduces a new method to the compute Executor interface for executors to implement.

Initially we support only docker, with support for wasm coming at a future time.  In addition, we re-use the framing that docker uses when multiplexing stdout and stderr across a single stream, something we can re-use for wasm and transport across the network to a requester node. The format of the data frame is documented in
pkg/util/logstream/dataframe.go.