### PR TITLE
 Removes the result folder immediately after publish

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
@@ -190,6 +191,12 @@ func (e *BaseExecutor) Publish(ctx context.Context, execution store.Execution) (
 	})
 	if err != nil {
 		return
+	}
+
+	log.Ctx(ctx).Debug().Msgf("Cleaning up result folder for %s: %s", execution.ID, resultFolder)
+	err = os.RemoveAll(resultFolder)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msgf("failed to remove results folder at %s", resultFolder)
 	}
 
 	e.callback.OnPublishComplete(ctx, PublishResult{

--- a/pkg/verifier/deterministic/verifier.go
+++ b/pkg/verifier/deterministic/verifier.go
@@ -27,12 +27,6 @@ func NewDeterministicVerifier(
 		return nil, err
 	}
 
-	cm.RegisterCallback(func() error {
-		if err := results.Close(); err != nil {
-			return fmt.Errorf("unable to remove results folder: %w", err)
-		}
-		return nil
-	})
 	return &DeterministicVerifier{
 		results:   results,
 		encrypter: encrypter,

--- a/pkg/verifier/noop/verifier.go
+++ b/pkg/verifier/noop/verifier.go
@@ -2,7 +2,6 @@ package noop
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
@@ -39,12 +38,6 @@ func NewNoopVerifier(
 		return nil, err
 	}
 
-	cm.RegisterCallback(func() error {
-		if err := results.Close(); err != nil {
-			return fmt.Errorf("unable to remove results folder: %w", err)
-		}
-		return nil
-	})
 	return &NoopVerifier{
 		results: results,
 	}, nil

--- a/pkg/verifier/results/results.go
+++ b/pkg/verifier/results/results.go
@@ -42,5 +42,9 @@ func (results *Results) EnsureResultsDir(executionID string) (string, error) {
 }
 
 func (results *Results) Close() error {
+	if _, err := os.Stat(results.ResultsDir); os.IsNotExist(err) {
+		return nil
+	}
+
 	return os.RemoveAll(results.ResultsDir)
 }


### PR DESCRIPTION
Currently, the results folders are queued up the verifiers to cleanup
the folders when the node is shut down. This means that until then there
are a lot of unnecessary folders on disk.

To resolve this the code now deletes the results folder immediately
after publishing it to ensure the space is freed up immediately. The
previous cleanup callbacks are removed from the verifiers as they 
are no longer necessary.

Fixes #2202 