### PR TITLE
Return error message in execution failure events.

### DIFF
--- a/pkg/requester/scheduler.go
+++ b/pkg/requester/scheduler.go
@@ -490,6 +490,7 @@ func (s *BaseScheduler) handleExecutionFailure(ctx context.Context, executionID 
 			State:  model.ExecutionStateFailed,
 			Status: failure.Error(),
 		},
+		Comment: failure.Error(),
 	})
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msgf("[handleExecutionFailure] failed to update execution")


### PR DESCRIPTION
Currently when there is an execution failure, such as a missing binary in a docker image, the error is returned by the `describe` command as the execution status.  Unfortunately, the command line relies on the events to determine the current state and the status is not available, they do however contain a Comment field and the CLI was previously using it and expecting it to show an error message.

This PR sets the Comment on the event for an execution failure.