### PR TITLE
Allow fetching of events/history 'since' a specific time

### DIFF
--- a/cmd/bacalhau/describe.go
+++ b/cmd/bacalhau/describe.go
@@ -114,7 +114,7 @@ func describe(cmd *cobra.Command, cmdArgs []string, OD *DescribeOptions) error {
 	jobDesc := j
 
 	if OD.IncludeEvents {
-		jobEvents, innerErr := GetAPIClient().GetEvents(ctx, j.Job.Metadata.ID)
+		jobEvents, innerErr := GetAPIClient().GetEvents(ctx, j.Job.Metadata.ID, "")
 		if innerErr != nil {
 			Fatal(cmd, fmt.Sprintf("Failure retrieving job events '%s': %s\n", j.Job.Metadata.ID, innerErr), 1)
 		}

--- a/cmd/bacalhau/utils.go
+++ b/cmd/bacalhau/utils.go
@@ -614,7 +614,7 @@ To get more information at any time, run:
 
 	time.Sleep(1 * time.Second)
 
-	jobEvents, err := GetAPIClient().GetEvents(ctx, j.Metadata.ID)
+	jobEvents, err := GetAPIClient().GetEvents(ctx, j.Metadata.ID, "")
 	if err != nil {
 		Fatal(cmd, fmt.Sprintf("Failure retrieving job events '%s': %s\n", j.Metadata.ID, err), 1)
 	}
@@ -758,7 +758,7 @@ To get more information at any time, run:
 			signalChan <- os.Interrupt
 			break
 		} else {
-			jobEvents, err = GetAPIClient().GetEvents(ctx, j.Metadata.ID)
+			jobEvents, err = GetAPIClient().GetEvents(ctx, j.Metadata.ID, "")
 			if err != nil {
 				if _, ok := err.(*bacerrors.ContextCanceledError); ok {
 					// We're done, the user canceled the job

--- a/ops/aws/canary/lambda/pkg/scenarios/submitAndDescribe.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitAndDescribe.go
@@ -39,7 +39,7 @@ func SubmitAnDescribe(ctx context.Context) error {
 		return err
 	}
 
-	_, err = client.GetEvents(ctx, submittedJob.Metadata.ID)
+	_, err = client.GetEvents(ctx, submittedJob.Metadata.ID, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/jobstore/types.go
+++ b/pkg/jobstore/types.go
@@ -2,6 +2,7 @@ package jobstore
 
 import (
 	"context"
+	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 )
@@ -25,7 +26,7 @@ type Store interface {
 	GetJobs(ctx context.Context, query JobQuery) ([]model.Job, error)
 	GetJobState(ctx context.Context, jobID string) (model.JobState, error)
 	GetInProgressJobs(ctx context.Context) ([]model.JobWithInfo, error)
-	GetJobHistory(ctx context.Context, jobID string) ([]model.JobHistory, error)
+	GetJobHistory(ctx context.Context, jobID string, since time.Time) ([]model.JobHistory, error)
 	GetJobsCount(ctx context.Context, query JobQuery) (int, error)
 	CreateJob(ctx context.Context, j model.Job) error
 	// UpdateJobState updates the Job state

--- a/pkg/requester/publicapi/endpoints_websockets_events.go
+++ b/pkg/requester/publicapi/endpoints_websockets_events.go
@@ -3,6 +3,7 @@ package publicapi
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/gorilla/websocket"
@@ -43,7 +44,7 @@ func (s *RequesterAPIServer) websocketJobEvents(res http.ResponseWriter, req *ht
 
 	if jobID != "" {
 		// list events for job out of localDB and send them to the client
-		events, err := s.jobStore.GetJobHistory(context.Background(), jobID)
+		events, err := s.jobStore.GetJobHistory(context.Background(), jobID, time.Unix(0, 0))
 		if err != nil {
 			log.Ctx(req.Context()).Error().Msgf("error listing job events: %s\n", err.Error())
 			return


### PR DESCRIPTION
Currently in the CLI we fetch the event history of a job and filter it client-side, as well as maintaining state (what have we seen and processed). This PR adds a `since` parameter to the GetJobHistory method of the store, allowing for the filtering to be done earlier (and thus reducing the amount of records moved unncessarily). This also adds support in the ApiClient, but does not provide a mechanism for the user to specify this value in the CLI.