### PR TITLE
feat: functions to relate job inputs & outputs

### DIFF
--- a/dashboard/api/pkg/model/api.go
+++ b/dashboard/api/pkg/model/api.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
+	"go.ptx.dk/multierrgroup"
+
 	"github.com/bacalhau-project/bacalhau/dashboard/api/pkg/store"
 	"github.com/bacalhau-project/bacalhau/dashboard/api/pkg/types"
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
@@ -16,19 +19,18 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/util"
-	"github.com/pkg/errors"
-	"go.ptx.dk/multierrgroup"
+
+	libp2p_pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/exp/slices"
 
 	"github.com/bacalhau-project/bacalhau/pkg/node"
 	"github.com/bacalhau-project/bacalhau/pkg/pubsub"
 	"github.com/bacalhau-project/bacalhau/pkg/pubsub/libp2p"
 	"github.com/bacalhau-project/bacalhau/pkg/routing"
 	"github.com/bacalhau-project/bacalhau/pkg/routing/inmemory"
-	libp2p_pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/rs/zerolog/log"
-	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/exp/slices"
 )
 
 type ModelOptions struct {
@@ -201,6 +203,18 @@ func (api *ModelAPI) GetNodes(ctx context.Context) (map[string]bacalhau_model.No
 		}
 	}
 	return nodesMap, nil
+}
+
+func (api *ModelAPI) GetJobsProducingJobInput(ctx context.Context, id string) ([]*types.JobRelation, error) {
+	return api.store.GetJobsProducingJobInput(ctx, id)
+}
+
+func (api *ModelAPI) GetJobsOperatingOnJobOutput(ctx context.Context, id string) ([]*types.JobRelation, error) {
+	return api.store.GetJobsOperatingOnJobOutput(ctx, id)
+}
+
+func (api *ModelAPI) GetJobsOperatingOnCID(ctx context.Context, cid string) ([]*types.JobDataIO, error) {
+	return api.store.GetJobsOperatingOnCID(ctx, cid)
 }
 
 func (api *ModelAPI) GetJobs(ctx context.Context, query localdb.JobQuery) ([]*bacalhau_model_beta.Job, error) {

--- a/dashboard/api/pkg/store/queries/find_jobs_with_input_or_output.sql
+++ b/dashboard/api/pkg/store/queries/find_jobs_with_input_or_output.sql
@@ -1,12 +1,12 @@
 SELECT job.id::text, input_element ->> 'CID' AS input_output, true AS is_input
 FROM job, json_array_elements(jobdata::json -> 'Spec' -> 'inputs') AS input_element
-WHERE input_element ->> 'CID' = $1
+WHERE job.apiversion = 'V1beta1' and input_element ->> 'CID' = $1
 UNION ALL
 SELECT node_states.JobID, node_states.output_cid AS input_output, false AS is_input
 FROM (
          SELECT id AS JobID, key AS NodeID, value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'CID' as output_cid
          FROM job,
              LATERAL jsonb_each(job.statedata::jsonb -> 'Nodes')
-         WHERE statedata != ''
+         WHERE job.apiversion = 'V1beta1' and statedata != ''
      ) as node_states
 WHERE node_states.output_cid = $1;

--- a/dashboard/api/pkg/store/queries/find_jobs_with_input_or_output.sql
+++ b/dashboard/api/pkg/store/queries/find_jobs_with_input_or_output.sql
@@ -1,0 +1,12 @@
+SELECT job.id::text, input_element ->> 'CID' AS input_output, true AS is_input
+FROM job, json_array_elements(jobdata::json -> 'Spec' -> 'inputs') AS input_element
+WHERE input_element ->> 'CID' = $1
+UNION ALL
+SELECT node_states.JobID, node_states.output_cid AS input_output, false AS is_input
+FROM (
+         SELECT id AS JobID, key AS NodeID, value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'CID' as output_cid
+         FROM job,
+             LATERAL jsonb_each(job.statedata::jsonb -> 'Nodes')
+         WHERE statedata != ''
+     ) as node_states
+WHERE node_states.output_cid = $1;

--- a/dashboard/api/pkg/store/queries/get_job_input_relations.sql
+++ b/dashboard/api/pkg/store/queries/get_job_input_relations.sql
@@ -6,7 +6,7 @@ WITH job_inputs AS (
     FROM
         job,
         json_array_elements(jobdata::json -> 'Spec' -> 'inputs') AS input_element
-    WHERE input_element ->> 'StorageSource' = 'IPFS'
+    WHERE job.apiversion = 'V1beta1' and input_element ->> 'StorageSource' = 'IPFS'
 ),
      job_outputs AS (
          SELECT
@@ -23,7 +23,7 @@ WITH job_inputs AS (
                       value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'StorageSource' as storage_source,
                       value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'CID' as output_cid
                   FROM job, LATERAL jsonb_each(job.statedata::jsonb -> 'Nodes')
-                  WHERE statedata != ''
+                  WHERE job.apiversion = 'V1beta1' and statedata != ''
               ) as node_states
          WHERE node_states.State = 'Completed' and node_states.storage_source = 'IPFS'
      )

--- a/dashboard/api/pkg/store/queries/get_job_input_relations.sql
+++ b/dashboard/api/pkg/store/queries/get_job_input_relations.sql
@@ -1,0 +1,42 @@
+WITH job_inputs AS (
+    SELECT
+        id AS JobID,
+        input_element ->> 'StorageSource' as storage_source,
+        input_element ->> 'CID' AS input
+    FROM
+        job,
+        json_array_elements(jobdata::json -> 'Spec' -> 'inputs') AS input_element
+    WHERE input_element ->> 'StorageSource' = 'IPFS'
+),
+     job_outputs AS (
+         SELECT
+             node_states.JobID,
+             node_states.NodeID,
+             node_states.storage_source,
+             node_states.output_cid
+         FROM (
+                  SELECT
+                      id                                             AS JobID,
+                      key                                            AS NodeID,
+                      value -> 'Shards' -> '0' ->> 'State'           AS State,
+                      value -> 'Shards' -> '0' -> 'PublishedResults' AS PublishedResults,
+                      value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'StorageSource' as storage_source,
+                      value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'CID' as output_cid
+                  FROM job, LATERAL jsonb_each(job.statedata::jsonb -> 'Nodes')
+                  WHERE statedata != ''
+              ) as node_states
+         WHERE node_states.State = 'Completed' and node_states.storage_source = 'IPFS'
+     )
+
+SELECT
+    job_outputs.JobID AS job_id,
+    job_outputs.output_cid AS cid
+FROM
+    job_inputs
+        JOIN
+    job_outputs
+    ON
+            job_inputs.input = job_outputs.output_cid
+WHERE
+        job_inputs.JobID = $1
+ORDER BY job_id DESC;

--- a/dashboard/api/pkg/store/queries/get_job_output_relations.sql
+++ b/dashboard/api/pkg/store/queries/get_job_output_relations.sql
@@ -6,7 +6,7 @@ WITH job_inputs AS (
     FROM
         job,
         json_array_elements(jobdata::json -> 'Spec' -> 'inputs') AS input_element
-    WHERE input_element ->> 'StorageSource' = 'IPFS'
+    WHERE job.apiversion = 'V1beta1' and input_element ->> 'StorageSource' = 'IPFS'
 ),
      job_outputs AS (
          SELECT
@@ -23,7 +23,7 @@ WITH job_inputs AS (
                       value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'StorageSource' as storage_source,
                       value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'CID' as output_cid
                   FROM job, LATERAL jsonb_each(job.statedata::jsonb -> 'Nodes')
-                  WHERE statedata != ''
+                  WHERE job.apiversion = 'V1beta1' and statedata != ''
               ) as node_states
          WHERE node_states.State = 'Completed' and node_states.storage_source = 'IPFS'
      )

--- a/dashboard/api/pkg/store/queries/get_job_output_relations.sql
+++ b/dashboard/api/pkg/store/queries/get_job_output_relations.sql
@@ -1,0 +1,42 @@
+WITH job_inputs AS (
+    SELECT
+        id AS JobID,
+        input_element ->> 'StorageSource' as storage_source,
+        input_element ->> 'CID' AS input
+    FROM
+        job,
+        json_array_elements(jobdata::json -> 'Spec' -> 'inputs') AS input_element
+    WHERE input_element ->> 'StorageSource' = 'IPFS'
+),
+     job_outputs AS (
+         SELECT
+             node_states.JobID,
+             node_states.NodeID,
+             node_states.storage_source,
+             node_states.output_cid
+         FROM (
+                  SELECT
+                      id                                             AS JobID,
+                      key                                            AS NodeID,
+                      value -> 'Shards' -> '0' ->> 'State'           AS State,
+                      value -> 'Shards' -> '0' -> 'PublishedResults' AS PublishedResults,
+                      value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'StorageSource' as storage_source,
+                      value -> 'Shards' -> '0' -> 'PublishedResults' ->> 'CID' as output_cid
+                  FROM job, LATERAL jsonb_each(job.statedata::jsonb -> 'Nodes')
+                  WHERE statedata != ''
+              ) as node_states
+         WHERE node_states.State = 'Completed' and node_states.storage_source = 'IPFS'
+     )
+
+SELECT
+    job_inputs.JobID AS job_id,
+    job_inputs.input AS cid
+FROM
+    job_inputs
+        JOIN
+    job_outputs
+    ON
+            job_inputs.input = job_outputs.output_cid
+WHERE
+        job_outputs.JobID = $1
+ORDER BY job_id DESC;

--- a/dashboard/api/pkg/types/types.go
+++ b/dashboard/api/pkg/types/types.go
@@ -75,3 +75,14 @@ type JobInfo struct {
 	Requests    []JobModerationRequest           `json:"requests"`
 	Moderations []JobModerationSummary           `json:"moderations"`
 }
+
+type JobRelation struct {
+	JobID string `json:"job_id,omitempty"`
+	CID   string `json:"cid,omitempty"`
+}
+
+type JobDataIO struct {
+	JobID       string `json:"job_id,omitempty"`
+	InputOutput string `json:"input_output,omitempty"`
+	IsInput     bool   `json:"is_input"`
+}

--- a/dashboard/frontend/src/pages/Job.tsx
+++ b/dashboard/frontend/src/pages/Job.tsx
@@ -14,7 +14,7 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 
 import useApi from '../hooks/useApi'
 import {
-  JobInfo,
+  JobInfo, JobRelation,
   ModerateRequest,
   ModerationType,
 } from '../types'
@@ -28,9 +28,6 @@ import ShardState from '../components/job/ShardState'
 import JobProgram from '../components/job/JobProgram'
 import FilPlus from '../components/job/FilPlus'
 
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import CancelIcon from '@mui/icons-material/Cancel'
-
 import {
   SmallText,
   SmallLink,
@@ -38,19 +35,23 @@ import {
   BoldSectionTitle,
   RequesterNode,
 } from '../components/widgets/GeneralText'
+import Accordion from "@mui/material/Accordion"
+import AccordionDetails from "@mui/material/AccordionDetails"
+import AccordionSummary from "@mui/material/AccordionSummary"
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Link from "@mui/material/Link";
+import ModerationPanel from '../components/widgets/ModerationSummary'
+import ModerationWindow from '../components/widgets/ModerationWindow'
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell"
+import TableContainer from "@mui/material/TableContainer"
+import TableRow from "@mui/material/TableRow";
 import TerminalWindow from '../components/widgets/TerminalWindow'
 import useLoadingErrorHandler from '../hooks/useLoadingErrorHandler'
-import { UserContext } from '../contexts/user'
-import ModerationWindow from '../components/widgets/ModerationWindow'
 import useSnackbar from '../hooks/useSnackbar'
-import ModerationPanel from '../components/widgets/ModerationSummary'
-import {Accordion, AccordionDetails, AccordionSummary, TableCell, TableContainer, TableHead} from "@mui/material";
-import Table from "@mui/material/Table";
-import TableRow from "@mui/material/TableRow";
-import TableBody from "@mui/material/TableBody";
+import { UserContext } from '../contexts/user'
 import {styled} from "@mui/system";
-import Link from "@mui/material/Link";
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 
 type JSONWindowConfig = {
@@ -106,9 +107,11 @@ const JobPage: FC<{
   const snackbar = useSnackbar()
   const [ datacapWindowOpen, setDatacapWindowOpen ] = useState(false)
   const [ execModWindowOpen, setExecModWindowOpen ] = useState(false)
+
   const [ jobInfo, setJobInfo ] = useState<JobInfo>()
-  const [jobInputRelation, setJobInputRelation] = useState([]); // Add this state for JobRelation
-  const [jobOutputRelation, setJobOutputRelation] = useState([]); // Add this state for JobRelation
+  const [ jobOutputRelation, setJobOutputRelation] = useState<JobRelation[]>([]);
+  const [jobInputRelation, setJobInputRelation] = useState<JobRelation[]>([]);
+
   const [ jsonWindow, setJsonWindow ] = useState<JSONWindowConfig>()
   const api = useApi()
   const loadingErrorHandler = useLoadingErrorHandler()
@@ -151,7 +154,9 @@ const JobPage: FC<{
       setJobInfo(info)
     })
     await handler()
-  }, [])
+  }, [
+      id,
+  ])
 
   const loadInputRelationInfo = useCallback(async () => {
     const handler = loadingErrorHandler(async () => {
@@ -159,7 +164,9 @@ const JobPage: FC<{
       setJobInputRelation(info);
     });
     await handler();
-  }, []);
+  }, [
+     id,
+  ]);
 
   const loadOutputRelationInfo = useCallback(async () => {
     const handler = loadingErrorHandler(async () => {
@@ -167,7 +174,9 @@ const JobPage: FC<{
       setJobOutputRelation(info);
     });
     await handler();
-  }, []);
+  }, [
+     id,
+  ]);
 
   const groupByCID = (jobRelation) => {
     const groups = {};
@@ -226,7 +235,7 @@ const JobPage: FC<{
     loadInfo();
     loadInputRelationInfo();
     loadOutputRelationInfo();
-  }, [loadInfo, loadInputRelationInfo]);
+  }, [id]);
 
   if(!jobInfo) return null
 

--- a/dashboard/frontend/src/types.ts
+++ b/dashboard/frontend/src/types.ts
@@ -201,6 +201,17 @@ export interface JobInfo {
   moderations: JobModerationSummary[],
 }
 
+export interface JobRelation {
+  JobID: string,
+  CID: string,
+}
+
+export interface JobIO {
+  JobID: string,
+  InputOutput: string,
+  IsInput: boolean,
+}
+
 export interface ResourceUsageData {
   CPU?: number,
   Memory?: number,


### PR DESCRIPTION
### What
This PR enhances the dashboard's `ModelAPI` by introducing three new API methods:
- `/api/v1/job/{id}/inputs`: Given a jobID, returns all jobs producing input that the specified job consumes.
- `/api/v1/job/{id}/outputs`: Given a jobID, returns all jobs operating on the output of the specified job.
- `/api/v1/cid/{cid}/jobs`: Given a CID, returns all jobs producing or operating on the content associated with that CID.

These API methods query the underlying PostgreSQL database to find jobs using IPFS as input or output. As a result, these queries will only work for jobs involving data stored on or retrieved from IPFS. The queries target the job table and examine the JSON data within the jobdata and statedata columns. These queries may be affected by changes to the Job Spec, so they should be maintained accordingly as the spec evolves.

Additionally, this PR updates the dashboard's job frontend to display the results of the new API methods for the job being viewed. This allows users to inspect related jobs and navigate between them within the dashboard. A screenshot is provided below to illustrate these changes:![JobRelationView](https://user-images.githubusercontent.com/6546409/231025611-656093dd-1b8c-4397-804f-13346314a029.jpg)


The `/api/v1/cid/{cid}/jobs` endpoint is currently not used by the dashboard as I lack the required frontend skills to make that change. However the api is callable via: `/api/v1/cid/QmSCWyNhhUhFPQM8WoAhCt7mhJt4iN5SbpGkkS8Rktt6QV/jobs` for example. @binocarlos if you are able to help with the frontend work here that would be great.