### PR TITLE
generic cli storage inputs

### DIFF
--- a/cmd/bacalhau/constants.go
+++ b/cmd/bacalhau/constants.go
@@ -1,0 +1,13 @@
+package bacalhau
+
+const inputUsageMsg = `Mount URIs as inputs to the job. Can be specified multiple times. Format: src=URI,dst=PATH[,opt=key=value]
+		Examples:
+		# Mount IPFS CID to /inputs directory
+		-i src=ipfs://QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72
+
+		# Mount S3 object to a specific path
+		-i src=s3://bucket/key,dst=/my/input/path
+
+		# Mount S3 object with specific endpoint and region
+		-i src=s3://bucket/key,dst=/my/input/path,opt=endpoint=http://s3.example.com,opt=region=us-east-1
+`

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -290,8 +290,8 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 		testURLs := []struct {
 			inputURL InputURL
 		}{
-			{inputURL: InputURL{url: "https://raw.githubusercontent.com/bacalhau-project/bacalhau/main/README.md", pathInContainer: "/inputs", filename: "README.md", flag: "-u"}},
-			{inputURL: InputURL{url: "https://raw.githubusercontent.com/bacalhau-project/bacalhau/main/main.go", pathInContainer: "/inputs", filename: "main.go", flag: "-u"}},
+			{inputURL: InputURL{url: "https://raw.githubusercontent.com/bacalhau-project/bacalhau/main/README.md", pathInContainer: "/inputs", filename: "README.md", flag: "-i"}},
+			{inputURL: InputURL{url: "https://raw.githubusercontent.com/bacalhau-project/bacalhau/main/main.go", pathInContainer: "/inputs", filename: "main.go", flag: "-i"}},
 		}
 
 		for _, turls := range testURLs {
@@ -636,7 +636,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		"--api-host", s.host,
 		"--api-port", fmt.Sprint(s.port),
 		"--wait",
-		"-v", fmt.Sprintf("%s:/inputs", directoryCid),
+		"-i", fmt.Sprintf("ipfs://%s,dst=/inputs", directoryCid),
 		"ubuntu", "echo", "hello",
 	}
 
@@ -657,7 +657,6 @@ func (s *DockerRunSuite) TestRun_Deterministic_Verifier() {
 			"docker", "run",
 			"--api-host", host,
 			"--api-port", port,
-			"-v", "123:/",
 			"--verifier", "deterministic",
 			"--concurrency", strconv.Itoa(args.NodeCount),
 			"--confidence", strconv.Itoa(args.Confidence),
@@ -800,19 +799,13 @@ func (s *DockerRunSuite) TestRun_MultipleURLs() {
 		},
 		{
 			1,
-			[]string{"-u", "http://127.0.0.1:/inputs/url1.txt"},
+			[]string{"-i", "http://127.0.0.1/url1,dst=/inputs/url1.txt"},
 		},
 		{
 			2,
 			[]string{
-				"-u", "http://127.0.0.1:/inputs/url1.txt",
-				"-u", "http://127.0.0.1:/inputs/url2.txt",
-			},
-		},
-		{
-			2,
-			[]string{
-				"-u", "http://127.0.0.1:/inputs/url1.txt,http://127.0.0.1:/inputs/url2.txt",
+				"-i", "http://127.0.0.1/url1.txt,dst=/inputs/url1.txt",
+				"-i", "http://127.0.0.1/url2.txt,dst=/inputs/url2.txt",
 			},
 		},
 	}

--- a/cmd/bacalhau/opts/storage.go
+++ b/cmd/bacalhau/opts/storage.go
@@ -1,0 +1,81 @@
+package opts
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/bacalhau-project/bacalhau/pkg/job"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	flag "github.com/spf13/pflag"
+)
+
+type StorageOpt struct {
+	values []model.StorageSpec
+}
+
+func (o *StorageOpt) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	var sourceURI string
+	destination := "/inputs" // default destination
+	options := make(map[string]string)
+
+	for i, field := range fields {
+		key, val, ok := strings.Cut(field, "=")
+
+		if !ok {
+			if i == 0 {
+				sourceURI = field
+				continue
+			} else {
+				return fmt.Errorf("invalid storage option: %s. Must be a key=value pair", field)
+			}
+		}
+
+		key = strings.ToLower(key)
+		switch key {
+		case "source", "src":
+			sourceURI = val
+		case "target", "dst", "destination":
+			destination = val
+		case "opt", "option":
+			k, v, _ := strings.Cut(val, "=")
+			if k != "" {
+				options[k] = v
+			}
+		default:
+			return fmt.Errorf("unpexted key %s in field %s", key, field)
+		}
+	}
+	storageSpec, err := job.ParseStorageString(sourceURI, destination, options)
+	if err != nil {
+		return err
+	}
+	o.values = append(o.values, storageSpec)
+	return nil
+}
+
+func (o *StorageOpt) Type() string {
+	return "storage"
+}
+
+func (o *StorageOpt) String() string {
+	storages := make([]string, len(o.values))
+	for _, storage := range o.values {
+		repr := fmt.Sprintf("%s %s %s", storage.StorageSource, storage.Name, storage.Path)
+		storages = append(storages, repr)
+	}
+	return strings.Join(storages, ", ")
+}
+
+func (o *StorageOpt) Values() []model.StorageSpec {
+	return o.values
+}
+
+// compile-time check to ensure type implements the flag.Value interface
+var _ flag.Value = &StorageOpt{}

--- a/cmd/bacalhau/opts/storage_test.go
+++ b/cmd/bacalhau/opts/storage_test.go
@@ -1,0 +1,100 @@
+//go:build unit || !integration
+
+package opts
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected model.StorageSpec
+		error    bool
+	}{
+		{
+			name:  "ipfs",
+			input: "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/inputs",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
+			name:  "ipfs with explicit dst path",
+			input: "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA,dst=/mount/path",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/mount/path",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
+			name:  "ipfs with explicit src and dst",
+			input: "src=ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA,dst=/mount/path",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/mount/path",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
+			name:  "s3",
+			input: "s3://myBucket/dir/file-001.txt",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+				Name:          "s3://myBucket/dir/file-001.txt",
+				Path:          "/inputs",
+				S3: &model.S3StorageSpec{
+					Bucket: "myBucket",
+					Key:    "dir/file-001.txt",
+				},
+			},
+		},
+		{
+			name:  "s3 with endpoint and region",
+			input: "s3://myBucket/dir/file-001.txt,opt=endpoint=http://localhost:9000,opt=region=us-east-1",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+				Name:          "s3://myBucket/dir/file-001.txt",
+				Path:          "/inputs",
+				S3: &model.S3StorageSpec{
+					Bucket:   "myBucket",
+					Key:      "dir/file-001.txt",
+					Endpoint: "http://localhost:9000",
+					Region:   "us-east-1",
+				},
+			},
+		},
+		{
+			name:  "empty",
+			input: "",
+			error: true,
+		},
+		{
+			name:  "invalid flags",
+			input: "x=ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA,y=/mount/path",
+			error: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			opt := StorageOpt{}
+			err := opt.Set(test.input)
+			if test.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, opt.Values()[0])
+			}
+		})
+	}
+}

--- a/cmd/bacalhau/opts/storage_test.go
+++ b/cmd/bacalhau/opts/storage_test.go
@@ -28,6 +28,16 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "ipfs with path",
+			input: "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA:/mount/path",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/mount/path",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
 			name:  "ipfs with explicit dst path",
 			input: "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA,dst=/mount/path",
 			expected: model.StorageSpec{
@@ -40,6 +50,16 @@ func TestParse(t *testing.T) {
 		{
 			name:  "ipfs with explicit src and dst",
 			input: "src=ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA,dst=/mount/path",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/mount/path",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
+			name:  "ipfs with explicit dst overrides",
+			input: "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA:/input,dst=/mount/path",
 			expected: model.StorageSpec{
 				StorageSource: model.StorageSourceIPFS,
 				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
@@ -72,6 +92,19 @@ func TestParse(t *testing.T) {
 					Key:      "dir/file-001.txt",
 					Endpoint: "http://localhost:9000",
 					Region:   "us-east-1",
+				},
+			},
+		},
+		{
+			name:  "s3 with multiple colons",
+			input: "s3://myBucket/dir:file:001.txt:/mount/path",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+				Name:          "s3://myBucket/dir:file:001.txt",
+				Path:          "/mount/path",
+				S3: &model.S3StorageSpec{
+					Bucket: "myBucket",
+					Key:    "dir:file:001.txt",
 				},
 			},
 		},

--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/cmd/bacalhau/opts"
 	"github.com/bacalhau-project/bacalhau/pkg/downloader/util"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/wasm"
 	"github.com/bacalhau-project/bacalhau/pkg/job"
@@ -41,6 +42,24 @@ var (
 
 const null rune = 0
 
+type WasmRunOptions struct {
+	Job             *model.Job
+	RunTimeSettings RunTimeSettings
+	DownloadFlags   model.DownloaderSettings
+	NodeSelector    string // Selector (label query) to filter nodes on which this job can be executed
+	Inputs          opts.StorageOpt
+}
+
+func NewRunWasmOptions() *WasmRunOptions {
+	return &WasmRunOptions{
+		Job:             defaultWasmJobSpec(),
+		RunTimeSettings: *NewRunTimeSettings(),
+		DownloadFlags:   *util.NewDownloadSettings(),
+		NodeSelector:    "",
+		Inputs:          opts.StorageOpt{},
+	}
+}
+
 func defaultWasmJobSpec() *model.Job {
 	wasmJob, _ := model.NewJobWithSaneProductionDefaults()
 	wasmJob.Spec.Engine = model.EngineWasm
@@ -74,12 +93,9 @@ func newWasmCmd() *cobra.Command {
 }
 
 func newRunWasmCmd() *cobra.Command {
-	wasmJob := defaultWasmJobSpec()
-	runtimeSettings := NewRunTimeSettings()
-	downloadSettings := util.NewDownloadSettings()
-	var nodeSelector string
+	ODR := NewRunWasmOptions()
 
-	runWasmCommand := &cobra.Command{
+	wasmRunCmd := &cobra.Command{
 		Use:     "run {cid-of-wasm | <local.wasm>} [--entry-point <string>] [wasm-args ...]",
 		Short:   "Run a WASM job on the network",
 		Long:    wasmRunLong,
@@ -87,102 +103,88 @@ func newRunWasmCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		PreRun:  applyPorcelainLogLevel,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runWasm(cmd, args, wasmJob, runtimeSettings, downloadSettings, nodeSelector)
+			return runWasm(cmd, args, ODR)
 		},
 	}
 
-	settingsFlags := NewRunTimeSettingsFlags(runtimeSettings)
-	runWasmCommand.Flags().AddFlagSet(settingsFlags)
+	wasmRunCmd.PersistentFlags().AddFlagSet(NewRunTimeSettingsFlags(&ODR.RunTimeSettings))
+	wasmRunCmd.PersistentFlags().AddFlagSet(NewIPFSDownloadFlags(&ODR.DownloadFlags))
 
-	downloadFlags := NewIPFSDownloadFlags(downloadSettings)
-	runWasmCommand.Flags().AddFlagSet(downloadFlags)
-
-	runWasmCommand.PersistentFlags().StringVarP(
-		&nodeSelector, "selector", "s", nodeSelector,
+	wasmRunCmd.PersistentFlags().StringVarP(
+		&ODR.NodeSelector, "selector", "s", ODR.NodeSelector,
 		`Selector (label query) to filter nodes on which this job can be executed, supports '=', '==', and '!='.(e.g. -s key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.`, //nolint:lll // Documentation, ok if long.
 	)
 
-	runWasmCommand.PersistentFlags().Var(
-		VerifierFlag(&wasmJob.Spec.Verifier), "verifier",
+	wasmRunCmd.PersistentFlags().Var(
+		VerifierFlag(&ODR.Job.Spec.Verifier), "verifier",
 		`What verification engine to use to run the job`,
 	)
-	runWasmCommand.PersistentFlags().Var(
-		PublisherFlag(&wasmJob.Spec.Publisher), "publisher",
+	wasmRunCmd.PersistentFlags().Var(
+		PublisherFlag(&ODR.Job.Spec.Publisher), "publisher",
 		`What publisher engine to use to publish the job results`,
 	)
-	runWasmCommand.PersistentFlags().IntVarP(
-		&wasmJob.Spec.Deal.Concurrency, "concurrency", "c", wasmJob.Spec.Deal.Concurrency,
+	wasmRunCmd.PersistentFlags().IntVarP(
+		&ODR.Job.Spec.Deal.Concurrency, "concurrency", "c", ODR.Job.Spec.Deal.Concurrency,
 		`How many nodes should run the job`,
 	)
-	runWasmCommand.PersistentFlags().IntVar(
-		&wasmJob.Spec.Deal.Confidence, "confidence", wasmJob.Spec.Deal.Confidence,
+	wasmRunCmd.PersistentFlags().IntVar(
+		&ODR.Job.Spec.Deal.Confidence, "confidence", ODR.Job.Spec.Deal.Confidence,
 		`The minimum number of nodes that must agree on a verification result`,
 	)
-	runWasmCommand.PersistentFlags().IntVar(
-		&wasmJob.Spec.Deal.MinBids, "min-bids", wasmJob.Spec.Deal.MinBids,
+	wasmRunCmd.PersistentFlags().IntVar(
+		&ODR.Job.Spec.Deal.MinBids, "min-bids", ODR.Job.Spec.Deal.MinBids,
 		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`,
 	)
-	runWasmCommand.PersistentFlags().Float64Var(
-		&wasmJob.Spec.Timeout, "timeout", wasmJob.Spec.Timeout,
+	wasmRunCmd.PersistentFlags().Float64Var(
+		&ODR.Job.Spec.Timeout, "timeout", ODR.Job.Spec.Timeout,
 		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
 	)
-	runWasmCommand.PersistentFlags().StringVar(
-		&wasmJob.Spec.Wasm.EntryPoint, "entry-point", wasmJob.Spec.Wasm.EntryPoint,
+	wasmRunCmd.PersistentFlags().StringVar(
+		&ODR.Job.Spec.Wasm.EntryPoint, "entry-point", ODR.Job.Spec.Wasm.EntryPoint,
 		`The name of the WASM function in the entry module to call. This should be a zero-parameter zero-result function that
 		will execute the job.`,
 	)
-	runWasmCommand.PersistentFlags().VarP(
-		NewURLStorageSpecArrayFlag(&wasmJob.Spec.Inputs), "input-urls", "u",
-		`URL of the input data volumes downloaded from a URL source. Mounts data at '/inputs' (e.g. '-u http://foo.com/bar.tar.gz'
-		mounts 'bar.tar.gz' at '/inputs/bar.tar.gz'). URL accept any valid URL supported by the 'wget' command,
-		and supports both HTTP and HTTPS.`,
-	)
-	runWasmCommand.PersistentFlags().VarP(
-		NewIPFSStorageSpecArrayFlag(&wasmJob.Spec.Inputs), "input-volumes", "v",
-		`CID:path of the input data volumes, if you need to set the path of the mounted data.`,
-	)
-	runWasmCommand.PersistentFlags().VarP(
-		EnvVarMapFlag(&wasmJob.Spec.Wasm.EnvironmentVariables), "env", "e",
+	wasmRunCmd.PersistentFlags().VarP(&ODR.Inputs, "input", "i", inputUsageMsg)
+	wasmRunCmd.PersistentFlags().VarP(
+		EnvVarMapFlag(&ODR.Job.Spec.Wasm.EnvironmentVariables), "env", "e",
 		`The environment variables to supply to the job (e.g. --env FOO=bar --env BAR=baz)`,
 	)
-	runWasmCommand.PersistentFlags().VarP(
-		NewURLStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-urls", "U",
+	wasmRunCmd.PersistentFlags().VarP(
+		NewURLStorageSpecArrayFlag(&ODR.Job.Spec.Wasm.ImportModules), "import-module-urls", "U",
 		`URL of the WASM modules to import from a URL source. URL accept any valid URL supported by `+
 			`the 'wget' command, and supports both HTTP and HTTPS.`,
 	)
-	runWasmCommand.PersistentFlags().VarP(
-		NewIPFSStorageSpecArrayFlag(&wasmJob.Spec.Wasm.ImportModules), "import-module-volumes", "I",
+	wasmRunCmd.PersistentFlags().VarP(
+		NewIPFSStorageSpecArrayFlag(&ODR.Job.Spec.Wasm.ImportModules), "import-module-volumes", "I",
 		`CID:path of the WASM modules to import from IPFS, if you need to set the path of the mounted data.`,
 	)
 
-	return runWasmCommand
+	return wasmRunCmd
 }
 
 func runWasm(
 	cmd *cobra.Command,
 	args []string,
-	wasmJob *model.Job,
-	runtimeSettings *RunTimeSettings,
-	downloadSettings *model.DownloaderSettings,
-	nodeSelector string,
+	ODR *WasmRunOptions,
 ) error {
 	ctx := cmd.Context()
 	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
 
 	wasmCidOrPath := args[0]
-	wasmJob.Spec.Wasm.Parameters = args[1:]
+	ODR.Job.Spec.Wasm.Parameters = args[1:]
 
-	nodeSelectorRequirements, err := job.ParseNodeSelector(nodeSelector)
+	nodeSelectorRequirements, err := job.ParseNodeSelector(ODR.NodeSelector)
 	if err != nil {
 		return err
 	}
-	wasmJob.Spec.NodeSelectors = nodeSelectorRequirements
+	ODR.Job.Spec.NodeSelectors = nodeSelectorRequirements
+	ODR.Job.Spec.Inputs = ODR.Inputs.Values()
 
 	// Try interpreting this as a CID.
 	wasmCid, err := cid.Parse(wasmCidOrPath)
 	if err == nil {
 		// It is a valid CID – proceed to create IPFS context.
-		wasmJob.Spec.Wasm.EntryModule = model.StorageSpec{
+		ODR.Job.Spec.Wasm.EntryModule = model.StorageSpec{
 			StorageSource: model.StorageSourceIPFS,
 			CID:           wasmCid.String(),
 		}
@@ -214,18 +216,18 @@ func runWasm(
 		if err != nil {
 			return err
 		}
-		wasmJob.Spec.Wasm.EntryModule = inlineData
+		ODR.Job.Spec.Wasm.EntryModule = inlineData
 	}
 
 	// We can only use a Deterministic verifier if we have multiple nodes running the job
 	// If the user has selected a Deterministic verifier (or we are using it by default)
 	// then switch back to a Noop Verifier if the concurrency is too low.
-	if wasmJob.Spec.Deal.Concurrency <= 1 && wasmJob.Spec.Verifier == model.VerifierDeterministic {
-		wasmJob.Spec.Verifier = model.VerifierNoop
+	if ODR.Job.Spec.Deal.Concurrency <= 1 && ODR.Job.Spec.Verifier == model.VerifierDeterministic {
+		ODR.Job.Spec.Verifier = model.VerifierNoop
 	}
 
 	// See wazero.ModuleConfig.WithEnv
-	for key, value := range wasmJob.Spec.Wasm.EnvironmentVariables {
+	for key, value := range ODR.Job.Spec.Wasm.EnvironmentVariables {
 		for _, str := range []string{key, value} {
 			if str == "" || strings.ContainsRune(str, null) {
 				return fmt.Errorf("invalid environment variable %s=%s", key, value)
@@ -233,7 +235,7 @@ func runWasm(
 		}
 	}
 
-	return ExecuteJob(ctx, cm, cmd, wasmJob, *runtimeSettings, *downloadSettings)
+	return ExecuteJob(ctx, cm, cmd, ODR.Job, ODR.RunTimeSettings, ODR.DownloadFlags)
 }
 
 func newValidateWasmCmd() *cobra.Command {

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -113,7 +113,7 @@ func NewStandardStorageProvider(
 		model.StorageSourceURLDownload:      tracing.Wrap(urlDownloadStorage),
 		model.StorageSourceFilecoinUnsealed: tracing.Wrap(filecoinUnsealedStorage),
 		model.StorageSourceInline:           tracing.Wrap(inlineStorage),
-		model.StorageSourceRepoClone:        tracing.Wrap(repoCloneStorage),
+		model.StorageSourceRepoCloneLFS:     tracing.Wrap(repoCloneStorage),
 		model.StorageSourceS3:               tracing.Wrap(s3Storage),
 	}), nil
 }

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -21,9 +21,7 @@ func ConstructDockerJob( //nolint:funlen
 	cpu, memory, gpu string,
 	network model.Network,
 	domains []string,
-	inputUrls []string,
-	inputRepos []string,
-	inputVolumes []string,
+	inputs []model.StorageSpec,
 	outputVolumes []string,
 	env []string,
 	entrypoint []string,
@@ -42,25 +40,6 @@ func ConstructDockerJob( //nolint:funlen
 		GPU:    gpu,
 	}
 
-	// for _, url := range inputRepos {
-	// 	repoCID, _ := clone.RepoExistsOnIPFSGivenURL(url)
-	// 	// if err != nil {
-	// 	// 	fmt.Print(err)
-	// 	// }
-	// 	if repoCID != "" {
-	// 		inputRepos = clone.RemoveFromSlice(inputRepos, url)
-	// 		repoCIDPATH := repoCID + ":/inputs"
-
-	// 		SHAtoCID := []string{}
-	// 		SHAtoCID = append(SHAtoCID, repoCIDPATH)
-	// 		inputVolumes = append(inputVolumes, SHAtoCID...)
-	// 	}
-	// }
-
-	jobInputs, err := buildJobInputs(inputVolumes, inputUrls, inputRepos)
-	if err != nil {
-		return &model.Job{}, err
-	}
 	jobOutputs, err := buildJobOutputs(ctx, outputVolumes)
 	if err != nil {
 		return &model.Job{}, err
@@ -115,7 +94,7 @@ func ConstructDockerJob( //nolint:funlen
 		},
 		Timeout:       timeout,
 		Resources:     jobResources,
-		Inputs:        jobInputs,
+		Inputs:        inputs,
 		Outputs:       jobOutputs,
 		Annotations:   jobAnnotations,
 		NodeSelectors: nodeSelectorRequirements,
@@ -137,8 +116,7 @@ func ConstructDockerJob( //nolint:funlen
 
 func ConstructLanguageJob(
 	ctx context.Context,
-	inputVolumes []string,
-	inputUrls []string,
+	inputs []model.StorageSpec,
 	outputVolumes []string,
 	concurrency int,
 	confidence int,
@@ -155,10 +133,6 @@ func ConstructLanguageJob(
 ) (*model.Job, error) {
 	// TODO refactor this wrt ConstructDockerJob
 
-	jobInputs, err := buildJobInputs(inputVolumes, inputUrls, nil)
-	if err != nil {
-		return &model.Job{}, err
-	}
 	jobOutputs, err := buildJobOutputs(ctx, outputVolumes)
 	if err != nil {
 		return &model.Job{}, err
@@ -196,7 +170,7 @@ func ConstructLanguageJob(
 		RequirementsPath: requirementsPath,
 	}
 	j.Spec.Timeout = timeout
-	j.Spec.Inputs = jobInputs
+	j.Spec.Inputs = inputs
 	j.Spec.Outputs = jobOutputs
 	j.Spec.Annotations = jobAnnotations
 

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -74,14 +74,12 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 					model.EngineNoop,
 					model.VerifierNoop,
 					model.PublisherNoop,
-					"1",               // cpu
-					"1",               // memory
-					"0",               // gpu
-					model.NetworkNone, // networking
-					[]string{},        // domains
-					[]string{},        // input urls
-					[]string{},        // input repos
-					[]string{},        // input volumes
+					"1",                   // cpu
+					"1",                   // memory
+					"0",                   // gpu
+					model.NetworkNone,     // networking
+					[]string{},            // domains
+					[]model.StorageSpec{}, // inputs
 					outputVolumes,
 					[]string{}, // env
 					[]string{}, // entrypoint

--- a/pkg/job/parser.go
+++ b/pkg/job/parser.go
@@ -1,0 +1,75 @@
+package job
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bacalhau-project/bacalhau/pkg/clone"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/url/urldownload"
+)
+
+const defaultStoragePath = "/inputs"
+
+func ParseStorageString(sourceURI, destinationPath string, options map[string]string) (model.StorageSpec, error) {
+	parsedURI, err := url.Parse(sourceURI)
+	if err != nil {
+		return model.StorageSpec{}, err
+	}
+
+	var res model.StorageSpec
+	switch parsedURI.Scheme {
+	case "ipfs":
+		res = model.StorageSpec{
+			StorageSource: model.StorageSourceIPFS,
+			CID:           parsedURI.Host,
+		}
+	case "http", "https":
+		u, err := urldownload.IsURLSupported(sourceURI)
+		if err != nil {
+			return model.StorageSpec{}, err
+		}
+		res = model.StorageSpec{
+			StorageSource: model.StorageSourceURLDownload,
+			URL:           u.String(),
+		}
+	case "s3":
+		res = model.StorageSpec{
+			StorageSource: model.StorageSourceS3,
+			S3: &model.S3StorageSpec{
+				Bucket: parsedURI.Host,
+				Key:    strings.TrimLeft(parsedURI.Path, "/"),
+			},
+		}
+		for key, value := range options {
+			switch key {
+			case "endpoint":
+				res.S3.Endpoint = value
+			case "region":
+				res.S3.Region = value
+			}
+		}
+	case "git", "gitlfs":
+		u, err := clone.IsValidGitRepoURL(sourceURI)
+		if err != nil {
+			return model.StorageSpec{}, err
+		}
+		storageSource := model.StorageSourceRepoClone
+		if parsedURI.Scheme == "gitlfs" {
+			storageSource = model.StorageSourceRepoCloneLFS
+		}
+		res = model.StorageSpec{
+			StorageSource: storageSource,
+			Repo:          u.String(),
+		}
+	default:
+		return model.StorageSpec{}, fmt.Errorf("unknown storage schema: %s", parsedURI.Scheme)
+	}
+	res.Name = sourceURI
+	res.Path = destinationPath
+	if res.Path == "" {
+		res.Path = defaultStoragePath
+	}
+	return res, nil
+}

--- a/pkg/job/parser.go
+++ b/pkg/job/parser.go
@@ -13,6 +13,8 @@ import (
 const defaultStoragePath = "/inputs"
 
 func ParseStorageString(sourceURI, destinationPath string, options map[string]string) (model.StorageSpec, error) {
+	sourceURI = strings.Trim(sourceURI, " '\"")
+	destinationPath = strings.Trim(destinationPath, " '\"")
 	parsedURI, err := url.Parse(sourceURI)
 	if err != nil {
 		return model.StorageSpec{}, err

--- a/pkg/job/parser_test.go
+++ b/pkg/job/parser_test.go
@@ -1,0 +1,96 @@
+//go:build unit || !integration
+
+package job
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStorageString(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		source      string
+		destination string
+		options     map[string]string
+		expected    model.StorageSpec
+		error       bool
+	}{
+		{
+			name:   "ipfs",
+			source: "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/inputs",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
+			name:        "ipfs with explicit dst path",
+			source:      "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			destination: "/mount/path",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				Name:          "ipfs://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+				Path:          "/mount/path",
+				CID:           "QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			},
+		},
+		{
+			name:   "s3",
+			source: "s3://myBucket/dir/file-001.txt",
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+				Name:          "s3://myBucket/dir/file-001.txt",
+				Path:          "/inputs",
+				S3: &model.S3StorageSpec{
+					Bucket: "myBucket",
+					Key:    "dir/file-001.txt",
+				},
+			},
+		},
+		{
+			name:   "s3 with endpoint and region",
+			source: "s3://myBucket/dir/file-001.txt",
+			options: map[string]string{
+				"endpoint": "http://localhost:9000",
+				"region":   "us-east-1",
+			},
+			expected: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+				Name:          "s3://myBucket/dir/file-001.txt",
+				Path:          "/inputs",
+				S3: &model.S3StorageSpec{
+					Bucket:   "myBucket",
+					Key:      "dir/file-001.txt",
+					Endpoint: "http://localhost:9000",
+					Region:   "us-east-1",
+				},
+			},
+		},
+		{
+			name:   "empty",
+			source: "",
+			error:  true,
+		},
+		{
+			name:   "invalid schema",
+			source: "metalloca://QmXJ3wT1C27W8Vvc21NjLEb7VdNk9oM8zJYtDkG1yH2fnA",
+			error:  true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			spec, err := ParseStorageString(test.source, test.destination, test.options)
+			if test.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, spec)
+			}
+		})
+	}
+}

--- a/pkg/job/util_test.go
+++ b/pkg/job/util_test.go
@@ -77,16 +77,15 @@ func (s *JobUtilSuite) TestRun_URLs() {
 		for _, testURL := range testURLs {
 			func() {
 				// Test all URLs against the validator
-				spec, err := buildJobInputs(nil, []string{testURL.submittedURL}, nil)
+				spec, err := ParseStorageString(testURL.submittedURL, "/inputs", map[string]string{})
 				originalURLTrimmed := strings.Trim(testURL.submittedURL, `"' `)
 				convertedTrimmed := strings.Trim(testURL.convertedURL, `"' `)
 				if testURL.valid {
 					require.NoError(s.T(), err, fmt.Sprintf("%s: Should not have errored - %s", testURL.errorMsg, testURL.submittedURL))
-					require.Equal(s.T(), 1, len(spec), testURL.errorMsg)
 					if testURL.convertedURL != "" {
-						require.Equal(s.T(), convertedTrimmed, spec[0].URL, testURL.errorMsg)
+						require.Equal(s.T(), convertedTrimmed, spec.URL, testURL.errorMsg)
 					} else {
-						require.Equal(s.T(), originalURLTrimmed, spec[0].URL, testURL.errorMsg)
+						require.Equal(s.T(), originalURLTrimmed, spec.URL, testURL.errorMsg)
 					}
 				} else {
 					require.Error(s.T(), err, fmt.Sprintf("%s: Should have errored - %s", testURL.errorMsg, testURL.submittedURL))

--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -29,7 +29,7 @@ const (
 	//
 	// As a command, something like:
 	//
-	//  bacalhau docker run —network=http —domain=crates.io —domain=github.com -v Qmy1234myd4t4:/code rust/compile
+	//  bacalhau docker run —network=http —domain=crates.io —domain=github.com -i ipfs://Qmy1234myd4t4,dst=/code rust/compile
 	//
 	// The “risk” for the compute provider is that the job does something that
 	// violates its terms, the terms of its hosting provider or ISP, or even the

--- a/pkg/model/storage_source.go
+++ b/pkg/model/storage_source.go
@@ -16,6 +16,7 @@ const (
 	storageSourceUnknown StorageSourceType = iota // must be first
 	StorageSourceIPFS
 	StorageSourceRepoClone
+	StorageSourceRepoCloneLFS
 	StorageSourceURLDownload
 	StorageSourceFilecoinUnsealed
 	StorageSourceFilecoin

--- a/pkg/model/storagesourcetype_string.go
+++ b/pkg/model/storagesourcetype_string.go
@@ -11,19 +11,20 @@ func _() {
 	_ = x[storageSourceUnknown-0]
 	_ = x[StorageSourceIPFS-1]
 	_ = x[StorageSourceRepoClone-2]
-	_ = x[StorageSourceURLDownload-3]
-	_ = x[StorageSourceFilecoinUnsealed-4]
-	_ = x[StorageSourceFilecoin-5]
-	_ = x[StorageSourceEstuary-6]
-	_ = x[StorageSourceInline-7]
-	_ = x[StorageSourceLocalDirectory-8]
-	_ = x[StorageSourceS3-9]
-	_ = x[storageSourceDone-10]
+	_ = x[StorageSourceRepoCloneLFS-3]
+	_ = x[StorageSourceURLDownload-4]
+	_ = x[StorageSourceFilecoinUnsealed-5]
+	_ = x[StorageSourceFilecoin-6]
+	_ = x[StorageSourceEstuary-7]
+	_ = x[StorageSourceInline-8]
+	_ = x[StorageSourceLocalDirectory-9]
+	_ = x[StorageSourceS3-10]
+	_ = x[storageSourceDone-11]
 }
 
-const _StorageSourceType_name = "storageSourceUnknownIPFSRepoCloneURLDownloadFilecoinUnsealedFilecoinEstuaryInlineLocalDirectoryS3storageSourceDone"
+const _StorageSourceType_name = "storageSourceUnknownIPFSRepoCloneRepoCloneLFSURLDownloadFilecoinUnsealedFilecoinEstuaryInlineLocalDirectoryS3storageSourceDone"
 
-var _StorageSourceType_index = [...]uint8{0, 20, 24, 33, 44, 60, 68, 75, 81, 95, 97, 114}
+var _StorageSourceType_index = [...]uint8{0, 20, 24, 33, 45, 56, 72, 80, 87, 93, 107, 109, 126}
 
 func (i StorageSourceType) String() string {
 	if i < 0 || i >= StorageSourceType(len(_StorageSourceType_index)-1) {

--- a/pkg/storage/repo/storage.go
+++ b/pkg/storage/repo/storage.go
@@ -249,8 +249,5 @@ func RemoveFromSlice(arr []string, item string) []string {
 
 func checkGitLFS() error {
 	_, err := exec.LookPath("git-lfs")
-	if err != nil {
-		return fmt.Errorf("git-lfs is not installed. Please install it first")
-	}
-	return nil
+	return err
 }

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -99,7 +99,7 @@ func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
 		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
 		"--api-host=localhost",
 		"run",
-		"-v", fmt.Sprintf("%s:%s", fileCid, inputPath),
+		"-i", fmt.Sprintf("ipfs://%s,dst=%s", fileCid, inputPath),
 		"-o", fmt.Sprintf("%s:%s", "output", outputPath),
 		"python",
 		"--deterministic",


### PR DESCRIPTION
A generic way to define storage inputs using URIs instead of separate flags per input types. This change enables and exposes S3 inputs to CLI users.

Users can also pass additional options depending on the storage type, such as endpoint and region for S3 storage.

## Examples:
```
# Mount IPFS CID to /inputs directory
-i src=ipfs://QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72

# Mount IPFS CID using simple form to /inputs directory 
-i ipfs://QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72

# Mount S3 object to a specific path
-i src=s3://bucket/key,dst=/my/input/path

# Mount S3 object with specific endpoint and region
-i src=s3://bucket/key,dst=/my/input/path,opt=endpoint=http://s3.example.com,opt=region=us-east-1

# Mount S3 object using long flag names
--input source=s3://bucket/key,destination=/my/input/path

```

## Breaking Changes
1. Removed `--input-urls, -u` to mount URLs
2. Removed `--input-volumes, -v` to mount CIDs
3. Defining `ipfs://` schema is mandatory when defining input CIDs
4. Mount path is explicitly defined using `,dst=<path>` instead of using colon as delimiter 