### PR TITLE
Add simple documentation for `run python`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,3 +157,8 @@ run:
   # Allow multiple parallel golangci-lint instances running.
   # If false (default) - golangci-lint acquires file lock on start.
   allow-parallel-runners: false
+
+issues:
+  exclude:
+    # Naming of `error` variables as `err` is standard practise for Go
+    - 'shadow: declaration of "err" shadows declaration at'

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -20,7 +20,9 @@ var (
 		`))
 
 	languageRunExample = templates.Examples(i18n.T(`
-		TBD`))
+		# Run a simple "Hello, World" script within the current directory
+		bacalhau run python -- hello-world.py
+		`))
 )
 
 // LanguageRunOptions declares the arguments accepted by the `'language' run` command

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -125,14 +125,14 @@ func NewDevStack(
 	}
 
 	if options.LocalNetworkLotus {
-		lotus, err = newLotusNode(ctx) //nolint:govet
+		lotus, err = newLotusNode(ctx)
 		if err != nil {
 			return nil, err
 		}
 
 		cm.RegisterCallbackWithContext(lotus.Close)
 
-		if err := lotus.start(ctx); err != nil { //nolint:govet
+		if err := lotus.start(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -155,7 +155,7 @@ func NewDevStack(
 
 		var ipfsSwarmAddresses []string
 		if i > 0 {
-			addresses, err := nodes[0].IPFSClient.SwarmAddresses(ctx) //nolint:govet
+			addresses, err := nodes[0].IPFSClient.SwarmAddresses(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get ipfs swarm addresses: %w", err)
 			}
@@ -194,7 +194,7 @@ func NewDevStack(
 				libp2pPeer = append(libp2pPeer, peerAddr)
 			}
 		} else {
-			p2pAddr, err := multiaddr.NewMultiaddr("/p2p/" + nodes[0].Host.ID().String()) //nolint:govet
+			p2pAddr, err := multiaddr.NewMultiaddr("/p2p/" + nodes[0].Host.ID().String())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/devstack/lotus.go
+++ b/pkg/devstack/lotus.go
@@ -65,7 +65,7 @@ func (l *LotusNode) start(ctx context.Context) error {
 	}
 
 	// Container may be running as a different user, so need to be sure that they can read the contents
-	if err := os.Chmod(uploadDir, util.OS_ALL_RWX); err != nil { //nolint:govet
+	if err := os.Chmod(uploadDir, util.OS_ALL_RWX); err != nil {
 		return err
 	}
 	l.UploadDir = uploadDir
@@ -111,7 +111,7 @@ func (l *LotusNode) start(ctx context.Context) error {
 	}
 
 	if err := l.waitForLotusToBeHealthy(ctx); err != nil {
-		if err := l.Close(ctx); err != nil { //nolint:govet
+		if err := l.Close(ctx); err != nil {
 			log.Ctx(ctx).Err(err).Msgf(`Problem occurred when giving up waiting for Lotus to become healthy`)
 		}
 		return err
@@ -165,7 +165,7 @@ func (l *LotusNode) copyOutTokenFile(ctx context.Context) error {
 	defer closer.CloseWithLogOnError("content", content)
 
 	tarContent := tar.NewReader(content)
-	if _, err := tarContent.Next(); err != nil { //nolint:govet
+	if _, err := tarContent.Next(); err != nil {
 		return err
 	}
 

--- a/pkg/executor/wasm/validator.go
+++ b/pkg/executor/wasm/validator.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"golang.org/x/exp/maps"
 )
 
 // ValidateModuleAgainstJob will return an error if the passed job does not
@@ -32,11 +31,6 @@ func ValidateModuleImports(
 	module wazero.CompiledModule,
 	importModules ...wazero.CompiledModule,
 ) error {
-	availableImports := make(map[string]api.FunctionDefinition)
-	for _, importModule := range importModules {
-		maps.Copy(importModule.ExportedFunctions(), availableImports)
-	}
-
 	for _, requiredImport := range module.ImportedFunctions() {
 		importNamespace, funcName, _ := requiredImport.Import()
 		exists := false

--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -233,14 +233,14 @@ func (n *Node) Close(ctx context.Context) error {
 		// as the message can be written just after the test has finished but before the repo has been told by node
 		// that it's supposed to shut down.
 		if n.ipfsNode.Repo != nil {
-			if err := n.ipfsNode.Repo.Close(); err != nil { //nolint:govet
+			if err := n.ipfsNode.Repo.Close(); err != nil {
 				errs = multierror.Append(errs, fmt.Errorf("failed to close repo: %w", err))
 			}
 		}
 	}
 
 	if n.RepoPath != "" {
-		if err := os.RemoveAll(n.RepoPath); err != nil { //nolint:govet
+		if err := os.RemoveAll(n.RepoPath); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("failed to clean up repo directory: %w", err))
 		}
 	}

--- a/pkg/libp2p/utils.go
+++ b/pkg/libp2p/utils.go
@@ -34,7 +34,7 @@ func NewHostForTest(ctx context.Context, peers ...host.Host) (host.Host, error) 
 	}
 
 	for _, peerHost := range peers {
-		if err := connectToPeer(ctx, h, peerHost); err != nil { //nolint:govet
+		if err := connectToPeer(ctx, h, peerHost); err != nil {
 			return nil, err
 		}
 	}
@@ -52,7 +52,7 @@ func connectToPeer(ctx context.Context, h host.Host, peer host.Host) error {
 		Stringer("peer", peer.ID()).
 		Int("addresses", len(peerAddresses)).
 		Msg("Connecting to peer")
-	if err := connectToPeers(ctx, h, peerAddresses); err != nil { //nolint:govet
+	if err := connectToPeers(ctx, h, peerAddresses); err != nil {
 		return err
 	}
 

--- a/pkg/localdb/postgres/postgres.go
+++ b/pkg/localdb/postgres/postgres.go
@@ -29,7 +29,7 @@ func NewPostgresDatastore(
 		return nil, err
 	}
 
-	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemPostgreSQL)); err != nil { //nolint:govet
+	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemPostgreSQL)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/localdb/sqlite/sqlite.go
+++ b/pkg/localdb/sqlite/sqlite.go
@@ -20,7 +20,7 @@ func NewSQLiteDatastore(filename string) (*shared.GenericSQLDatastore, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemSqlite)); err != nil { //nolint:govet
+	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemSqlite)); err != nil {
 		return nil, err
 	}
 	datastore, err := shared.NewGenericSQLDatastore(

--- a/pkg/publisher/filecoin_lotus/api/api.go
+++ b/pkg/publisher/filecoin_lotus/api/api.go
@@ -82,7 +82,7 @@ func fetchHostnameFromConfig(file string) (string, error) {
 			ListenAddress string
 		}
 	}
-	if err := toml.Unmarshal(unparsedConfig, &config); err != nil { //nolint:govet
+	if err := toml.Unmarshal(unparsedConfig, &config); err != nil {
 		return "", fmt.Errorf("unable to parse config file %s: %w", file, err)
 	}
 

--- a/pkg/publisher/filecoin_lotus/publisher.go
+++ b/pkg/publisher/filecoin_lotus/publisher.go
@@ -120,7 +120,7 @@ func (l *Publisher) carResultsDir(ctx context.Context, resultsDir string) (strin
 
 	// Temporary files will have 0600 as their permissions, which could cause issues when sharing with a Lotus node
 	// running inside a container.
-	if err := tempFile.Chmod(util.OS_ALL_RW); err != nil { //nolint:govet
+	if err := tempFile.Chmod(util.OS_ALL_RW); err != nil {
 		return "", err
 	}
 

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -67,7 +67,7 @@ func newStorage(dir string) *StorageProvider {
 	client.RetryWaitMax = time.Second * 1
 	client.Logger = retryLogger{}
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		if err := ctx.Err(); err != nil { //nolint:govet
+		if err := ctx.Err(); err != nil {
 			return false, err
 		}
 		if err == nil {


### PR DESCRIPTION
Also:
* Fix error when adding current context to job caused by attempting to avoid shadowing `err`
* Allow `err` to be shadowed as calling `error` variables `err` is standard practise in Go
* Connect the context up to wazero when validating so that it can be correctly cancelled

Fixes #2164