### PR TITLE
Enforce lints in CI rather than locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,21 +113,6 @@ jobs:
             go version
             which go
 
-      - run:
-          name: Install Pre-commit
-          command: |
-            make install-pre-commit
-
-      - run:
-          name: Cache Precommit
-          command: |
-            cp .pre-commit-config.yaml pre-commit-cache-key.txt
-            poetry run python --version --version >> pre-commit-cache-key.txt
-
-      - restore_cache:
-          name: Restoring pre-commit cache
-          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
-
       - restore_cache:
           name: Restoring Go cache
           key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
@@ -329,6 +314,11 @@ jobs:
       - checkout
 
       - run:
+          name: Init tools
+          command: |
+            make init
+
+      - run:
           name: Set GOVER
           command: |
             go_spec=$(grep 'go [[:digit:]].[[:digit:]]*' go.work | cut -d' ' -f2)
@@ -356,56 +346,24 @@ jobs:
             golangci-lint version
 
       - run:
-          name: Run linter
+          name: Install Pre-commit
           command: |
-            make lint
+            make install-pre-commit
 
       - run:
-          name: Run go mod tidy check diff
-          command: make modtidy check-diff
+          name: Cache Precommit
+          command: |
+            cp .pre-commit-config.yaml pre-commit-cache-key.txt
+            poetry run python --version --version >> pre-commit-cache-key.txt
 
-  # deploy:
-  #   docker:
-  #     - image: google/cloud-sdk:392.0.0
-  #   parameters:
-  #     rollout_stage:
-  #       type: string
-  #     GOOGLE_APPLICATION_CREDENTIALS_VARIABLE:
-  #       type: string
-  #   environment:
-  #     GCLOUD_VERSION: 392.0.0
-  #     TERRAFORM_VERSION: 1.2.4
-  #     GOOGLE_APPLICATION_CREDENTIALS: "/tmp/GOOGLE_APPLICATION_CREDENTIALS.json"
-  #   steps:
-  #     - checkout
-  #     - run:
-  #         name: Setup GCloud
-  #         command: |
-  #           # Create service account and get credentials here
-  #           # https://console.cloud.google.com/iam-admin/serviceaccounts?authuser=1&project=bacalhau-development
-  #           echo "$<< parameters.GOOGLE_APPLICATION_CREDENTIALS_VARIABLE >>" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
-  #           echo "Using GCloud: $GCLOUD_VERSION"
+      - restore_cache:
+          name: Restoring pre-commit cache
+          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
 
-  #     - run:
-  #         name: Authenticate to Google Cloud
-  #         command: |
-  #           gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-
-  #     - run:
-  #         name: Install terraform
-  #         command: |
-  #           echo "Insalling Terraform: $TERRAFORM_VERSION"
-  #           apt-get install -y software-properties-common
-  #           curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
-  #           apt-add-repository -y "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-  #           apt-get -y update && apt-get -y install terraform=$TERRAFORM_VERSION
-
-  #     - run:
-  #         name: Deploy cluster
-  #         command: |
-  #           cd ops/terraform && terraform init && \
-  #                               terraform workspace select << parameters.rollout_stage >> && \
-  #                               terraform apply -auto-approve --var-file=<< parameters.rollout_stage >>.tfvars
+      - run:
+          name: Run linter
+          command: |
+            make precommit
 
   performance_job:
     resource_class: bacalhau-project/self-hosted-bacalhau

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ REPO ?= $(shell echo $$(cd ../${BUILD_DIR} && git config --get remote.origin.url
 BRANCH ?= $(shell cd ../${BUILD_DIR} && git branch | grep '^*' | awk '{print $$2}')
 BUILDDATE ?= $(eval BUILDDATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))$(BUILDDATE)
 PACKAGE := $(shell echo "bacalhau_$(TAG)_${GOOS}_$(GOARCH)${GOARM}")
-PRECOMMIT_HOOKS_INSTALLED ?= $(shell grep -R "pre-commit.com" .git/hooks)
 TEST_BUILD_TAGS ?= unit,integration
 TEST_PARALLEL_PACKAGES ?= 1
 
@@ -68,39 +67,14 @@ install-pre-commit:
 # Target: precommit
 ################################################################################
 .PHONY: precommit
-precommit: buildenvcorrect
+precommit:
 	${PRECOMMIT} run --all
 	cd python && make pre-commit
 
-.PHONY: buildenvcorrect
-buildenvcorrect:
-	@echo "Checking build environment..."
-# Checking GO
-# @echo "Checking for go..."
-# @which go
-# @echo "Checking for go version..."
-# @go version
-# @echo "Checking for go env..."
-# @go env
-# @echo "Checking for go env GOOS..."
-# @go env GOOS
-# @echo "Checking for go env GOARCH..."
-# @go env GOARCH
-# @echo "Checking for go env GO111MODULE..."
-# @go env GO111MODULE
-# @echo "Checking for go env GOPATH..."
-# @go env GOPATH
-# @echo "Checking for go env GOCACHE..."
-# @go env GOCACHE
-# ===============
-# Ensure that "pre-commit.com" is in .git/hooks/pre-commit to run all pre-commit hooks
-# before each commit.
-# Error if it's empty or not found.
+PRECOMMIT_HOOKS_INSTALLED ?= $(shell grep -R "pre-commit.com" .git/hooks)
 ifeq ($(PRECOMMIT_HOOKS_INSTALLED),)
-	@echo "Pre-commit is not installed in .git/hooks/pre-commit. Please run 'make install-pre-commit' to install it."
-	@exit 1
+$(warning "Pre-commit is not installed in .git/hooks/pre-commit. Please run 'make install-pre-commit' to install it.")
 endif
-	@echo "Build environment correct."
 
 ################################################################################
 # Target: swagger-docs
@@ -178,7 +152,7 @@ release-bacalhau-airflow:
 # Target: build
 ################################################################################
 .PHONY: build
-build: buildenvcorrect build-bacalhau
+build: build-bacalhau
 
 .PHONY: build-ci
 build-ci: build-bacalhau

--- a/ops/repo_init.sh
+++ b/ops/repo_init.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-python3 -q -m pip install --upgrade pip 
+python3 -q -m pip install --upgrade pip
 pip3 install poetry
 poetry install
 poetry run pre-commit install
+
+pushd python
+poetry install

--- a/python/bacalhau_sdk/api.py
+++ b/python/bacalhau_sdk/api.py
@@ -8,12 +8,8 @@ from bacalhau_apiclient.models.list_request import ListRequest
 from bacalhau_apiclient.models.state_request import StateRequest
 from bacalhau_apiclient.models.submit_request import SubmitRequest
 from bacalhau_apiclient.rest import ApiException
-from bacalhau_sdk.config import (
-    get_client_id,
-    get_client_public_key,
-    init_config,
-    sign_for_client,
-)
+
+from bacalhau_sdk.config import get_client_id, get_client_public_key, init_config, sign_for_client
 
 conf = init_config()
 client = job_api.ApiClient(conf)

--- a/python/bacalhau_sdk/config.py
+++ b/python/bacalhau_sdk/config.py
@@ -59,12 +59,8 @@ def init_config():
 
     conf = Configuration()
     if os.getenv("BACALHAU_API_HOST") and os.getenv("BACALHAU_API_PORT"):
-        conf.host = "http://{}:{}".format(
-            os.getenv("BACALHAU_API_HOST"), os.getenv("BACALHAU_API_PORT")
-        )
-        log.debug(
-            "Using BACALHAU_API_HOST and BACALHAU_API_PORT to set host: %s", conf.host
-        )
+        conf.host = "http://{}:{}".format(os.getenv("BACALHAU_API_HOST"), os.getenv("BACALHAU_API_PORT"))
+        log.debug("Using BACALHAU_API_HOST and BACALHAU_API_PORT to set host: %s", conf.host)
 
     # Remove trailing slash from host
     if conf.host[-1] == "/":


### PR DESCRIPTION
Enforcing linting locally is not having the desired effect because it only checks that the hooks are installed when running the Makefile. It is clear that many contributors are not even running make! Plus, the git hooks fail in odd ways when run locally.

So instead we now don't require hooks to be install (but recommend them still) and ensure that they all pass in CI.