### PR TITLE
Allow compute nodes to receive async job authorizations

### DIFF
--- a/.gitprecommit/go_test_build_header.sh
+++ b/.gitprecommit/go_test_build_header.sh
@@ -11,9 +11,9 @@ set -o pipefail
 # Turn on traces, useful while debugging but commented out by default
 #set -o xtrace
 
-files_without_header=$(grep --include '*_test.go' -lR 'func Test[A-Z].*(t \*testing.T' ./* | xargs grep --files-without-match -e '//go:build integration' -e '//go:build unit || !integration' --)
+files_without_header=$(grep --include '*_test.go' -lR 'func Test[A-Z].*(t \*testing.T' ./* | xargs grep --files-without-match -e '//go:build integration || !unit' -e '//go:build unit || !integration' --)
 
 if [[ -n "${files_without_header}"  ]]; then
-  printf "Test files missing '//go:build integration' or '//go:build unit || !integration':\n%s\n" "${files_without_header}"
+  printf "Test files missing '//go:build integration || !unit' or '//go:build unit || !integration':\n%s\n" "${files_without_header}"
   exit 1
 fi

--- a/cmd/bacalhau/docker_run_test.go
+++ b/cmd/bacalhau/docker_run_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package bacalhau
 

--- a/cmd/bacalhau/get_test.go
+++ b/cmd/bacalhau/get_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package bacalhau
 

--- a/dashboard/api/cmd/dashboard/root.go
+++ b/dashboard/api/cmd/dashboard/root.go
@@ -10,16 +10,12 @@ import (
 
 var Fatal = FatalErrorHandler
 
-func init() { //nolint:gochecknoinits
-	NewRootCmd()
-}
-
 func NewRootCmd() *cobra.Command {
 	RootCmd := &cobra.Command{
 		Use:   getCommandLineExecutable(),
 		Short: "Dashboard",
 		Long:  `Dashboard`,
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logger.ConfigureLogging(logger.LogModeDefault)
 		},
 	}

--- a/ops/aws/canary/lambda/pkg/test/integration_test.go
+++ b/ops/aws/canary/lambda/pkg/test/integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package test
 

--- a/pkg/bidstrategy/fixed_strategy.go
+++ b/pkg/bidstrategy/fixed_strategy.go
@@ -8,21 +8,23 @@ import (
 
 // FixedBidStrategy is a bid strategy that always returns the same response, which is useful for testing
 type FixedBidStrategy struct {
-	response bool
+	Response bool
+	Wait     bool
 }
 
 // NewFixedBidStrategy creates a new FixedBidStrategy
-func NewFixedBidStrategy(response bool) *FixedBidStrategy {
+func NewFixedBidStrategy(response, wait bool) *FixedBidStrategy {
 	return &FixedBidStrategy{
-		response: response,
+		Response: response,
+		Wait:     wait,
 	}
 }
 
 func (s *FixedBidStrategy) ShouldBid(_ context.Context, _ BidStrategyRequest) (BidStrategyResponse, error) {
-	return BidStrategyResponse{ShouldBid: s.response}, nil
+	return BidStrategyResponse{ShouldBid: s.Response, ShouldWait: s.Wait}, nil
 }
 
 func (s *FixedBidStrategy) ShouldBidBasedOnUsage(
 	context.Context, BidStrategyRequest, model.ResourceUsageData) (BidStrategyResponse, error) {
-	return BidStrategyResponse{ShouldBid: s.response}, nil
+	return BidStrategyResponse{ShouldBid: s.Response, ShouldWait: s.Wait}, nil
 }

--- a/pkg/compute/bidder.go
+++ b/pkg/compute/bidder.go
@@ -1,0 +1,108 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog/log"
+)
+
+type BidderParams struct {
+	NodeID        string
+	Strategy      bidstrategy.BidStrategy
+	Store         store.ExecutionStore
+	Callback      Callback
+	GetApproveURL func() *url.URL
+}
+
+type Bidder struct {
+	nodeID        string
+	strategy      bidstrategy.BidStrategy
+	store         store.ExecutionStore
+	callback      Callback
+	getApproveURL func() *url.URL
+}
+
+func NewBidder(params BidderParams) Bidder {
+	return Bidder{
+		nodeID:        params.NodeID,
+		strategy:      params.Strategy,
+		store:         params.Store,
+		getApproveURL: params.GetApproveURL,
+		callback:      params.Callback,
+	}
+}
+
+func (b Bidder) RunBidding(ctx context.Context, execution store.Execution) {
+	// ask the bidding strategy if we should bid on this job
+	bidStrategyRequest := bidstrategy.BidStrategyRequest{
+		NodeID:   b.nodeID,
+		Job:      execution.Job,
+		Callback: b.getApproveURL(),
+	}
+
+	response, err := b.doBidding(ctx, bidStrategyRequest, execution.ResourceUsage)
+	if err != nil {
+		// TODO what do we do with it?
+		log.Ctx(ctx).Error().Err(err).Msg("Error running bid strategy")
+	}
+
+	b.ReturnBidResult(ctx, execution, response)
+}
+
+func (b Bidder) ReturnBidResult(ctx context.Context, execution store.Execution, response *bidstrategy.BidStrategyResponse) {
+	if response.ShouldWait {
+		return
+	}
+
+	if !response.ShouldBid {
+		err := b.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
+			ExecutionID:   execution.ID,
+			NewState:      store.ExecutionStateCancelled,
+			ExpectedState: store.ExecutionStateCreated,
+			Comment:       response.Reason,
+		})
+
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("Unable to update execution state")
+			return
+		}
+	}
+
+	result := BidResult{
+		RoutingMetadata: RoutingMetadata{
+			SourcePeerID: b.nodeID,
+			TargetPeerID: execution.RequesterNodeID,
+		},
+		ExecutionMetadata: NewExecutionMetadata(execution),
+		Accepted:          response.ShouldBid,
+		Reason:            response.Reason,
+	}
+	b.callback.OnBidComplete(ctx, result)
+}
+
+func (b Bidder) doBidding(
+	ctx context.Context,
+	bidStrategyRequest bidstrategy.BidStrategyRequest,
+	jobRequirements model.ResourceUsageData,
+) (*bidstrategy.BidStrategyResponse, error) {
+	// Check bidding strategies before having to calculate resource usage
+	bidStrategyResponse, err := b.strategy.ShouldBid(ctx, bidStrategyRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error asking bidding strategy if we should bid: %w", err)
+	}
+
+	if bidStrategyResponse.ShouldBid {
+		// Check bidding strategies after calculating resource usage
+		bidStrategyResponse, err = b.strategy.ShouldBidBasedOnUsage(ctx, bidStrategyRequest, jobRequirements)
+		if err != nil {
+			return nil, fmt.Errorf("error asking bidding strategy if we should bid: %w", err)
+		}
+	}
+
+	return &bidStrategyResponse, nil
+}

--- a/pkg/compute/callback_chain.go
+++ b/pkg/compute/callback_chain.go
@@ -17,6 +17,12 @@ func NewChainedCallback(params ChainedCallbackParams) *ChainedCallback {
 	}
 }
 
+func (c ChainedCallback) OnBidComplete(ctx context.Context, result BidResult) {
+	for _, callback := range c.callbacks {
+		callback.OnBidComplete(ctx, result)
+	}
+}
+
 func (c ChainedCallback) OnRunComplete(ctx context.Context, result RunResult) {
 	for _, callback := range c.callbacks {
 		callback.OnRunComplete(ctx, result)

--- a/pkg/compute/callback_mock.go
+++ b/pkg/compute/callback_mock.go
@@ -1,0 +1,48 @@
+package compute
+
+import "context"
+
+type CallbackMock struct {
+	OnBidCompleteHandler     func(ctx context.Context, result BidResult)
+	OnCancelCompleteHandler  func(ctx context.Context, result CancelResult)
+	OnComputeFailureHandler  func(ctx context.Context, err ComputeError)
+	OnPublishCompleteHandler func(ctx context.Context, result PublishResult)
+	OnRunCompleteHandler     func(ctx context.Context, result RunResult)
+}
+
+// OnBidComplete implements Callback
+func (c CallbackMock) OnBidComplete(ctx context.Context, result BidResult) {
+	if c.OnBidCompleteHandler != nil {
+		c.OnBidCompleteHandler(ctx, result)
+	}
+}
+
+// OnCancelComplete implements Callback
+func (c CallbackMock) OnCancelComplete(ctx context.Context, result CancelResult) {
+	if c.OnCancelCompleteHandler != nil {
+		c.OnCancelCompleteHandler(ctx, result)
+	}
+}
+
+// OnComputeFailure implements Callback
+func (c CallbackMock) OnComputeFailure(ctx context.Context, err ComputeError) {
+	if c.OnComputeFailureHandler != nil {
+		c.OnComputeFailureHandler(ctx, err)
+	}
+}
+
+// OnPublishComplete implements Callback
+func (c CallbackMock) OnPublishComplete(ctx context.Context, result PublishResult) {
+	if c.OnPublishCompleteHandler != nil {
+		c.OnPublishCompleteHandler(ctx, result)
+	}
+}
+
+// OnRunComplete implements Callback
+func (c CallbackMock) OnRunComplete(ctx context.Context, result RunResult) {
+	if c.OnRunCompleteHandler != nil {
+		c.OnRunCompleteHandler(ctx, result)
+	}
+}
+
+var _ Callback = CallbackMock{}

--- a/pkg/compute/publicapi/endpoint_approve.go
+++ b/pkg/compute/publicapi/endpoint_approve.go
@@ -1,0 +1,45 @@
+package publicapi
+
+import (
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+)
+
+// approve godoc
+//
+//	@ID			apiServer/approver
+//	@Summary	Approves a job to be run on this compute node.
+//	@Produce	json
+//	@Success	200	{object}	string
+//	@Failure	400	{object}	string
+//	@Failure	403	{object}	string
+//	@Failure	500	{object}	string
+//	@Router		/approve [get]
+func (s *ComputeAPIServer) approve(res http.ResponseWriter, req *http.Request) {
+	request, err := publicapi.UnmarshalSigned[bidstrategy.ModerateJobRequest](req.Context(), req.Body)
+	if err != nil {
+		publicapi.HTTPError(req.Context(), res, err, http.StatusBadRequest)
+		return
+	}
+
+	approvingClient := os.Getenv("BACALHAU_JOB_APPROVER")
+	if request.ClientID != approvingClient {
+		err := errors.New("approval submitted by unknown client")
+		publicapi.HTTPError(req.Context(), res, err, http.StatusUnauthorized)
+		return
+	}
+
+	executions, err := s.store.GetExecutions(req.Context(), request.JobID)
+	if err != nil {
+		publicapi.HTTPError(req.Context(), res, err, http.StatusInternalServerError)
+		return
+	}
+
+	for _, execution := range executions {
+		go s.bidder.ReturnBidResult(req.Context(), execution, &request.Response)
+	}
+}

--- a/pkg/compute/publicapi/server.go
+++ b/pkg/compute/publicapi/server.go
@@ -3,26 +3,35 @@ package publicapi
 import (
 	"net/http"
 
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
 )
 
 const APIPrefix = "compute/"
 const APIDebugSuffix = "debug"
+const APIApproveSuffix = "approve"
 
 type ComputeAPIServerParams struct {
 	APIServer          *publicapi.APIServer
+	Bidder             compute.Bidder
+	Store              store.ExecutionStore
 	DebugInfoProviders []model.DebugInfoProvider
 }
 
 type ComputeAPIServer struct {
 	apiServer          *publicapi.APIServer
+	bidder             compute.Bidder
+	store              store.ExecutionStore
 	debugInfoProviders []model.DebugInfoProvider
 }
 
 func NewComputeAPIServer(params ComputeAPIServerParams) *ComputeAPIServer {
 	return &ComputeAPIServer{
 		apiServer:          params.APIServer,
+		bidder:             params.Bidder,
+		store:              params.Store,
 		debugInfoProviders: params.DebugInfoProviders,
 	}
 }
@@ -30,6 +39,7 @@ func NewComputeAPIServer(params ComputeAPIServerParams) *ComputeAPIServer {
 func (s *ComputeAPIServer) RegisterAllHandlers() error {
 	handlerConfigs := []publicapi.HandlerConfig{
 		{URI: "/" + APIPrefix + APIDebugSuffix, Handler: http.HandlerFunc(s.debug)},
+		{URI: "/" + APIPrefix + APIApproveSuffix, Handler: http.HandlerFunc(s.approve)},
 	}
 	return s.apiServer.RegisterHandlers(handlerConfigs...)
 }

--- a/pkg/compute/types.go
+++ b/pkg/compute/types.go
@@ -42,6 +42,7 @@ type Executor interface {
 
 // Callback Callbacks are used to notify the caller of the result of a job execution.
 type Callback interface {
+	OnBidComplete(ctx context.Context, result BidResult)
 	OnRunComplete(ctx context.Context, result RunResult)
 	OnPublishComplete(ctx context.Context, result PublishResult)
 	OnCancelComplete(ctx context.Context, result CancelResult)
@@ -70,6 +71,7 @@ func NewExecutionMetadata(execution store.Execution) ExecutionMetadata {
 }
 
 type AskForBidRequest struct {
+	ExecutionMetadata
 	RoutingMetadata
 	// Job specifies the job to be executed.
 	Job model.Job
@@ -77,8 +79,6 @@ type AskForBidRequest struct {
 
 type AskForBidResponse struct {
 	ExecutionMetadata
-	Accepted bool
-	Reason   string
 }
 
 type BidAcceptedRequest struct {
@@ -146,6 +146,15 @@ type ExecutionLogsResponse struct {
 ///////////////////////////////////
 // Callback result models
 ///////////////////////////////////
+
+// BidResult is the result of the compute node bidding on a job that is returned
+// to the caller through a Callback.
+type BidResult struct {
+	RoutingMetadata
+	ExecutionMetadata
+	Accepted bool
+	Reason   string
+}
 
 // RunResult Result of a job execution that is returned to the caller through a Callback.
 type RunResult struct {

--- a/pkg/executor/docker/bid_strategy_test.go
+++ b/pkg/executor/docker/bid_strategy_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package docker
 

--- a/pkg/localdb/postgres/postgres_test.go
+++ b/pkg/localdb/postgres/postgres_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package postgres
 

--- a/pkg/localdb/sqlite/sqlite_test.go
+++ b/pkg/localdb/sqlite/sqlite_test.go
@@ -1,9 +1,10 @@
-//go:build integration && linux
+//go:build integration || !unit
 
 package sqlite
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/localdb/shared"
@@ -13,6 +14,10 @@ import (
 )
 
 func TestSQLiteSuite(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("Test only runs on linux and not %s", runtime.GOOS)
+	}
+
 	testingSuite := new(shared.GenericSQLSuite)
 	testingSuite.SetupHandler = func() *shared.GenericSQLDatastore {
 		datafile, err := os.CreateTemp("", "sqlite-test-*.db")

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -33,11 +34,13 @@ import (
 
 type Compute struct {
 	// Visible for testing
+	ID                  string
 	LocalEndpoint       compute.Endpoint
 	Capacity            capacity.Tracker
 	ExecutionStore      store.ExecutionStore
 	Executors           executor.ExecutorProvider
 	LogServer           *logstream.LogStreamServer
+	Bidder              compute.Bidder
 	computeCallback     *bprotocol.CallbackProxy
 	cleanupFunc         func(ctx context.Context)
 	computeInfoProvider model.ComputeNodeInfoProvider
@@ -200,11 +203,21 @@ func NewComputeNode(
 		MaxJobRequirements: config.JobResourceLimits,
 	})
 
+	bidder := compute.NewBidder(compute.BidderParams{
+		NodeID:   host.ID().String(),
+		Strategy: biddingStrategy,
+		Store:    executionStore,
+		Callback: computeCallback,
+		GetApproveURL: func() *url.URL {
+			return apiServer.GetURI().JoinPath(compute_publicapi.APIPrefix, compute_publicapi.APIApproveSuffix)
+		},
+	})
+
 	baseEndpoint := compute.NewBaseEndpoint(compute.BaseEndpointParams{
 		ID:              host.ID().String(),
 		ExecutionStore:  executionStore,
 		UsageCalculator: capacityCalculator,
-		BidStrategy:     biddingStrategy,
+		Bidder:          bidder,
 		Executor:        bufferRunner,
 		LogServer:       *logserver,
 	})
@@ -231,6 +244,8 @@ func NewComputeNode(
 	// register compute public http apis
 	computeAPIServer := compute_publicapi.NewComputeAPIServer(compute_publicapi.ComputeAPIServerParams{
 		APIServer:          apiServer,
+		Bidder:             bidder,
+		Store:              executionStore,
 		DebugInfoProviders: debugInfoProviders,
 	})
 	err = computeAPIServer.RegisterAllHandlers()
@@ -244,10 +259,12 @@ func NewComputeNode(
 	}
 
 	return &Compute{
+		ID:                  host.ID().String(),
 		LocalEndpoint:       baseEndpoint,
 		Capacity:            runningCapacityTracker,
 		ExecutionStore:      executionStore,
 		Executors:           executors,
+		Bidder:              bidder,
 		LogServer:           logserver,
 		computeCallback:     standardComputeCallback,
 		cleanupFunc:         cleanupFunc,

--- a/pkg/publisher/estuary/publisher_test.go
+++ b/pkg/publisher/estuary/publisher_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package estuary
 

--- a/pkg/requester/discovery/identity_test.go
+++ b/pkg/requester/discovery/identity_test.go
@@ -1,16 +1,17 @@
-//go:build integration
+//go:build integration || !unit
 
 package discovery
 
 import (
 	"context"
+	"testing"
+
 	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/transport/bprotocol"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type IdentityNodeDiscovererSuite struct {

--- a/pkg/requester/event_emitter.go
+++ b/pkg/requester/event_emitter.go
@@ -55,10 +55,10 @@ func (e EventEmitter) EmitJobCanceled(ctx context.Context, req CancelJobRequest)
 }
 
 func (e EventEmitter) EmitBidReceived(
-	ctx context.Context, request compute.AskForBidRequest, response compute.AskForBidResponse) {
-	event := e.constructEvent(request.RoutingMetadata, response.ExecutionMetadata, model.JobEventBid)
+	ctx context.Context, result compute.BidResult) {
+	event := e.constructEvent(result.RoutingMetadata, result.ExecutionMetadata, model.JobEventBid)
 	// we flip senders to mimic a bid was received instead of being asked
-	event.SourceNodeID = request.RoutingMetadata.TargetPeerID
+	event.SourceNodeID = result.RoutingMetadata.SourcePeerID
 	event.TargetNodeID = "" // localdb don't assume a target node for events coming from compute nodes
 	e.EmitEventSilently(ctx, event)
 }

--- a/pkg/test/compute/ask_for_bid_test.go
+++ b/pkg/test/compute/ask_for_bid_test.go
@@ -4,11 +4,17 @@ package compute
 
 import (
 	"context"
+	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/stretchr/testify/suite"
 )
+
+type AskForBidSuite struct {
+	ComputeSuite
+}
 
 type bidResponseTestCase struct {
 	name          string
@@ -17,99 +23,76 @@ type bidResponseTestCase struct {
 	resourceUsage model.ResourceUsageData
 }
 
-func (s *ComputeSuite) TestAskForBid() {
+func TestAskForBidSuite(t *testing.T) {
+	suite.Run(t, new(AskForBidSuite))
+}
+
+func (s *AskForBidSuite) TestAskForBid() {
 	s.runAskForBidTest(bidResponseTestCase{})
 }
 
-func (s *ComputeSuite) TestAskForBid_PopulateResourceUsage() {
-	ctx := context.Background()
-	verify := func(response compute.AskForBidResponse, expected model.ResourceUsageData) {
-		execution, err := s.node.ExecutionStore.GetExecution(ctx, response.ExecutionID)
-		s.NoError(err)
-		s.Equal(expected, execution.ResourceUsage)
-	}
+func (s *AskForBidSuite) verify(response compute.BidResult, expected model.ResourceUsageData) {
+	execution, err := s.node.ExecutionStore.GetExecution(context.Background(), response.ExecutionID)
+	s.NoError(err)
+	s.Equal(expected, execution.ResourceUsage)
+}
 
-	s.Run("populate default usage", func() {
-		response := s.runAskForBidTest(bidResponseTestCase{})
-		verify(response, s.config.DefaultJobResourceLimits)
+func (s *AskForBidSuite) TestPopulateResourceUsage() {
+	response := s.runAskForBidTest(bidResponseTestCase{})
+	s.verify(response, s.config.DefaultJobResourceLimits)
+}
+
+func (s *AskForBidSuite) TestUseSubmittedResourceUsage() {
+	usage := model.ResourceUsageData{CPU: 1, Memory: 2, Disk: 3}
+	response := s.runAskForBidTest(bidResponseTestCase{
+		job: addResourceUsage(generateJob(), usage),
 	})
+	s.verify(response, usage)
+}
 
-	s.Run("use submitted usage", func() {
-		usage := model.ResourceUsageData{CPU: 1, Memory: 2, Disk: 3}
-		response := s.runAskForBidTest(bidResponseTestCase{
-			job: addResourceUsage(generateJob(), usage),
-		})
-		verify(response, usage)
+func (s *AskForBidSuite) TestAcceptUsageBelowLimits() {
+	s.runAskForBidTest(bidResponseTestCase{
+		job: addResourceUsage(generateJob(),
+			model.ResourceUsageData{CPU: s.config.JobResourceLimits.CPU / 2}),
 	})
 }
 
-func (s *ComputeSuite) TestAskForBid_JobResourceLimits() {
-	s.Run("accept usage below limits", func() {
-		s.runAskForBidTest(bidResponseTestCase{
-			job: addResourceUsage(generateJob(),
-				model.ResourceUsageData{CPU: s.config.JobResourceLimits.CPU / 2}),
-		})
-	})
-
-	s.Run("accept usage matching limits", func() {
-		s.runAskForBidTest(bidResponseTestCase{
-			job: addResourceUsage(generateJob(),
-				model.ResourceUsageData{CPU: s.config.JobResourceLimits.CPU}),
-		})
-	})
-
-	s.Run("reject usage exceeding limits", func() {
-		s.runAskForBidTest(bidResponseTestCase{
-			job: addResourceUsage(generateJob(),
-				model.ResourceUsageData{CPU: s.config.JobResourceLimits.CPU + 0.01}),
-			rejected: true,
-		})
-	})
-
-}
-
-func (s *ComputeSuite) TestAskForBid_RejectStateless() {
-	s.config.JobSelectionPolicy.RejectStatelessJobs = true
-	s.setupNode()
-
-	s.Run("reject stateless", func() {
-		s.runAskForBidTest(bidResponseTestCase{
-			rejected: true,
-		})
-	})
-
-	s.Run("accept stateful", func() {
-		s.runAskForBidTest(bidResponseTestCase{
-			job: addInput(generateJob(), "cid"),
-		})
+func (s *AskForBidSuite) TestAcceptUsageMatachingLimits() {
+	s.runAskForBidTest(bidResponseTestCase{
+		job: addResourceUsage(generateJob(),
+			model.ResourceUsageData{CPU: s.config.JobResourceLimits.CPU}),
 	})
 }
 
-func (s *ComputeSuite) runAskForBidTest(testCase bidResponseTestCase) compute.AskForBidResponse {
+func (s *AskForBidSuite) TestRejectUsageExceedingLimits() {
+	s.runAskForBidTest(bidResponseTestCase{
+		job: addResourceUsage(generateJob(),
+			model.ResourceUsageData{CPU: s.config.JobResourceLimits.CPU + 0.01}),
+		rejected: true,
+	})
+}
+
+func (s *AskForBidSuite) runAskForBidTest(testCase bidResponseTestCase) compute.BidResult {
 	ctx := context.Background()
 
 	// setup default values
 	job := testCase.job
+	job.Metadata.Requester.RequesterNodeID = s.node.ID
 	if job.Metadata.ID == "" {
 		job = generateJob()
 	}
 
-	// issue the request
-	request := compute.AskForBidRequest{
-		Job: job,
-	}
-	response, err := s.node.LocalEndpoint.AskForBid(ctx, request)
-	s.NoError(err)
-
-	// check the response
-	s.Equal(!testCase.rejected, response.Accepted)
+	result := s.askForBid(ctx, job)
+	s.Equal(!testCase.rejected, result.Accepted)
 
 	// check execution state
-	if !testCase.rejected {
-		execution, err := s.node.ExecutionStore.GetExecution(ctx, response.ExecutionID)
-		s.NoError(err)
+	execution, err := s.node.ExecutionStore.GetExecution(ctx, result.ExecutionID)
+	s.NoError(err)
+	if testCase.rejected {
+		s.Equal(store.ExecutionStateCancelled, execution.State)
+	} else {
 		s.Equal(store.ExecutionStateCreated, execution.State)
 	}
 
-	return response
+	return result
 }

--- a/pkg/test/compute/ask_for_bid_test.go
+++ b/pkg/test/compute/ask_for_bid_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package compute
 

--- a/pkg/test/compute/async_bid_test.go
+++ b/pkg/test/compute/async_bid_test.go
@@ -1,0 +1,78 @@
+//go:build integration || !unit
+
+package compute
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/stretchr/testify/suite"
+)
+
+type AsyncBidSuite struct {
+	ComputeSuite
+
+	strategy *bidstrategy.FixedBidStrategy
+}
+
+func TestAsyncBidSuite(t *testing.T) {
+	suite.Run(t, new(AsyncBidSuite))
+}
+
+func (s *AsyncBidSuite) SetupSuite() {
+	s.ComputeSuite.SetupSuite()
+	s.strategy = bidstrategy.NewFixedBidStrategy(true, true)
+	s.config.BidStrategy = s.strategy
+}
+
+func (s *AsyncBidSuite) TestAsyncApproval() {
+	s.runAsyncBidTest(true)
+}
+
+func (s *AsyncBidSuite) TestAsyncReject() {
+	s.runAsyncBidTest(false)
+}
+
+func (s *AsyncBidSuite) runAsyncBidTest(response bool) {
+	job := generateJob()
+
+	s.strategy.Response = response
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expectingResponse := false
+	go func() {
+		defer wg.Done()
+		select {
+		case result := <-s.bidChannel:
+			s.True(expectingResponse, "received result before it was expected")
+			s.Equal(response, result.Accepted)
+			s.Equal(job.Metadata.ID, result.JobID)
+		case <-time.After(2 * time.Second):
+			s.FailNow("did not receive a bid response")
+		}
+	}()
+
+	resp, err := s.node.LocalEndpoint.AskForBid(ctx, compute.AskForBidRequest{
+		RoutingMetadata: compute.RoutingMetadata{TargetPeerID: s.node.ID, SourcePeerID: s.node.ID},
+		Job:             job,
+	})
+	s.NoError(err)
+
+	execution, err := s.node.ExecutionStore.GetExecution(ctx, resp.ExecutionID)
+	s.NoError(err)
+
+	expectingResponse = true
+	s.node.Bidder.ReturnBidResult(ctx, execution, &bidstrategy.BidStrategyResponse{
+		ShouldBid: response,
+	})
+}

--- a/pkg/test/compute/bid_accepted_test.go
+++ b/pkg/test/compute/bid_accepted_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package compute
 

--- a/pkg/test/compute/bid_accepted_test.go
+++ b/pkg/test/compute/bid_accepted_test.go
@@ -4,14 +4,24 @@ package compute
 
 import (
 	"context"
+	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store/resolver"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
 )
 
-func (s *ComputeSuite) TestBidAccepted() {
+type BidAcceptedSuite struct {
+	ComputeSuite
+}
+
+func TestBidAcceptedSuite(t *testing.T) {
+	suite.Run(t, new(BidAcceptedSuite))
+}
+
+func (s *BidAcceptedSuite) TestBidAccepted() {
 	ctx := context.Background()
 	executionID := s.prepareAndAskForBid(ctx, generateJob())
 
@@ -21,13 +31,13 @@ func (s *ComputeSuite) TestBidAccepted() {
 	s.NoError(err)
 }
 
-func (s *ComputeSuite) TestBidAccepted_DoesntExist() {
+func (s *BidAcceptedSuite) TestDoesntExist() {
 	ctx := context.Background()
 	_, err := s.node.LocalEndpoint.BidAccepted(ctx, compute.BidAcceptedRequest{ExecutionID: uuid.NewString()})
 	s.Error(err)
 }
 
-func (s *ComputeSuite) TestBidAccepted_WrongState() {
+func (s *BidAcceptedSuite) TestWrongState() {
 	ctx := context.Background()
 
 	// loop over few states to make sure we don't accept bids, if state is not `Created`

--- a/pkg/test/compute/bid_rejected_test.go
+++ b/pkg/test/compute/bid_rejected_test.go
@@ -4,14 +4,24 @@ package compute
 
 import (
 	"context"
+	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store/resolver"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
 )
 
-func (s *ComputeSuite) TestBidRejected() {
+type BidRejectedSuite struct {
+	ComputeSuite
+}
+
+func TestBidRejectedSuite(t *testing.T) {
+	suite.Run(t, new(BidRejectedSuite))
+}
+
+func (s *BidRejectedSuite) TestBidRejected() {
 	ctx := context.Background()
 	executionID := s.prepareAndAskForBid(ctx, generateJob())
 
@@ -21,13 +31,13 @@ func (s *ComputeSuite) TestBidRejected() {
 	s.NoError(err)
 }
 
-func (s *ComputeSuite) TestBidRejected_DoesntExist() {
+func (s *BidRejectedSuite) TestDoesntExist() {
 	ctx := context.Background()
 	_, err := s.node.LocalEndpoint.BidRejected(ctx, compute.BidRejectedRequest{ExecutionID: uuid.NewString()})
 	s.Error(err)
 }
 
-func (s *ComputeSuite) TestBidRejected_WrongState() {
+func (s *BidRejectedSuite) TestWrongState() {
 	ctx := context.Background()
 
 	// loop over few states to make sure we don't accept bids, if state is not `Created`

--- a/pkg/test/compute/bid_rejected_test.go
+++ b/pkg/test/compute/bid_rejected_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package compute
 

--- a/pkg/test/compute/data_locality_bid_test.go
+++ b/pkg/test/compute/data_locality_bid_test.go
@@ -1,0 +1,34 @@
+//go:build integration || !unit
+
+package compute
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type DataLocalityBidSuite struct {
+	AskForBidSuite
+}
+
+func TestDataLocalityBidSuite(t *testing.T) {
+	suite.Run(t, new(AskForBidSuite))
+}
+
+func (s *DataLocalityBidSuite) SetupTest() {
+	s.config.JobSelectionPolicy.RejectStatelessJobs = true
+	s.AskForBidSuite.SetupTest()
+}
+
+func (s *DataLocalityBidSuite) TestRejectStateless() {
+	s.runAskForBidTest(bidResponseTestCase{
+		rejected: true,
+	})
+}
+
+func (s *DataLocalityBidSuite) TestAcceptStateful() {
+	s.runAskForBidTest(bidResponseTestCase{
+		job: addInput(generateJob(), "cid"),
+	})
+}

--- a/pkg/test/compute/resourcelimits_test.go
+++ b/pkg/test/compute/resourcelimits_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package compute
 

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package compute
 

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -4,7 +4,7 @@ package compute
 
 import (
 	"context"
-	"testing"
+	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
@@ -22,6 +22,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/verifier"
 	noop_verifier "github.com/bacalhau-project/bacalhau/pkg/verifier/noop"
+	"github.com/google/uuid"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/suite"
 )
@@ -35,21 +36,28 @@ type ComputeSuite struct {
 	verifier      *noop_verifier.NoopVerifier
 	publisher     *noop_publisher.NoopPublisher
 	stateResolver resolver.StateResolver
+	bidChannel    chan compute.BidResult
+}
+
+func (s *ComputeSuite) SetupSuite() {
+	s.config = node.NewComputeConfigWith(node.ComputeConfigParams{
+		TotalResourceLimits: model.ResourceUsageData{
+			CPU: 2,
+		},
+	})
 }
 
 func (s *ComputeSuite) SetupTest() {
 	var err error
 	ctx := context.Background()
 	s.cm = system.NewCleanupManager()
-	s.config = node.NewComputeConfigWith(node.ComputeConfigParams{
-		TotalResourceLimits: model.ResourceUsageData{
-			CPU: 2,
-		},
-	})
+	s.T().Cleanup(func() { s.cm.Cleanup(ctx) })
+
 	s.executor = noop_executor.NewNoopExecutor()
 	s.verifier, err = noop_verifier.NewNoopVerifier(ctx, s.cm)
 	s.Require().NoError(err)
 	s.publisher = noop_publisher.NewNoopPublisher()
+	s.bidChannel = make(chan compute.BidResult)
 	s.setupNode()
 }
 
@@ -59,6 +67,7 @@ func (s *ComputeSuite) setupNode() {
 
 	host, err := libp2p.NewHost(libp2pPort)
 	s.NoError(err)
+	s.T().Cleanup(func() { _ = host.Close })
 
 	apiServer, err := publicapi.NewAPIServer(publicapi.APIServerParams{
 		Address: "0.0.0.0",
@@ -69,8 +78,6 @@ func (s *ComputeSuite) setupNode() {
 	s.NoError(err)
 
 	noopstorage := noop_storage.NewNoopStorage()
-	s.Require().NoError(err)
-
 	s.node, err = node.NewComputeNode(
 		context.Background(),
 		s.cm,
@@ -88,22 +95,42 @@ func (s *ComputeSuite) setupNode() {
 	s.stateResolver = *resolver.NewStateResolver(resolver.StateResolverParams{
 		ExecutionStore: s.node.ExecutionStore,
 	})
+
+	s.node.RegisterLocalComputeCallback(compute.CallbackMock{
+		OnBidCompleteHandler: func(ctx context.Context, result compute.BidResult) {
+			s.bidChannel <- result
+		},
+	})
+	s.T().Cleanup(func() { close(s.bidChannel) })
 }
 
-func TestComputeSuite(t *testing.T) {
-	suite.Run(t, new(ComputeSuite))
-}
-
-func (s *ComputeSuite) prepareAndAskForBid(ctx context.Context, job model.Job) string {
-	response, err := s.node.LocalEndpoint.AskForBid(ctx, compute.AskForBidRequest{
+func (s *ComputeSuite) askForBid(ctx context.Context, job model.Job) compute.BidResult {
+	_, err := s.node.LocalEndpoint.AskForBid(ctx, compute.AskForBidRequest{
+		ExecutionMetadata: compute.ExecutionMetadata{
+			JobID:       job.Metadata.ID,
+			ExecutionID: uuid.NewString(),
+		},
+		RoutingMetadata: compute.RoutingMetadata{
+			TargetPeerID: s.node.ID,
+			SourcePeerID: s.node.ID,
+		},
 		Job: job,
 	})
 	s.NoError(err)
 
-	// check the response
-	s.True(response.Accepted)
+	select {
+	case result := <-s.bidChannel:
+		return result
+	case <-time.After(5 * time.Second):
+		s.FailNow("did not receive a bid response")
+		return compute.BidResult{}
+	}
+}
 
-	return response.ExecutionID
+func (s *ComputeSuite) prepareAndAskForBid(ctx context.Context, job model.Job) string {
+	result := s.askForBid(ctx, job)
+	s.True(result.Accepted)
+	return result.ExecutionID
 }
 
 func (s *ComputeSuite) prepareAndRun(ctx context.Context, job model.Job) string {

--- a/pkg/test/compute/utils_test.go
+++ b/pkg/test/compute/utils_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package compute
 

--- a/pkg/test/devstack/combodriver_test.go
+++ b/pkg/test/devstack/combodriver_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/concurrency_test.go
+++ b/pkg/test/devstack/concurrency_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/extract_car_test.go
+++ b/pkg/test/devstack/extract_car_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/lotus_test.go
+++ b/pkg/test/devstack/lotus_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/multiple_cid_test.go
+++ b/pkg/test/devstack/multiple_cid_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/publish_on_error_test.go
+++ b/pkg/test/devstack/publish_on_error_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/submit_test.go
+++ b/pkg/test/devstack/submit_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/timeout_test.go
+++ b/pkg/test/devstack/timeout_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/devstack/url_test.go
+++ b/pkg/test/devstack/url_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package devstack
 

--- a/pkg/test/executor/scenario_test.go
+++ b/pkg/test/executor/scenario_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package executor
 

--- a/pkg/test/requester/node_selection_test.go
+++ b/pkg/test/requester/node_selection_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package requester
 

--- a/pkg/test/requester/retries_test.go
+++ b/pkg/test/requester/retries_test.go
@@ -55,7 +55,7 @@ func (s *RetriesSuite) SetupSuite() {
 				"name": "bid-rejector",
 			},
 			ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-				BidStrategy: bidstrategy.NewFixedBidStrategy(false),
+				BidStrategy: bidstrategy.NewFixedBidStrategy(false, false),
 			}),
 		},
 		{

--- a/pkg/test/requester/retries_test.go
+++ b/pkg/test/requester/retries_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package requester
 
@@ -64,7 +64,7 @@ func (s *RetriesSuite) SetupSuite() {
 			},
 			DependencyInjector: node.NodeDependencyInjector{
 				ExecutorsFactory: devstack.NewNoopExecutorsFactoryWithConfig(noop_executor.ExecutorConfig{
-					noop_executor.ExecutorConfigExternalHooks{
+					ExternalHooks: noop_executor.ExecutorConfigExternalHooks{
 						JobHandler: noop_executor.ErrorJobHandler(executionErr),
 					},
 				}),
@@ -76,7 +76,7 @@ func (s *RetriesSuite) SetupSuite() {
 			},
 			DependencyInjector: node.NodeDependencyInjector{
 				ExecutorsFactory: devstack.NewNoopExecutorsFactoryWithConfig(noop_executor.ExecutorConfig{
-					noop_executor.ExecutorConfigExternalHooks{
+					ExternalHooks: noop_executor.ExecutorConfigExternalHooks{
 						JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
 							return executor.WriteJobResults(resultsDir, strings.NewReader("apples"), strings.NewReader(""), 0, nil)
 						},
@@ -90,7 +90,7 @@ func (s *RetriesSuite) SetupSuite() {
 			},
 			DependencyInjector: node.NodeDependencyInjector{
 				ExecutorsFactory: devstack.NewNoopExecutorsFactoryWithConfig(noop_executor.ExecutorConfig{
-					noop_executor.ExecutorConfigExternalHooks{
+					ExternalHooks: noop_executor.ExecutorConfigExternalHooks{
 						JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
 							return executor.WriteJobResults(resultsDir, strings.NewReader("oranges"), strings.NewReader(""), 0, nil)
 						},
@@ -104,7 +104,7 @@ func (s *RetriesSuite) SetupSuite() {
 			},
 			DependencyInjector: node.NodeDependencyInjector{
 				PublishersFactory: devstack.NewNoopPublishersFactoryWithConfig(noop_publisher.PublisherConfig{
-					noop_publisher.PublisherExternalHooks{
+					ExternalHooks: noop_publisher.PublisherExternalHooks{
 						PublishResult: noop_publisher.ErrorResultPublisher(publishErr),
 					},
 				}),
@@ -116,7 +116,7 @@ func (s *RetriesSuite) SetupSuite() {
 			},
 			DependencyInjector: node.NodeDependencyInjector{
 				ExecutorsFactory: devstack.NewNoopExecutorsFactoryWithConfig(noop_executor.ExecutorConfig{
-					noop_executor.ExecutorConfigExternalHooks{
+					ExternalHooks: noop_executor.ExecutorConfigExternalHooks{
 						JobHandler: noop_executor.DelayedJobHandler(slowExecutorSleep),
 					},
 				}),

--- a/pkg/test/simulator/server_test.go
+++ b/pkg/test/simulator/server_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || !unit
 
 package simulator
 

--- a/pkg/test/simulator/server_test.go
+++ b/pkg/test/simulator/server_test.go
@@ -30,14 +30,7 @@ func (suite *SimulatorSuite) TestSimulatorSanity() {
 	nodeCount := 3
 	s := scenario.Scenario{
 		JobCheckers: scenario.WaitUntilSuccessful(3),
-		Spec: model.Spec{
-			Engine: model.EngineWasm,
-			Wasm: model.JobSpecWasm{
-				EntryPoint:  scenario.WasmHelloWorld.Spec.Wasm.EntryPoint,
-				EntryModule: scenario.WasmHelloWorld.Spec.Wasm.EntryModule,
-				Parameters:  []string{},
-			},
-		},
+		Spec:        scenario.WasmHelloWorld.Spec,
 		Deal: model.Deal{
 			Concurrency: 3,
 		},

--- a/pkg/transport/bprotocol/callback_handler.go
+++ b/pkg/transport/bprotocol/callback_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/rs/zerolog/log"
@@ -24,39 +25,30 @@ type CallbackHandler struct {
 	callback compute.Callback
 }
 
+type callbackHandler[Request any] func(context.Context, Request)
+
 func NewCallbackHandler(params CallbackHandlerParams) *CallbackHandler {
 	handler := &CallbackHandler{
 		host:     params.Host,
 		callback: params.Callback,
 	}
 
-	handler.host.SetStreamHandler(OnRunComplete, handler.onRunSuccess)
-	handler.host.SetStreamHandler(OnPublishComplete, handler.onPublishSuccess)
-	handler.host.SetStreamHandler(OnCancelComplete, handler.onCancelSuccess)
-	handler.host.SetStreamHandler(OnComputeFailure, handler.onComputeFailure)
+	host := handler.host
+	host.SetStreamHandler(OnBidComplete, handleCallback(host, handler.callback.OnBidComplete))
+	host.SetStreamHandler(OnRunComplete, handleCallback(host, handler.callback.OnRunComplete))
+	host.SetStreamHandler(OnPublishComplete, handleCallback(host, handler.callback.OnPublishComplete))
+	host.SetStreamHandler(OnCancelComplete, handleCallback(host, handler.callback.OnCancelComplete))
+	host.SetStreamHandler(OnComputeFailure, handleCallback(host, handler.callback.OnComputeFailure))
 	return handler
 }
 
-func (h *CallbackHandler) onRunSuccess(stream network.Stream) {
-	ctx := logger.ContextWithNodeIDLogger(context.Background(), h.host.ID().String())
-	handleCallbackStream[compute.RunResult](ctx, stream, h.callback.OnRunComplete)
-}
-func (h *CallbackHandler) onPublishSuccess(stream network.Stream) {
-	ctx := logger.ContextWithNodeIDLogger(context.Background(), h.host.ID().String())
-	handleCallbackStream[compute.PublishResult](ctx, stream, h.callback.OnPublishComplete)
+func handleCallback[Request any](host host.Host, f callbackHandler[Request]) func(network.Stream) {
+	return func(stream network.Stream) {
+		ctx := logger.ContextWithNodeIDLogger(context.Background(), host.ID().String())
+		handleCallbackStream(ctx, stream, f)
+	}
 }
 
-func (h *CallbackHandler) onCancelSuccess(stream network.Stream) {
-	ctx := logger.ContextWithNodeIDLogger(context.Background(), h.host.ID().String())
-	handleCallbackStream[compute.CancelResult](ctx, stream, h.callback.OnCancelComplete)
-}
-
-func (h *CallbackHandler) onComputeFailure(stream network.Stream) {
-	ctx := logger.ContextWithNodeIDLogger(context.Background(), h.host.ID().String())
-	handleCallbackStream[compute.ComputeError](ctx, stream, h.callback.OnComputeFailure)
-}
-
-//nolint:errcheck
 func handleCallbackStream[Request any](
 	ctx context.Context,
 	stream network.Stream,
@@ -75,7 +67,7 @@ func handleCallbackStream[Request any](
 		_ = stream.Reset()
 		return
 	}
-	defer stream.Close() //nolint:errcheck
+	defer closer.CloseWithLogOnError("stream", stream)
 
 	// TODO: validate which context to use here, and whether running in a goroutine is ok
 	newCtx := logger.ContextWithNodeIDLogger(context.Background(), stream.Conn().LocalPeer().String())

--- a/pkg/transport/bprotocol/callback_proxy.go
+++ b/pkg/transport/bprotocol/callback_proxy.go
@@ -41,6 +41,12 @@ func (p *CallbackProxy) RegisterLocalComputeCallback(callback compute.Callback) 
 	p.localCallback = callback
 }
 
+func (p *CallbackProxy) OnBidComplete(ctx context.Context, result compute.BidResult) {
+	proxyCallbackRequest(ctx, p, result.RoutingMetadata, OnBidComplete, result, func(ctx2 context.Context) {
+		p.localCallback.OnBidComplete(ctx2, result)
+	})
+}
+
 func (p *CallbackProxy) OnRunComplete(ctx context.Context, result compute.RunResult) {
 	proxyCallbackRequest(ctx, p, result.RoutingMetadata, OnRunComplete, result, func(ctx2 context.Context) {
 		p.localCallback.OnRunComplete(ctx2, result)
@@ -85,7 +91,7 @@ func proxyCallbackRequest(
 		targetPeerID := resultInfo.TargetPeerID
 		peerID, err := peer.Decode(targetPeerID)
 		if err != nil {
-			log.Ctx(ctx).Error().Err(errors.WithStack(err)).Msgf("%s: failed to decode peer ID %s", reflect.TypeOf(request), targetPeerID)
+			log.Ctx(ctx).Error().Err(errors.WithStack(err)).Msgf("%s: failed to decode peer ID %q", reflect.TypeOf(request), targetPeerID)
 			return
 		}
 

--- a/pkg/transport/bprotocol/compute_proxy.go
+++ b/pkg/transport/bprotocol/compute_proxy.go
@@ -15,7 +15,6 @@ import (
 type ComputeProxyParams struct {
 	Host          host.Host
 	LocalEndpoint compute.Endpoint // optional in case this host is also a compute node and to allow local calls
-
 }
 
 // ComputeProxy is a proxy to a compute node endpoint that will forward requests to remote compute nodes, or

--- a/pkg/transport/bprotocol/constants.go
+++ b/pkg/transport/bprotocol/constants.go
@@ -11,6 +11,7 @@ const (
 	ExecutionLogsID          = "/bacalhau/compute/executionlogs/1.0.0"
 
 	CallbackServiceName = "bacalhau.callback"
+	OnBidComplete       = "/bacalhau/callback/on_bid_complete/1.0.0"
 	OnRunComplete       = "/bacalhau/callback/on_run_complete/1.0.0"
 	OnPublishComplete   = "/bacalhau/callback/on_publish_complete/1.0.0"
 	OnCancelComplete    = "/bacalhau/callback/on_cancel_complete/1.0.0"

--- a/pkg/transport/simulator/callback_proxy.go
+++ b/pkg/transport/simulator/callback_proxy.go
@@ -44,6 +44,12 @@ func (p *CallbackProxy) RegisterLocalComputeCallback(callback compute.Callback) 
 	p.localCallback = callback
 }
 
+func (p *CallbackProxy) OnBidComplete(ctx context.Context, result compute.BidResult) {
+	proxyCallbackRequest(ctx, p, result.RoutingMetadata, bprotocol.OnBidComplete, result, func(ctx2 context.Context) {
+		p.localCallback.OnBidComplete(ctx2, result)
+	})
+}
+
 func (p *CallbackProxy) OnRunComplete(ctx context.Context, result compute.RunResult) {
 	proxyCallbackRequest(ctx, p, result.RoutingMetadata, bprotocol.OnRunComplete, result, func(ctx2 context.Context) {
 		p.localCallback.OnRunComplete(ctx2, result)


### PR DESCRIPTION
The compute node has always been able to call out to an external web hook as part of the bidding process but until now it has not been able to handle a waiting response and was required to respond to bids immediately. The compute node therefore had no need for a web callback once the job was moderated.

Now, the bid response is an asynchronous operation and the compute node can receive its own web callback. Compute nodes acknowledge that they have received a bid request but will respond to it in an async manner.

This allows compute nodes to exist in a separate trust domain from the requester node, because they can now have their own dashboard which will moderate jobs which can be separate from anything else.

Resolves #2290.