### PR TITLE
Remove unused type from logs endpoint

### DIFF
--- a/pkg/requester/publicapi/endpoints_logs.go
+++ b/pkg/requester/publicapi/endpoints_logs.go
@@ -19,13 +19,6 @@ import (
 
 type logRequest = SignedRequest[model.LogsPayload] //nolint:unused // Swagger wants this
 
-type LogStreamRequest struct {
-	JobID       string
-	ExecutionID string
-	WithHistory bool
-	Follow      bool
-}
-
 type Msg struct {
 	Tag  uint8
 	Data string


### PR DESCRIPTION
Removes the unused (and duplicated) type from the logs endpoint