### PR TITLE
Add job count to persistent local store

### DIFF
--- a/pkg/compute/sensors/completed_jobs.go
+++ b/pkg/compute/sensors/completed_jobs.go
@@ -17,11 +17,11 @@ func NewCompletedJobs(e store.ExecutionStore) *CompletedJobProvider {
 
 // GetDebugInfo implements model.DebugInfoProvider
 func (c *CompletedJobProvider) GetDebugInfo(ctx context.Context) (model.DebugInfo, error) {
-	jobcounts := c.ExecutionStore.GetExecutionCount(ctx)
+	jobcounts, err := c.ExecutionStore.GetExecutionCount(ctx)
 	return model.DebugInfo{
 		Component: "jobsCompleted",
 		Info:      jobcounts,
-	}, nil
+	}, err
 }
 
 var _ model.DebugInfoProvider = (*CompletedJobProvider)(nil)

--- a/pkg/compute/store/inlocalstore/store.go
+++ b/pkg/compute/store/inlocalstore/store.go
@@ -1,0 +1,133 @@
+package inlocalstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/rs/zerolog/log"
+)
+
+type PersistentJobStore struct {
+	store store.ExecutionStore
+}
+
+type JobStats struct {
+	JobsCompleted uint
+}
+
+// Check if the json file exists, and create it if it doesn't.
+func EnsureJobStatsJSONExists() (string, error) {
+	configDir, err := system.EnsureConfigDir()
+	if err != nil {
+		return "", err
+	}
+	jsonFilepath := filepath.Join(configDir, "jobStats.json")
+	if _, err := os.Stat(jsonFilepath); errors.Is(err, os.ErrNotExist) {
+		log.Debug().Err(err).Msg("Creating jobStats.json")
+		//Initialise JSON with counter of 0
+		err = writeCounter(jsonFilepath, 0)
+		if err != nil {
+			return "", err
+		}
+	}
+	return jsonFilepath, nil
+}
+
+func NewPersistentJobStore(store store.ExecutionStore) *PersistentJobStore {
+	return &PersistentJobStore{
+		store: store,
+	}
+}
+
+// CreateExecution implements store.ExecutionStore
+func (proxy *PersistentJobStore) CreateExecution(ctx context.Context, execution store.Execution) error {
+	return proxy.store.CreateExecution(ctx, execution)
+}
+
+// DeleteExecution implements store.ExecutionStore
+func (proxy *PersistentJobStore) DeleteExecution(ctx context.Context, id string) error {
+	return proxy.store.DeleteExecution(ctx, id)
+}
+
+// GetExecution implements store.ExecutionStore
+func (proxy *PersistentJobStore) GetExecution(ctx context.Context, id string) (store.Execution, error) {
+	return proxy.store.GetExecution(ctx, id)
+}
+
+// GetExecutionCount implements store.ExecutionStore
+func (proxy *PersistentJobStore) GetExecutionCount(ctx context.Context) (uint, error) {
+	jsonFilepath, err := EnsureJobStatsJSONExists()
+	if err != nil {
+		return 0, err
+	}
+	return readCounter(jsonFilepath)
+}
+
+// GetExecutionHistory implements store.ExecutionStore
+func (proxy *PersistentJobStore) GetExecutionHistory(ctx context.Context, id string) ([]store.ExecutionHistory, error) {
+	return proxy.store.GetExecutionHistory(ctx, id)
+}
+
+// GetExecutions implements store.ExecutionStore
+func (proxy *PersistentJobStore) GetExecutions(ctx context.Context, sharedID string) ([]store.Execution, error) {
+	return proxy.store.GetExecutions(ctx, sharedID)
+}
+
+// UpdateExecutionState implements store.ExecutionStore
+func (proxy *PersistentJobStore) UpdateExecutionState(ctx context.Context, request store.UpdateExecutionStateRequest) error {
+	err := proxy.store.UpdateExecutionState(ctx, request)
+	if err != nil {
+		return err
+	}
+	//check json file exists in .bacalhau config dir
+	jsonFilepath, err := EnsureJobStatsJSONExists()
+	if err != nil {
+		return err
+	}
+	if request.NewState == store.ExecutionStateCompleted {
+		count, err := readCounter(jsonFilepath)
+		if err != nil {
+			return err
+		}
+		err = writeCounter(jsonFilepath, count+1)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func writeCounter(filepath string, count uint) error {
+	var jobStore JobStats
+	jobStore.JobsCompleted += count
+	bs, err := json.Marshal(jobStore)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filepath, bs, util.OS_USER_RW|util.OS_ALL_R)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func readCounter(filepath string) (uint, error) {
+	jsonbs, err := os.ReadFile(filepath)
+	var jobStore JobStats
+	if err != nil {
+		return 0, err
+	}
+	err = json.Unmarshal(jsonbs, &jobStore)
+	if err != nil {
+		return 0, err
+	}
+	return jobStore.JobsCompleted, nil
+}
+
+var _ store.ExecutionStore = (*PersistentJobStore)(nil)

--- a/pkg/compute/store/inlocalstore/store_test.go
+++ b/pkg/compute/store/inlocalstore/store_test.go
@@ -1,0 +1,142 @@
+//go:build unit || !integration
+
+package inlocalstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store/inmemory"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroExecutionsReturnsZeroCount(t *testing.T) {
+	ctx := context.Background()
+	system.InitConfigForTesting(t)
+	//use inmemorystore
+	proxy := NewPersistentJobStore(inmemory.NewStore())
+	count, err := proxy.GetExecutionCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint(0), count)
+
+}
+
+func TestOneExecutionReturnsOneCount(t *testing.T) {
+	ctx := context.Background()
+	id := "fakeid1234"
+	system.InitConfigForTesting(t)
+	proxy := NewPersistentJobStore(inmemory.NewStore())
+	//check jobStore is initialised to zero
+	count, err := proxy.GetExecutionCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint(0), count)
+	//create execution
+	defaultJob, err := model.NewJobWithSaneProductionDefaults()
+	require.NoError(t, err)
+	execution := store.NewExecution(
+		id,
+		*defaultJob,
+		"defaultRequestorNodeID",
+		model.ResourceUsageData{},
+	)
+	err = proxy.CreateExecution(ctx, *execution)
+	require.NoError(t, err)
+	err = proxy.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
+		ExecutionID: execution.ID,
+		NewState:    store.ExecutionStateCompleted})
+	require.NoError(t, err)
+	count, err = proxy.GetExecutionCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint(1), count)
+}
+
+func TestConsecutiveExecutionsReturnCorrectJobCount(t *testing.T) {
+	ctx := context.Background()
+	idList := []string{"id1", "id2", "id3"}
+	system.InitConfigForTesting(t)
+	proxy := NewPersistentJobStore(inmemory.NewStore())
+	defaultJob, err := model.NewJobWithSaneProductionDefaults()
+	require.NoError(t, err)
+	// 3 executions
+	for index, id := range idList {
+		count, err := proxy.GetExecutionCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint(index), count)
+
+		execution := store.NewExecution(
+			id,
+			*defaultJob,
+			"defaultRequestorNodeID",
+			model.ResourceUsageData{},
+		)
+		err = proxy.CreateExecution(ctx, *execution)
+		require.NoError(t, err)
+		err = proxy.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
+			ExecutionID: execution.ID,
+			NewState:    store.ExecutionStateCompleted})
+		require.NoError(t, err)
+	}
+
+}
+
+func TestOnlyCompletedJobsIncreaseCounter(t *testing.T) {
+	ctx := context.Background()
+	system.InitConfigForTesting(t)
+	proxy := NewPersistentJobStore(inmemory.NewStore())
+	defaultJob, err := model.NewJobWithSaneProductionDefaults()
+	require.NoError(t, err)
+	execution := store.NewExecution(
+		"defaultID",
+		*defaultJob,
+		"defaultRequestorNodeID",
+		model.ResourceUsageData{},
+	)
+	err = proxy.CreateExecution(ctx, *execution)
+	require.NoError(t, err)
+	for executionState := 0; executionState < 7; executionState++ {
+		err = proxy.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
+			ExecutionID: execution.ID,
+			NewState:    store.ExecutionState(executionState)})
+		require.NoError(t, err)
+		count, err := proxy.GetExecutionCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint(0), count)
+	}
+}
+
+func TestSecondProxy(t *testing.T) {
+	ctx := context.Background()
+	idList := []string{"id1", "id2", "id3"}
+	system.InitConfigForTesting(t)
+	proxy := NewPersistentJobStore(inmemory.NewStore())
+	defaultJob, err := model.NewJobWithSaneProductionDefaults()
+	require.NoError(t, err)
+	// 3 executions
+	for index, id := range idList {
+		count, err := proxy.GetExecutionCount(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint(index), count)
+
+		execution := store.NewExecution(
+			id,
+			*defaultJob,
+			"defaultRequestorNodeID",
+			model.ResourceUsageData{},
+		)
+		err = proxy.CreateExecution(ctx, *execution)
+		require.NoError(t, err)
+		err = proxy.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
+			ExecutionID: execution.ID,
+			NewState:    store.ExecutionStateCompleted})
+		require.NoError(t, err)
+	}
+	count, err := proxy.GetExecutionCount(ctx)
+	require.NoError(t, err)
+	secondProxy := NewPersistentJobStore(inmemory.NewStore())
+	secondCount, err := secondProxy.GetExecutionCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, count, secondCount)
+}

--- a/pkg/compute/store/inmemory/store.go
+++ b/pkg/compute/store/inmemory/store.go
@@ -141,14 +141,14 @@ func (s *Store) DeleteExecution(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Store) GetExecutionCount(ctx context.Context) uint {
+func (s *Store) GetExecutionCount(ctx context.Context) (uint, error) {
 	var counter uint
 	for _, execution := range s.executionMap {
 		if execution.State == store.ExecutionStateCompleted {
 			counter++
 		}
 	}
-	return counter
+	return counter, nil
 }
 
 // compile-time check that we implement the interface ExecutionStore

--- a/pkg/compute/store/types.go
+++ b/pkg/compute/store/types.go
@@ -93,5 +93,5 @@ type ExecutionStore interface {
 	DeleteExecution(ctx context.Context, id string) error
 	// GetExecutionCount returns a count of all executions that completed
 	// successfully on this compute node
-	GetExecutionCount(ctx context.Context) uint
+	GetExecutionCount(ctx context.Context) (uint, error)
 }

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -11,6 +11,7 @@ import (
 	compute_publicapi "github.com/bacalhau-project/bacalhau/pkg/compute/publicapi"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/sensors"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store/inlocalstore"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store/inmemory"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	executor_util "github.com/bacalhau-project/bacalhau/pkg/executor/util"
@@ -51,7 +52,7 @@ func NewComputeNode(
 	executors executor.ExecutorProvider,
 	verifiers verifier.VerifierProvider,
 	publishers publisher.PublisherProvider) (*Compute, error) {
-	executionStore := inmemory.NewStore()
+	executionStore := inlocalstore.NewPersistentJobStore(inmemory.NewStore())
 
 	// executor/backend
 	runningCapacityTracker := capacity.NewLocalTracker(capacity.LocalTrackerParams{

--- a/pkg/system/config.go
+++ b/pkg/system/config.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -35,7 +34,7 @@ var (
 // InitConfig ensures that a bacalhau config file exists and loads it.
 // NOTE: this will override the global config cache if called twice.
 func InitConfig() error {
-	configDir, err := ensureConfigDir()
+	configDir, err := EnsureConfigDir()
 	if err != nil {
 		return fmt.Errorf("failed to init config dir: %w", err)
 	}
@@ -94,7 +93,10 @@ func InitConfigForTesting(t testingT) {
 	configDir := t.TempDir()
 	t.Setenv("BACALHAU_DIR", configDir)
 	err := InitConfig()
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("Unable to set up config in dir %s", configDir)
+		t.FailNow()
+	}
 }
 
 // SignForClient signs a message with the user's private ID key.
@@ -189,7 +191,7 @@ func PublicKeyMatchesID(publicKey, clientID string) (bool, error) {
 }
 
 // ensureDefaultConfigDir ensures that a bacalhau config dir exists.
-func ensureConfigDir() (string, error) {
+func EnsureConfigDir() (string, error) {
 	configDir := os.Getenv("BACALHAU_DIR")
 	//If FIL_WALLET_ADDRESS is set, assumes that ROOT_DIR is the config dir for Station
 	//and not a generic environment variable set by the user

--- a/pkg/system/config_test.go
+++ b/pkg/system/config_test.go
@@ -105,7 +105,7 @@ func (s *SystemConfigSuite) TestEnsureConfigDir() {
 			func() {
 				s.T().Setenv("ROOT_DIR", test.root_dir)
 				s.T().Setenv("BACALHAU_DIR", test.bacalhau_dir)
-				configDir, err := ensureConfigDir()
+				configDir, err := EnsureConfigDir()
 				s.DirExists(configDir)
 				s.Equal(configDir, test.exp)
 				s.NoError(err)


### PR DESCRIPTION
Station requires some form of persistence for the job count metric. A jobStats.JSON will be created in the default station config directory, which will store the job count.

We might want to add some form of database in the future for persisting these metrics.