### PR TITLE
Add nodeid to path of the result folder

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -86,7 +86,7 @@ func (e *BaseExecutor) Run(ctx context.Context, execution store.Execution) (err 
 		return
 	}
 
-	resultFolder, err := jobVerifier.GetResultPath(ctx, execution.Job)
+	resultFolder, err := jobVerifier.GetResultPath(ctx, execution.Job, e.ID)
 	if err != nil {
 		err = fmt.Errorf("failed to get result path: %w", err)
 		return
@@ -162,7 +162,7 @@ func (e *BaseExecutor) Publish(ctx context.Context, execution store.Execution) (
 		err = fmt.Errorf("failed to get verifier %s: %w", execution.Job.Spec.Verifier, err)
 		return
 	}
-	resultFolder, err := jobVerifier.GetResultPath(ctx, execution.Job)
+	resultFolder, err := jobVerifier.GetResultPath(ctx, execution.Job, e.ID)
 	if err != nil {
 		err = fmt.Errorf("failed to get result path: %w", err)
 		return

--- a/pkg/verifier/deterministic/verifier.go
+++ b/pkg/verifier/deterministic/verifier.go
@@ -47,8 +47,9 @@ func (deterministicVerifier *DeterministicVerifier) IsInstalled(context.Context)
 func (deterministicVerifier *DeterministicVerifier) GetResultPath(
 	_ context.Context,
 	job model.Job,
+	executorID string,
 ) (string, error) {
-	return deterministicVerifier.results.EnsureResultsDir(job.ID())
+	return deterministicVerifier.results.EnsureResultsDir(job.ID(), executorID)
 }
 
 func (deterministicVerifier *DeterministicVerifier) GetProposal(

--- a/pkg/verifier/noop/verifier.go
+++ b/pkg/verifier/noop/verifier.go
@@ -69,11 +69,12 @@ func (noopVerifier *NoopVerifier) IsInstalled(ctx context.Context) (bool, error)
 func (noopVerifier *NoopVerifier) GetResultPath(
 	ctx context.Context,
 	job model.Job,
+	executorID string,
 ) (string, error) {
 	if noopVerifier.externalHooks.GetResultPath != nil {
 		return noopVerifier.externalHooks.GetResultPath(ctx, job)
 	}
-	return noopVerifier.results.EnsureResultsDir(job.ID())
+	return noopVerifier.results.EnsureResultsDir(job.ID(), executorID)
 }
 
 func (noopVerifier *NoopVerifier) GetProposal(

--- a/pkg/verifier/results/results.go
+++ b/pkg/verifier/results/results.go
@@ -23,13 +23,12 @@ func NewResults() (*Results, error) {
 	}, nil
 }
 
-func (results *Results) GetResultsDir(jobID string) string {
-	//TODO: include executionID or a nuance to avoid collisions during retries
-	return fmt.Sprintf("%s/%s", results.ResultsDir, jobID)
+func (results *Results) GetResultsDir(jobID string, executorID string) string {
+	return fmt.Sprintf("%s/%s/%s", results.ResultsDir, executorID, jobID)
 }
 
-func (results *Results) EnsureResultsDir(jobID string) (string, error) {
-	dir := results.GetResultsDir(jobID)
+func (results *Results) EnsureResultsDir(jobID string, executorID string) (string, error) {
+	dir := results.GetResultsDir(jobID, executorID)
 	err := os.MkdirAll(dir, util.OS_ALL_RWX)
 	if err != nil {
 		return "", fmt.Errorf("error creating results dir %s: %w", dir, err)

--- a/pkg/verifier/types.go
+++ b/pkg/verifier/types.go
@@ -33,6 +33,7 @@ type Verifier interface {
 	GetResultPath(
 		ctx context.Context,
 		job model.Job,
+		executorID string,
 	) (string, error)
 
 	// compute node


### PR DESCRIPTION
Currently the result folder only contains the jobid.  This PR adds the current node's ID to the path, meaning that if a single machine is running multiple nodes it is able to create multiple result folders for a given job.  This may be useful when retries are needed.