### PR TITLE
enable downloading raw results

### DIFF
--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -162,6 +162,8 @@ curl -sL https://get.bacalhau.org/install.sh | bash`,
 
 func NewIPFSDownloadFlags(settings *model.DownloaderSettings) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("IPFS Download flags", pflag.ContinueOnError)
+	flags.BoolVar(&settings.Raw, "raw",
+		settings.Raw, "Download raw result CIDs instead of merging multiple CIDs into a single result")
 	flags.DurationVar(&settings.Timeout, "download-timeout-secs",
 		settings.Timeout, "Timeout duration for IPFS downloads.")
 	flags.StringVar(&settings.OutputDir, "output-dir",

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -85,13 +85,17 @@ func DownloadResults( //nolint:funlen,gocyclo
 		}
 	}
 
-	for _, cidDownloadDir := range downloadedCids {
-		err = moveData(ctx, resultsOutputDir, cidDownloadDir, len(downloadedCids) > 1)
-		if err != nil {
-			return err
+	if settings.Raw {
+		return nil
+	} else {
+		for _, cidDownloadDir := range downloadedCids {
+			err = moveData(ctx, resultsOutputDir, cidDownloadDir, len(downloadedCids) > 1)
+			if err != nil {
+				return err
+			}
 		}
+		return os.RemoveAll(cidParentDir)
 	}
-	return os.RemoveAll(cidParentDir)
 }
 
 func moveData(
@@ -130,7 +134,7 @@ func moveData(
 		if d.IsDir() {
 			err = os.MkdirAll(globalTargetPath, model.DownloadFolderPerm)
 			if err != nil {
-				return nil
+				return err
 			}
 		} else {
 			// if it's not a special file then we move it into the global dir
@@ -140,7 +144,7 @@ func moveData(
 					globalTargetPath,
 				)
 				if err != nil {
-					return nil
+					return err
 				}
 			}
 
@@ -152,7 +156,7 @@ func moveData(
 					globalTargetPath,
 				)
 				if err != nil {
-					return nil
+					return err
 				}
 			}
 		}
@@ -195,8 +199,8 @@ func moveFile(sourcePath, targetPath string) error {
 		}
 		// file doesn't exist
 	} else {
-		// this means there was no error and so the file exists
-		return nil
+		return fmt.Errorf(
+			"cannot merge results as output already exists: %s. Try --raw to download raw results instead of merging them", targetPath)
 	}
 
 	return os.Rename(sourcePath, targetPath)

--- a/pkg/model/downloader.go
+++ b/pkg/model/downloader.go
@@ -17,4 +17,5 @@ type DownloaderSettings struct {
 	OutputDir      string
 	IPFSSwarmAddrs string
 	LocalIPFS      bool
+	Raw            bool
 }


### PR DESCRIPTION
introduce flag to download `--raw` results instead of merged results. After sharding was removed, we always merge and delete raw directory, which might break something if a user submits a non-deterministic job with concurrency > 1.

This PR also fixes a bug by failing in case multiple results with different CIDs share the same output file names instead of silently skipping