### PR TITLE
Simplify client interface for setting host and port

### DIFF
--- a/cmd/bacalhau/base_test.go
+++ b/cmd/bacalhau/base_test.go
@@ -2,8 +2,6 @@ package bacalhau
 
 import (
 	"context"
-	"net"
-	"net/url"
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
@@ -11,7 +9,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/node"
 	"github.com/bacalhau-project/bacalhau/pkg/requester/publicapi"
 	testutils "github.com/bacalhau-project/bacalhau/pkg/test/utils"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,7 +17,7 @@ type BaseSuite struct {
 	node   *node.Node
 	client *publicapi.RequesterAPIClient
 	host   string
-	port   string
+	port   uint16
 }
 
 // before each test
@@ -40,12 +37,9 @@ func (s *BaseSuite) SetupTest() {
 		}),
 	)
 	s.node = stack.Nodes[0]
-	s.client = publicapi.NewRequesterAPIClient(s.node.APIServer.GetURI())
-	parsedBasedURI, err := url.Parse(s.client.BaseURI)
-	require.NoError(s.T(), err)
-	host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
-	s.host = host
-	s.port = port
+	s.host = s.node.APIServer.Address
+	s.port = s.node.APIServer.Port
+	s.client = publicapi.NewRequesterAPIClient(s.host, s.port)
 }
 
 // After each test

--- a/cmd/bacalhau/cancel_test.go
+++ b/cmd/bacalhau/cancel_test.go
@@ -35,7 +35,7 @@ func (suite *CancelSuite) TestCancelTerminalJob() {
 	ctx := context.Background()
 	_, stdout, err := ExecuteTestCobraCommand("create",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 		testFile,
 	)
 	require.NoError(suite.T(), err, "Error submitting job")
@@ -46,7 +46,7 @@ func (suite *CancelSuite) TestCancelTerminalJob() {
 	_, stdout, err = ExecuteTestCobraCommand("cancel",
 		job.Metadata.ID,
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 	)
 	require.NoError(suite.T(), err, "Error cancelling job")
 	require.Contains(suite.T(), stdout, "already in a terminal state")
@@ -60,7 +60,7 @@ func (suite *CancelSuite) TestCancelJob() {
 	_, stdout, err := ExecuteTestCobraCommand("create",
 		"--wait=false",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 		testFile,
 	)
 	require.NoError(suite.T(), err, "Error submitting job")
@@ -75,7 +75,7 @@ func (suite *CancelSuite) TestCancelJob() {
 	_, stdout, err = ExecuteTestCobraCommand("cancel",
 		jobInfo.Job.Metadata.ID,
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 	)
 	require.NoError(suite.T(), err, "Error cancelling job")
 

--- a/cmd/bacalhau/create_test.go
+++ b/cmd/bacalhau/create_test.go
@@ -55,7 +55,7 @@ func (s *CreateSuite) TestCreateGenericSubmit() {
 				ctx := context.Background()
 				_, out, err := ExecuteTestCobraCommand("create",
 					"--api-host", s.host,
-					"--api-port", s.port,
+					"--api-port", fmt.Sprint(s.port),
 					testFile,
 				)
 
@@ -74,7 +74,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 
 	_, out, err := ExecuteTestCobraCommandWithStdin(testSpec, "create",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 	)
 
 	require.NoError(s.T(), err, "Error submitting job.")
@@ -83,7 +83,7 @@ func (s *CreateSuite) TestCreateFromStdin() {
 	job := testutils.GetJobFromTestOutput(context.Background(), s.T(), s.client, out)
 	_, _, err = ExecuteTestCobraCommand("describe",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		job.Metadata.ID,
 	)
 

--- a/cmd/bacalhau/describe_test.go
+++ b/cmd/bacalhau/describe_test.go
@@ -60,14 +60,14 @@ func (s *DescribeSuite) TestDescribeJob() {
 				// No job id (should error)
 				_, _, err := ExecuteTestCobraCommand("describe",
 					"--api-host", s.host,
-					"--api-port", s.port,
+					"--api-port", fmt.Sprint(s.port),
 				)
 				require.Error(s.T(), err, "Submitting a describe request with no id should error.")
 
 				// Job Id at the end
 				_, out, err := ExecuteTestCobraCommand("describe",
 					"--api-host", s.host,
-					"--api-port", s.port,
+					"--api-port", fmt.Sprint(s.port),
 					submittedJob.Metadata.ID,
 				)
 				require.NoError(s.T(), err, "Error in describing job: %+v", err)
@@ -85,7 +85,7 @@ func (s *DescribeSuite) TestDescribeJob() {
 				_, out, err = ExecuteTestCobraCommand("describe",
 					"--api-host", s.host,
 					submittedJob.Metadata.ID,
-					"--api-port", s.port,
+					"--api-port", fmt.Sprint(s.port),
 				)
 
 				require.NoError(s.T(), err, "Error in describing job: %+v", err)
@@ -101,7 +101,7 @@ func (s *DescribeSuite) TestDescribeJob() {
 				_, out, err = ExecuteTestCobraCommand("describe",
 					"--api-host", s.host,
 					submittedJob.Metadata.ID[0:model.ShortIDLength],
-					"--api-port", s.port,
+					"--api-port", fmt.Sprint(s.port),
 				)
 
 				require.NoError(s.T(), err, "Error in describing job: %+v", err)
@@ -141,7 +141,7 @@ func (s *DescribeSuite) TestDescribeJobIncludeEvents() {
 
 			var args []string
 
-			args = append(args, "describe", "--api-host", s.host, "--api-port", s.port, submittedJob.Metadata.ID)
+			args = append(args, "describe", "--api-host", s.host, "--api-port", fmt.Sprint(s.port), submittedJob.Metadata.ID)
 			if tc.includeEvents {
 				args = append(args, "--include-events")
 			}
@@ -210,7 +210,7 @@ func (s *DescribeSuite) TestDescribeJobEdgeCases() {
 
 				_, out, err = ExecuteTestCobraCommand("describe",
 					"--api-host", s.host,
-					"--api-port", s.port,
+					"--api-port", fmt.Sprint(s.port),
 					jobID,
 				)
 				if tc.describeIDEdgecase == "" {

--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -192,7 +192,7 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOpt
 	}
 	defer os.Remove(portFileName)
 	firstNode := stack.Nodes[0]
-	_, err = f.WriteString(strconv.Itoa(firstNode.APIServer.Port))
+	_, err = f.WriteString(strconv.FormatUint(uint64(firstNode.APIServer.Port), 10))
 	if err != nil {
 		Fatal(cmd, fmt.Sprintf("Error writing out port file: %v", portFileName), 1)
 	}
@@ -209,7 +209,7 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, OS *ServeOpt
 	}
 
 	if loggingMode == logger.LogModeStation {
-		fmt.Printf("API: %s\n", firstNode.APIServer.GetURI()+"/"+publicapi.APIPrefix+publicapi.APIDebugSuffix)
+		fmt.Printf("API: %s\n", firstNode.APIServer.GetURI().JoinPath(publicapi.APIPrefix, publicapi.APIDebugSuffix))
 	}
 
 	<-ctx.Done() // block until killed

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/big"
 	"net"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -70,7 +69,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmit() {
 			randomUUID := uuid.New()
 			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 				"ubuntu",
 				"echo",
 				randomUUID.String(),
@@ -95,7 +94,7 @@ func (s *DockerRunSuite) TestRun_DryRun() {
 			entrypointCommand := fmt.Sprintf("echo %s", randomUUID.String())
 			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 				"ubuntu",
 				entrypointCommand,
 				"--dry-run",
@@ -137,7 +136,7 @@ func (s *DockerRunSuite) TestRun_GPURequests() {
 			}()
 
 			ctx := context.Background()
-			allArgs := []string{"docker", "run", "--api-host", s.host, "--api-port", s.port}
+			allArgs := []string{"docker", "run", "--api-host", s.host, "--api-port", fmt.Sprint(s.port)}
 			allArgs = append(allArgs, tc.submitArgs...)
 			_, out, submitErr := ExecuteTestCobraCommand(allArgs...)
 
@@ -177,7 +176,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 
 			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 				"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
 				"--wait",
 				"--output-dir", s.T().TempDir(),
@@ -231,7 +230,7 @@ func (s *DockerRunSuite) TestRun_SubmitInputs() {
 				ctx := context.Background()
 				flagsArray := []string{"docker", "run",
 					"--api-host", s.host,
-					"--api-port", s.port}
+					"--api-port", fmt.Sprint(s.port)}
 				for _, iv := range tcids.inputVolumes {
 					ivString := iv.cid
 					if iv.path != "" {
@@ -300,7 +299,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 				ctx := context.Background()
 				flagsArray := []string{"docker", "run",
 					"--api-host", s.host,
-					"--api-port", s.port}
+					"--api-port", fmt.Sprint(s.port)}
 
 				flagsArray = append(flagsArray, turls.inputURL.flag, turls.inputURL.url)
 				flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", turls.inputURL.pathInContainer, turls.inputURL.filename))
@@ -351,7 +350,7 @@ func (s *DockerRunSuite) TestRun_SubmitOutputs() {
 				ctx := context.Background()
 				flagsArray := []string{"docker", "run",
 					"--api-host", s.host,
-					"--api-port", s.port}
+					"--api-port", fmt.Sprint(s.port)}
 				ovString := ""
 				for _, ov := range tcids.outputVolumes {
 					if ov.name != "" {
@@ -428,7 +427,7 @@ func (s *DockerRunSuite) TestRun_CreatedAt() {
 			ctx := context.Background()
 			_, out, err := ExecuteTestCobraCommand("docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 				"ubuntu",
 				"echo", "'hello world'",
 			)
@@ -488,7 +487,7 @@ func (s *DockerRunSuite) TestRun_Annotations() {
 			for _, labelTest := range annotationsToTest {
 				var args []string
 
-				args = append(args, "docker", "run", "--api-host", s.host, "--api-port", s.port)
+				args = append(args, "docker", "run", "--api-host", s.host, "--api-port", fmt.Sprint(s.port))
 				for _, label := range labelTest.Annotations {
 					args = append(args, "-l", label)
 				}
@@ -544,7 +543,7 @@ func (s *DockerRunSuite) TestRun_EdgeCaseCLI() {
 			}()
 
 			ctx := context.Background()
-			allArgs := []string{"docker", "run", "--api-host", s.host, "--api-port", s.port}
+			allArgs := []string{"docker", "run", "--api-host", s.host, "--api-port", fmt.Sprint(s.port)}
 			allArgs = append(allArgs, tc.submitArgs...)
 			_, out, submitErr := ExecuteTestCobraCommand(allArgs...)
 
@@ -586,7 +585,7 @@ func (s *DockerRunSuite) TestRun_SubmitWorkdir() {
 			ctx := context.Background()
 			flagsArray := []string{"docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port}
+				"--api-port", fmt.Sprint(s.port)}
 			flagsArray = append(flagsArray, "-w", tc.workdir)
 			flagsArray = append(flagsArray, "ubuntu", "pwd")
 
@@ -635,7 +634,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 	allArgs := []string{
 		"docker", "run",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		"--wait",
 		"-v", fmt.Sprintf("%s:/inputs", directoryCid),
 		"ubuntu", "echo", "hello",
@@ -652,9 +651,7 @@ func (s *DockerRunSuite) TestRun_Deterministic_Verifier() {
 		apiClient *publicapi.RequesterAPIClient,
 		args devstack_tests.DeterministicVerifierTestArgs,
 	) (string, error) {
-
-		parsedBasedURI, _ := url.Parse(apiClient.BaseURI)
-		host, port, _ := net.SplitHostPort(parsedBasedURI.Host)
+		host, port, _ := net.SplitHostPort(apiClient.BaseURI.Host)
 
 		_, out, err := ExecuteTestCobraCommand(
 			"docker", "run",
@@ -776,7 +773,7 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 			_, out, err := ExecuteTestCobraCommand(
 				"docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 				"ubuntu", "--", "perl", "-e", fmt.Sprintf(`print "=" x %d`, tc.inputLength),
 			)
 			s.Require().NoError(err, "Error submitting job. Name: %s. Expected Length: %s", name, tc.expectedLength)
@@ -826,7 +823,7 @@ func (s *DockerRunSuite) TestRun_MultipleURLs() {
 
 		args = append(args, "docker", "run",
 			"--api-host", s.host,
-			"--api-port", s.port,
+			"--api-port", fmt.Sprint(s.port),
 		)
 		args = append(args, tc.inputFlags...)
 		args = append(args, "ubuntu", "--", "ls", "/input")
@@ -881,7 +878,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 
 			args = append(args, "docker", "run",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 			)
 			args = append(args, tc.imageName, "--", tc.executable)
 
@@ -904,7 +901,7 @@ func (s *DockerRunSuite) TestRun_InvalidImage() {
 
 	_, out, err := ExecuteTestCobraCommand("docker", "run",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		"@", "--",
 		"true",
 	)
@@ -926,7 +923,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefaultValue() {
 	ctx := context.Background()
 	_, out, err := ExecuteTestCobraCommand("docker", "run",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		"ubuntu",
 		"echo", "'hello world'",
 	)
@@ -943,7 +940,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 	ctx := context.Background()
 	_, out, err := ExecuteTestCobraCommand("docker", "run",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		"--timeout", fmt.Sprintf("%f", expectedTimeout),
 		"ubuntu",
 		"echo", "'hello world'",

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -99,7 +99,7 @@ func (s *GetSuite) getDockerRunArgs(extraArgs []string) []string {
 	args := []string{
 		"docker", "run",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
 		"-o", "data:/data",
 		"--wait",

--- a/cmd/bacalhau/list_test.go
+++ b/cmd/bacalhau/list_test.go
@@ -57,7 +57,7 @@ func (suite *ListSuite) TestList_NumberOfJobs() {
 			_, out, err := ExecuteTestCobraCommand("list",
 				"--hide-header",
 				"--api-host", suite.host,
-				"--api-port", suite.port,
+				"--api-port", fmt.Sprint(suite.port),
 				"--number", fmt.Sprintf("%d", tc.numberOfJobsOutput),
 				"--reverse", "false",
 			)
@@ -85,7 +85,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 	_, out, err := ExecuteTestCobraCommand("list",
 		"--hide-header",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 		"--id-filter", jobIds[0],
 	)
 	require.NoError(suite.T(), err)
@@ -108,7 +108,7 @@ func (suite *ListSuite) TestList_IdFilter() {
 	_, out, err = ExecuteTestCobraCommand("list",
 		"--hide-header",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 		"--id-filter", jobLongIds[0],
 		"--output", "json",
 	)
@@ -181,7 +181,7 @@ func (suite *ListSuite) TestList_AnnotationFilter() {
 				args := []string{"list",
 					"--hide-header",
 					"--api-host", suite.host,
-					"--api-port", suite.port,
+					"--api-port", fmt.Sprint(suite.port),
 					"--output", "json",
 				}
 				args = append(args, flags...)
@@ -288,7 +288,7 @@ func (suite *ListSuite) TestList_SortFlags() {
 					"--hide-header",
 					"--no-style",
 					"--api-host", suite.host,
-					"--api-port", suite.port,
+					"--api-port", fmt.Sprint(suite.port),
 					"--sort-by", sortFlags.sortFlag,
 					"--number", fmt.Sprintf("%d", tc.numberOfJobsOutput),
 					reverseString,

--- a/cmd/bacalhau/root.go
+++ b/cmd/bacalhau/root.go
@@ -20,14 +20,14 @@ import (
 )
 
 var apiHost string
-var apiPort int
+var apiPort uint16
 
 var loggingMode = logger.LogModeDefault
 
 var Fatal = FatalErrorHandler
 
 var defaultAPIHost string
-var defaultAPIPort int
+var defaultAPIPort uint16
 
 func init() { //nolint:gochecknoinits
 	defaultAPIHost = system.Envs[system.GetEnvironment()].APIHost
@@ -37,11 +37,8 @@ func init() { //nolint:gochecknoinits
 		defaultAPIHost = config.GetAPIHost()
 	}
 
-	if config.GetAPIPort() != "" {
-		intPort, err := strconv.Atoi(config.GetAPIPort())
-		if err == nil {
-			defaultAPIPort = intPort
-		}
+	if config.GetAPIPort() != nil {
+		defaultAPIPort = *config.GetAPIPort()
 	}
 
 	if logtype, set := os.LookupEnv("LOG_TYPE"); set {
@@ -125,7 +122,7 @@ func NewRootCmd() *cobra.Command {
 		`The host for the client and server to communicate on (via REST).
 Ignored if BACALHAU_API_HOST environment variable is set.`,
 	)
-	RootCmd.PersistentFlags().IntVar(
+	RootCmd.PersistentFlags().Uint16Var(
 		&apiPort, "api-port", defaultAPIPort,
 		`The port for the client and server to communicate on (via REST).
 Ignored if BACALHAU_API_PORT environment variable is set.`,
@@ -163,9 +160,11 @@ func Execute() {
 
 	if envAPIPort := viper.GetString("API_PORT"); envAPIPort != "" {
 		var parseErr error
-		apiPort, parseErr = strconv.Atoi(envAPIPort)
+		parsedPort, parseErr := strconv.ParseUint(envAPIPort, 10, 16)
 		if parseErr != nil {
 			log.Ctx(ctx).Fatal().Msgf("could not parse API_PORT into an int. %s", envAPIPort)
+		} else {
+			apiPort = uint16(parsedPort)
 		}
 	}
 

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -421,7 +421,7 @@ func serve(cmd *cobra.Command, OS *ServeOptions) error {
 
 	// only in station logging output
 	if loggingMode == logger.LogModeStation {
-		fmt.Printf("API: %s\n", standardNode.APIServer.GetURI()+"/"+publicapi.APIPrefix+publicapi.APIDebugSuffix)
+		fmt.Printf("API: %s\n", standardNode.APIServer.GetURI().JoinPath(publicapi.APIPrefix, publicapi.APIDebugSuffix))
 	}
 
 	if OS.PrivateInternalIPFS && OS.PeerConnect == "none" {

--- a/cmd/bacalhau/serve_test.go
+++ b/cmd/bacalhau/serve_test.go
@@ -55,9 +55,10 @@ func (s *ServeSuite) SetupTest() {
 	s.ipfsPort = node.APIPort
 }
 
-func (s *ServeSuite) serve(extraArgs ...string) int {
-	port, err := freeport.GetFreePort()
+func (s *ServeSuite) serve(extraArgs ...string) uint16 {
+	bigPort, err := freeport.GetFreePort()
 	s.Require().NoError(err)
+	port := uint16(bigPort)
 
 	cmd := NewRootCmd()
 
@@ -127,7 +128,7 @@ func (s *ServeSuite) TestHealthcheck() {
 
 func (s *ServeSuite) TestCanSubmitJob() {
 	port := s.serve("--node-type", "requester", "--node-type", "compute")
-	client := publicapi.NewRequesterAPIClient(fmt.Sprintf("http://localhost:%d", port))
+	client := publicapi.NewRequesterAPIClient("localhost", port)
 
 	job, err := model.NewJobWithSaneProductionDefaults()
 	s.Require().NoError(err)
@@ -140,7 +141,7 @@ func (s *ServeSuite) TestAppliesJobSelectionPolicy() {
 	// Networking is disabled by default so we try to submit a networked job and
 	// expect it to be rejected.
 	port := s.serve("--node-type", "requester")
-	client := publicapi.NewRequesterAPIClient(fmt.Sprintf("http://localhost:%d", port))
+	client := publicapi.NewRequesterAPIClient("localhost", port)
 
 	job, err := model.NewJobWithSaneProductionDefaults()
 	s.Require().NoError(err)

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -112,7 +112,7 @@ func shortID(outputWide bool, id string) string {
 }
 
 func GetAPIClient() *publicapi.RequesterAPIClient {
-	return publicapi.NewRequesterAPIClient(fmt.Sprintf("http://%s:%d", apiHost, apiPort))
+	return publicapi.NewRequesterAPIClient(apiHost, apiPort)
 }
 
 // ensureValidVersion checks that the server version is the same or less than the client version
@@ -262,8 +262,8 @@ func ExecuteJob(ctx context.Context,
 			return errLocalDevStack
 		}
 
-		apiURI := stack.Nodes[0].APIServer.GetURI()
-		apiClient = publicapi.NewRequesterAPIClient(apiURI)
+		apiServer := stack.Nodes[0].APIServer
+		apiClient = publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 	} else {
 		apiClient = GetAPIClient()
 	}

--- a/cmd/bacalhau/validate_test.go
+++ b/cmd/bacalhau/validate_test.go
@@ -34,7 +34,7 @@ func (s *ValidateSuite) TestValidate() {
 
 			_, out, err := ExecuteTestCobraCommand("validate",
 				"--api-host", s.host,
-				"--api-port", s.port,
+				"--api-port", fmt.Sprint(s.port),
 				test.testFile,
 			)
 

--- a/cmd/bacalhau/version_test.go
+++ b/cmd/bacalhau/version_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package bacalhau
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -36,7 +37,7 @@ type VersionSuite struct {
 func (suite *VersionSuite) Test_Version() {
 	_, out, err := ExecuteTestCobraCommand("version",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 	)
 	require.NoError(suite.T(), err)
 
@@ -47,7 +48,7 @@ func (suite *VersionSuite) Test_Version() {
 func (suite *VersionSuite) Test_VersionOutputs() {
 	_, out, err := ExecuteTestCobraCommand("version",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 		"--output", JSONFormat,
 	)
 	require.NoError(suite.T(), err, "Could not request version with json output.")
@@ -59,7 +60,7 @@ func (suite *VersionSuite) Test_VersionOutputs() {
 
 	_, out, err = ExecuteTestCobraCommand("version",
 		"--api-host", suite.host,
-		"--api-port", suite.port,
+		"--api-port", fmt.Sprint(suite.port),
 		"--output", YAMLFormat,
 	)
 	require.NoError(suite.T(), err, "Could not request version with json output.")

--- a/cmd/bacalhau/wasm_run_test.go
+++ b/cmd/bacalhau/wasm_run_test.go
@@ -4,6 +4,7 @@ package bacalhau
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	testutils "github.com/bacalhau-project/bacalhau/pkg/test/utils"
@@ -23,7 +24,7 @@ func (s *WasmRunSuite) Test_SupportsRelativeDirectory() {
 	ctx := context.Background()
 	_, out, err := ExecuteTestCobraCommand("wasm", "run",
 		"--api-host", s.host,
-		"--api-port", s.port,
+		"--api-port", fmt.Sprint(s.port),
 		"../../testdata/wasm/noop/main.wasm",
 	)
 	s.Require().NoError(err)

--- a/dashboard/api/pkg/server/client.go
+++ b/dashboard/api/pkg/server/client.go
@@ -71,8 +71,8 @@ func runGenericJob(s model.Spec) (string, error) {
 	j.Spec = s
 
 	env := system.EnvironmentProd
-	baseURI := fmt.Sprintf("http://%s:%d", system.Envs[env].APIHost, system.Envs[env].APIPort)
-	client := publicapi.NewRequesterAPIClient(baseURI)
+	host, port := system.Envs[env].APIHost, system.Envs[env].APIPort
+	client := publicapi.NewRequesterAPIClient(host, port)
 
 	submittedJob, err := client.Submit(context.Background(), j)
 	if err != nil {

--- a/ops/aws/canary/lambda/pkg/scenarios/utils.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/utils.go
@@ -135,9 +135,9 @@ func getClient() *publicapi.RequesterAPIClient {
 	if apiHost == "" {
 		apiHost = system.Envs[system.GetEnvironment()].APIHost
 	}
-	if apiPort == "" {
-		apiPort = fmt.Sprint(system.Envs[system.GetEnvironment()].APIPort)
+	if apiPort == nil {
+		defaultPort := system.Envs[system.GetEnvironment()].APIPort
+		apiPort = &defaultPort
 	}
-	client := publicapi.NewRequesterAPIClient(fmt.Sprintf("http://%s:%s", apiHost, apiPort))
-	return client
+	return publicapi.NewRequesterAPIClient(apiHost, *apiPort)
 }

--- a/pkg/compute/publicapi/client.go
+++ b/pkg/compute/publicapi/client.go
@@ -14,8 +14,8 @@ type ComputeAPIClient struct {
 }
 
 // NewComputeAPIClient returns a new client for a node's API server.
-func NewComputeAPIClient(baseURI string) *ComputeAPIClient {
-	return NewComputeAPIClientFromClient(publicapi.NewAPIClient(baseURI))
+func NewComputeAPIClient(host string, port uint16, path ...string) *ComputeAPIClient {
+	return NewComputeAPIClientFromClient(publicapi.NewAPIClient(host, port, path...))
 }
 
 // NewComputeAPIClientFromClient returns a new client for a node's API server.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,11 +8,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/rs/zerolog/log"
+)
+
+const (
+	maxUInt16 uint16 = 0xFFFF
+	minUInt16 uint16 = 0x0000
 )
 
 func DevstackShouldWriteEnvFile() bool {
@@ -47,8 +53,18 @@ func GetAPIHost() string {
 	return os.Getenv("BACALHAU_HOST")
 }
 
-func GetAPIPort() string {
-	return os.Getenv("BACALHAU_PORT")
+func GetAPIPort() *uint16 {
+	portStr, found := os.LookupEnv("BACALHAU_PORT")
+	if !found {
+		return nil
+	}
+
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		panic(fmt.Sprintf("must be uint16 (%d-%d): %s", minUInt16, maxUInt16, portStr))
+	}
+	smallPort := uint16(port)
+	return &smallPort
 }
 
 type contextKey int

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -217,9 +217,10 @@ func NewDevStack(
 		//////////////////////////////////////
 		// port for API
 		//////////////////////////////////////
-		apiPort := 0
+		apiPort := uint16(0)
 		if os.Getenv("PREDICTABLE_API_PORT") != "" {
-			apiPort = 20000 + i
+			const startPort = 20000
+			apiPort = uint16(startPort + i)
 		}
 
 		//////////////////////////////////////

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -40,7 +40,7 @@ type NodeConfig struct {
 	FilecoinUnsealedPath      string
 	EstuaryAPIKey             string
 	HostAddress               string
-	APIPort                   int
+	APIPort                   uint16
 	ComputeConfig             ComputeConfig
 	RequesterNodeConfig       RequesterConfig
 	APIServerConfig           publicapi.APIServerConfig

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -90,7 +90,7 @@ func (s *ServerSuite) TestTimeout() {
 	s.client = setupNodeForTestWithConfig(s.T(), s.cleanupManager, config)
 
 	endpoint := "/logz"
-	res, err := http.Get(s.client.BaseURI + endpoint)
+	res, err := http.Get(s.client.BaseURI.JoinPath(endpoint).String())
 	require.NoError(s.T(), err, "Could not get %s endpoint.", endpoint)
 	require.Equal(s.T(), http.StatusServiceUnavailable, res.StatusCode)
 
@@ -148,8 +148,7 @@ func (s *ServerSuite) TestMaxBodyReader() {
 }
 
 func (s *ServerSuite) testEndpoint(t *testing.T, endpoint string, contentToCheck string) []byte {
-
-	res, err := http.Get(s.client.BaseURI + endpoint)
+	res, err := http.Get(s.client.BaseURI.JoinPath(endpoint).String())
 	require.NoError(t, err, "Could not get %s endpoint.", endpoint)
 	defer res.Body.Close()
 

--- a/pkg/publicapi/util_test.go
+++ b/pkg/publicapi/util_test.go
@@ -40,7 +40,7 @@ func setupNodeForTestWithConfig(t *testing.T, cm *system.CleanupManager, serverC
 
 	require.NoError(t, apiServer.ListenAndServe(ctx, cm))
 
-	client := NewAPIClient(apiServer.GetURI())
+	client := NewAPIClient(apiServer.Address, apiServer.Port)
 	require.NoError(t, waitForHealthy(ctx, client))
 	return client
 }

--- a/pkg/requester/publicapi/client.go
+++ b/pkg/requester/publicapi/client.go
@@ -28,8 +28,8 @@ type RequesterAPIClient struct {
 }
 
 // NewRequesterAPIClient returns a new client for a node's API server.
-func NewRequesterAPIClient(baseURI string) *RequesterAPIClient {
-	return NewRequesterAPIClientFromClient(publicapi.NewAPIClient(baseURI))
+func NewRequesterAPIClient(host string, port uint16, path ...string) *RequesterAPIClient {
+	return NewRequesterAPIClientFromClient(publicapi.NewAPIClient(host, port, path...))
 }
 
 // NewRequesterAPIClientFromClient returns a new client for a node's API server.

--- a/pkg/system/constants.go
+++ b/pkg/system/constants.go
@@ -6,7 +6,7 @@ type EnvironmentData struct {
 	APIHost string
 
 	// APIPort is the port that an environment serves the public API on.
-	APIPort int
+	APIPort uint16
 
 	// Bootstrap lists the bacalhau addresses for bootstrapping new local nodes.
 	BootstrapAddresses []string

--- a/pkg/system/utils.go
+++ b/pkg/system/utils.go
@@ -2,7 +2,9 @@ package system
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -92,4 +94,12 @@ func GetShortID(ID string) string {
 		return ID
 	}
 	return ID[:model.ShortIDLength]
+}
+
+func MustParseURL(uri string) *url.URL {
+	url, err := url.Parse(uri)
+	if err != nil {
+		panic(fmt.Sprintf("url does not parse: %s", uri))
+	}
+	return url
 }

--- a/pkg/test/devstack/lotus_test.go
+++ b/pkg/test/devstack/lotus_test.go
@@ -64,8 +64,8 @@ func (s *lotusNodeSuite) TestLotusNode() {
 		Concurrency: 1,
 	}
 
-	apiUri := stack.Nodes[0].APIServer.GetURI()
-	apiClient := publicapi.NewRequesterAPIClient(apiUri)
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 	submittedJob, err := apiClient.Submit(ctx, j)
 	require.NoError(s.T(), err)
 

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -110,9 +110,8 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	log.Debug().Msgf("jobId=%s", jobID)
 	time.Sleep(time.Second * 5)
 
-	firstNode := stack.Nodes[0]
-	apiUri := firstNode.APIServer.GetURI()
-	apiClient := publicapi.NewRequesterAPIClient(apiUri)
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 	resolver := apiClient.GetJobStateResolver()
 	require.NoError(s.T(), err)
 	err = resolver.WaitUntilComplete(ctx, jobID)
@@ -128,7 +127,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 	require.NotEmpty(s.T(), executionState.PublishedResult.CID)
 
 	finalOutputPath := filepath.Join(outputDir, executionState.PublishedResult.CID)
-	err = firstNode.IPFSClient.Get(ctx, executionState.PublishedResult.CID, finalOutputPath)
+	err = stack.Nodes[0].IPFSClient.Get(ctx, executionState.PublishedResult.CID, finalOutputPath)
 	require.NoError(s.T(), err)
 
 	err = filepath.Walk(finalOutputPath,
@@ -182,8 +181,8 @@ func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
 	log.Debug().Msgf("jobId=%s", jobId)
 	time.Sleep(time.Second * 5)
 
-	apiUri := stack.Nodes[0].APIServer.GetURI()
-	apiClient := publicapi.NewRequesterAPIClient(apiUri)
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 	resolver := apiClient.GetJobStateResolver()
 	require.NoError(s.T(), err)
 	err = resolver.WaitUntilComplete(ctx, jobId)
@@ -233,8 +232,8 @@ func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
 	log.Debug().Msgf("jobId=%s", jobId)
 	time.Sleep(time.Second * 5)
 
-	apiUri := stack.Nodes[0].APIServer.GetURI()
-	apiClient := publicapi.NewRequesterAPIClient(apiUri)
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 	resolver := apiClient.GetJobStateResolver()
 	require.NoError(s.T(), err)
 	err = resolver.WaitUntilComplete(ctx, jobId)

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -48,8 +48,8 @@ func (suite *DevstackSubmitSuite) TestEmptySpec() {
 		node.NewRequesterConfigWithDefaults(),
 	)
 
-	apiUri := stack.Nodes[0].APIServer.GetURI()
-	apiClient := publicapi.NewRequesterAPIClient(apiUri)
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 
 	j := &model.Job{}
 	j.Spec.Deal = model.Deal{Concurrency: 1}

--- a/pkg/test/devstack/utils.go
+++ b/pkg/test/devstack/utils.go
@@ -111,8 +111,8 @@ func RunDeterministicVerifierTest( //nolint:funlen
 
 	// wait for other nodes to catch up
 	time.Sleep(time.Second * 1)
-	apiURI := stack.Nodes[0].APIServer.GetURI()
-	apiClient := publicapi.NewRequesterAPIClient(apiURI)
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 
 	jobID, err := submitJob(apiClient, args)
 	require.NoError(t, err)

--- a/pkg/test/requester/node_selection_test.go
+++ b/pkg/test/requester/node_selection_test.go
@@ -79,7 +79,7 @@ func (s *NodeSelectionSuite) SetupSuite() {
 	s.compute1 = stack.Nodes[1]
 	s.compute2 = stack.Nodes[2]
 	s.compute3 = stack.Nodes[3]
-	s.client = publicapi.NewRequesterAPIClient(s.requester.APIServer.GetURI())
+	s.client = publicapi.NewRequesterAPIClient(s.requester.APIServer.Address, s.requester.APIServer.Port)
 	s.stateResolver = job.NewStateResolver(
 		func(ctx context.Context, id string) (model.Job, error) {
 			return s.requester.RequesterNode.JobStore.GetJob(ctx, id)

--- a/pkg/test/requester/publicapi/util.go
+++ b/pkg/test/requester/publicapi/util.go
@@ -59,7 +59,7 @@ func setupNodeForTestWithConfig(t *testing.T, config publicapi.APIServerConfig) 
 	err = n.Start(ctx)
 	require.NoError(t, err)
 
-	client := requester_publicapi.NewRequesterAPIClient(n.APIServer.GetURI())
+	client := requester_publicapi.NewRequesterAPIClient(n.APIServer.Address, n.APIServer.Port)
 	require.NoError(t, waitForHealthy(ctx, client))
 	return n, client
 }

--- a/pkg/test/requester/publicapi/websocket_test.go
+++ b/pkg/test/requester/publicapi/websocket_test.go
@@ -51,9 +51,11 @@ func (s *WebsocketSuite) TearDownTest() {
 func (s *WebsocketSuite) TestWebsocketEverything() {
 	ctx := context.Background()
 	// string.Replace http with ws in c.BaseURI
-	url := "ws" + s.client.BaseURI[4:] + "/requester/websocket/events"
+	url := *s.client.BaseURI
+	url.Scheme = "ws"
+	wurl := url.JoinPath("requester", "websocket", "events")
 
-	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wurl.String(), nil)
 	require.NoError(s.T(), err)
 	s.T().Cleanup(func() {
 		s.NoError(conn.Close())
@@ -94,8 +96,12 @@ func (s *WebsocketSuite) TestWebsocketSingleJob() {
 	j, err := s.client.Submit(ctx, genericJob)
 	require.NoError(s.T(), err)
 
-	url := "ws" + s.client.BaseURI[4:] + fmt.Sprintf("/websocket/events?job_id=%s", j.Metadata.ID)
-	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	url := *s.client.BaseURI
+	url.Scheme = "ws"
+	wurl := url.JoinPath("websocket", "events")
+	wurl.RawQuery = fmt.Sprintf("job_id=%s", j.Metadata.ID)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wurl.String(), nil)
 	require.NoError(s.T(), err)
 
 	var event model.JobEvent

--- a/pkg/test/requester/retries_test.go
+++ b/pkg/test/requester/retries_test.go
@@ -152,7 +152,7 @@ func (s *RetriesSuite) SetupSuite() {
 	)
 
 	s.requester = stack.Nodes[0]
-	s.client = publicapi.NewRequesterAPIClient(s.requester.APIServer.GetURI())
+	s.client = publicapi.NewRequesterAPIClient(s.requester.APIServer.Address, s.requester.APIServer.Port)
 	s.stateResolver = job.NewStateResolver(
 		func(ctx context.Context, id string) (model.Job, error) {
 			return s.requester.RequesterNode.JobStore.GetJob(ctx, id)

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -142,7 +142,8 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) (resultsDir string) {
 		j.Spec.Deal.Concurrency = 1
 	}
 
-	apiClient := publicapi.NewRequesterAPIClient(stack.Nodes[0].APIServer.GetURI())
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
 	submittedJob, submitError := apiClient.Submit(s.Ctx, j)
 	if scenario.SubmitChecker == nil {
 		scenario.SubmitChecker = SubmitJobSuccess()


### PR DESCRIPTION
Previously our client(s) required specifying the base URL of the API to configure what requester/compute node the client will talk to. This was problematic for two reasons:

1. It requires specifying the protocol (as 'http') which doesn't make sense if our client calls actually use websockets or we upgrade to HTTPS in the future.
2. It requires all consumers to do a `fmt.Sprintf` as nearly always people have a host/port pair rather than a full URL.

Now the clients take hostname and port instead, so people can just supply these directly and it is up to the client what protocol it talks to the endpoint. We also use a proper uint16 to represent ports.