### PR TITLE
Attempt to avoid timing out when downloading

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -169,6 +169,11 @@ func (e *BaseExecutor) Publish(ctx context.Context, execution store.Execution) (
 		return
 	}
 
+	log.Ctx(ctx).Debug().
+		Str("execution", execution.ID).
+		Str("cid", publishedResult.CID).
+		Msg("Execution published")
+
 	err = e.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
 		ExecutionID:   execution.ID,
 		ExpectedState: store.ExecutionStatePublishing,

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -19,7 +19,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/util/multiaddresses"
 	"github.com/imdario/mergo"
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/phayes/freeport"
 	"github.com/rs/zerolog/log"
@@ -150,29 +149,27 @@ func NewDevStack(
 		isComputeNode := (totalNodeCount - i) <= computeNodeCount
 		log.Ctx(ctx).Debug().Msgf(`Creating Node #%d as {RequesterNode: %t, ComputeNode: %t}`, i+1, isRequesterNode, isComputeNode)
 
-		// -------------------------------------
+		//////////////////////////////////////
 		// IPFS
-		// -------------------------------------
-		var ipfsNode *ipfs.Node
-		var ipfsClient ipfs.Client
+		//////////////////////////////////////
 
-		var ipfsSwarmAddrs []string
+		var ipfsSwarmAddresses []string
 		if i > 0 {
-			ipfsSwarmAddrs, err = nodes[0].IPFSClient.SwarmAddresses(ctx)
+			addresses, err := nodes[0].IPFSClient.SwarmAddresses(ctx) //nolint:govet
 			if err != nil {
 				return nil, fmt.Errorf("failed to get ipfs swarm addresses: %w", err)
 			}
+			// Only use a single address as libp2p seems to have concurrency issues, like two nodes not able to finish
+			// connecting/joining topics, when using multiple addresses for a single host.
+			// All the IPFS nodes are running within the same process, so connecting over localhost will be fine.
+			ipfsSwarmAddresses = append(ipfsSwarmAddresses, addresses[0])
 		}
 
-		ipfsNode, err = createIPFSNode(ctx, cm, options.PublicIPFSMode, ipfsSwarmAddrs)
+		ipfsNode, err := createIPFSNode(ctx, cm, options.PublicIPFSMode, ipfsSwarmAddresses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create ipfs node: %w", err)
 		}
 
-		ipfsClient = ipfsNode.Client()
-
-		var libp2pHost host.Host
-		var libp2pPort int
 		var libp2pPeer []multiaddr.Multiaddr
 		if simulatorAddr != nil {
 			libp2pPeer = append(libp2pPeer, simulatorAddr)
@@ -208,7 +205,7 @@ func NewDevStack(
 			log.Ctx(ctx).Debug().Msgf("Connecting to first libp2p requester node: %s", libp2pPeer)
 		}
 
-		libp2pHost, err = libp2p.NewHost(libp2pPort)
+		libp2pHost, err := libp2p.NewHost(libp2pPort)
 		if err != nil {
 			return nil, err
 		}
@@ -224,11 +221,6 @@ func NewDevStack(
 		if os.Getenv("PREDICTABLE_API_PORT") != "" {
 			apiPort = 20000 + i
 		}
-
-		//////////////////////////////////////
-		// in-memory datastore
-		//////////////////////////////////////
-		datastore := inmemory.NewJobStore()
 
 		//////////////////////////////////////
 		// Create and Run Node
@@ -258,9 +250,9 @@ func NewDevStack(
 		}
 
 		nodeConfig := node.NodeConfig{
-			IPFSClient:           ipfsClient,
+			IPFSClient:           ipfsNode.Client(),
 			CleanupManager:       cm,
-			JobStore:             datastore,
+			JobStore:             inmemory.NewJobStore(),
 			Host:                 libp2pHost,
 			FilecoinUnsealedPath: options.FilecoinUnsealedPath,
 			EstuaryAPIKey:        options.EstuaryAPIKey,
@@ -336,7 +328,7 @@ func NewDevStack(
 func createIPFSNode(ctx context.Context,
 	cm *system.CleanupManager,
 	publicIPFSMode bool,
-	ipfsSwarmAddrs []string) (*ipfs.Node, error) {
+	ipfsSwarmAddresses []string) (*ipfs.Node, error) {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/devstack.createIPFSNode")
 	defer span.End()
 	//////////////////////////////////////
@@ -351,7 +343,7 @@ func createIPFSNode(ctx context.Context,
 			return nil, fmt.Errorf("failed to create ipfs node: %w", err)
 		}
 	} else {
-		ipfsNode, err = ipfs.NewLocalNode(ctx, cm, ipfsSwarmAddrs)
+		ipfsNode, err = ipfs.NewLocalNode(ctx, cm, ipfsSwarmAddresses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create ipfs node: %w", err)
 		}


### PR DESCRIPTION
Try to avoid test flakes by only connecting IPFS nodes within the devstack using `localhost`. This is because we've seen libp2p have concurrency issues when attempting to connect to a peer using multiple addresses. Also output the CID once it has been uploaded to make it easier to diagnose test flakes.