### PR TITLE
chore: requester node dictates ExecutionID/ComputeReference

### DIFF
--- a/pkg/compute/endpoint.go
+++ b/pkg/compute/endpoint.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/capacity"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type BaseEndpointParams struct {
@@ -104,7 +104,7 @@ func (s BaseEndpoint) prepareAskForBidResponse(
 	}
 
 	execution := *store.NewExecution(
-		"e-"+uuid.NewString(),
+		request.ExecutionID,
 		request.Job,
 		request.SourcePeerID,
 		resourceUsage,

--- a/pkg/compute/types.go
+++ b/pkg/compute/types.go
@@ -73,6 +73,8 @@ type AskForBidRequest struct {
 	RoutingMetadata
 	// Job specifies the job to be executed.
 	Job model.Job
+	// ExecutionID dictated by the requester node.
+	ExecutionID string
 }
 
 type AskForBidResponse struct {

--- a/pkg/jobstore/types.go
+++ b/pkg/jobstore/types.go
@@ -31,7 +31,7 @@ type Store interface {
 	// UpdateJobState updates the Job state
 	UpdateJobState(ctx context.Context, request UpdateJobStateRequest) error
 	// CreateExecution creates a new execution for a given job
-	CreateExecution(ctx context.Context, execution model.ExecutionState) error
+	CreateExecution(ctx context.Context, executionID string, execution model.ExecutionState) error
 	// UpdateExecution updates the Job state
 	UpdateExecution(ctx context.Context, request UpdateExecutionRequest) error
 }

--- a/pkg/model/execution_state.go
+++ b/pkg/model/execution_state.go
@@ -95,6 +95,8 @@ type ExecutionState struct {
 	NodeID string `json:"NodeId"`
 	// Compute node reference for this job execution
 	ComputeReference string `json:"ComputeReference"`
+	// Set to true iff the compute node responds to the ask for bid; does not imply the bid was accepted.
+	AcceptedAskForBid bool `json:"AcceptedAskForBid"`
 	// State is the current state of the execution
 	State ExecutionStateType `json:"State"`
 	// an arbitrary status message
@@ -128,5 +130,5 @@ func (e ExecutionState) String() string {
 // HasAcceptedAskForBid returns true if the execution has been accepted by the node
 // we rely on the value of the ExecutionID to determine if the askForBid has been accepted
 func (e ExecutionState) HasAcceptedAskForBid() bool {
-	return e.ComputeReference != ""
+	return e.AcceptedAskForBid
 }

--- a/pkg/test/compute/ask_for_bid_test.go
+++ b/pkg/test/compute/ask_for_bid_test.go
@@ -5,6 +5,8 @@ package compute
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -94,9 +96,11 @@ func (s *ComputeSuite) runAskForBidTest(testCase bidResponseTestCase) compute.As
 		job = generateJob()
 	}
 
+	executionID := "e" + uuid.NewString()
 	// issue the request
 	request := compute.AskForBidRequest{
-		Job: job,
+		Job:         job,
+		ExecutionID: executionID,
 	}
 	response, err := s.node.LocalEndpoint.AskForBid(ctx, request)
 	s.NoError(err)

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -6,6 +6,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store/resolver"
@@ -22,8 +26,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/verifier"
 	noop_verifier "github.com/bacalhau-project/bacalhau/pkg/verifier/noop"
-	"github.com/phayes/freeport"
-	"github.com/stretchr/testify/suite"
 )
 
 type ComputeSuite struct {
@@ -96,7 +98,8 @@ func TestComputeSuite(t *testing.T) {
 
 func (s *ComputeSuite) prepareAndAskForBid(ctx context.Context, job model.Job) string {
 	response, err := s.node.LocalEndpoint.AskForBid(ctx, compute.AskForBidRequest{
-		Job: job,
+		Job:         job,
+		ExecutionID: "e" + uuid.NewString(),
 	})
 	s.NoError(err)
 


### PR DESCRIPTION
- This removes the possibility of ExecutionID.ID() returning an incomplete ID as it does now. This change sets up future work of making the JobStore persistable.