### PR TITLE
Ensure the minimum number of bids is reached before execution starts

### DIFF
--- a/pkg/bidstrategy/callback_bid_strategy.go
+++ b/pkg/bidstrategy/callback_bid_strategy.go
@@ -1,0 +1,28 @@
+package bidstrategy
+
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+)
+
+type CallbackBidStrategy struct {
+	OnShouldBid             func(context.Context, BidStrategyRequest) (BidStrategyResponse, error)
+	OnShouldBidBasedOnUsage func(context.Context, BidStrategyRequest, model.ResourceUsageData) (BidStrategyResponse, error)
+}
+
+// ShouldBid implements BidStrategy
+func (s *CallbackBidStrategy) ShouldBid(ctx context.Context, request BidStrategyRequest) (BidStrategyResponse, error) {
+	return s.OnShouldBid(ctx, request)
+}
+
+// ShouldBidBasedOnUsage implements BidStrategy
+func (s *CallbackBidStrategy) ShouldBidBasedOnUsage(
+	ctx context.Context,
+	request BidStrategyRequest,
+	resourceUsage model.ResourceUsageData,
+) (BidStrategyResponse, error) {
+	return s.OnShouldBidBasedOnUsage(ctx, request, resourceUsage)
+}
+
+var _ BidStrategy = (*CallbackBidStrategy)(nil)

--- a/pkg/bidstrategy/fixed_strategy.go
+++ b/pkg/bidstrategy/fixed_strategy.go
@@ -7,24 +7,14 @@ import (
 )
 
 // FixedBidStrategy is a bid strategy that always returns the same response, which is useful for testing
-type FixedBidStrategy struct {
-	Response bool
-	Wait     bool
-}
-
-// NewFixedBidStrategy creates a new FixedBidStrategy
-func NewFixedBidStrategy(response, wait bool) *FixedBidStrategy {
-	return &FixedBidStrategy{
-		Response: response,
-		Wait:     wait,
+func NewFixedBidStrategy(response, wait bool) *CallbackBidStrategy {
+	return &CallbackBidStrategy{
+		OnShouldBid: func(_ context.Context, _ BidStrategyRequest) (BidStrategyResponse, error) {
+			return BidStrategyResponse{ShouldBid: response, ShouldWait: wait}, nil
+		},
+		OnShouldBidBasedOnUsage: func(
+			context.Context, BidStrategyRequest, model.ResourceUsageData) (BidStrategyResponse, error) {
+			return BidStrategyResponse{ShouldBid: response, ShouldWait: wait}, nil
+		},
 	}
-}
-
-func (s *FixedBidStrategy) ShouldBid(_ context.Context, _ BidStrategyRequest) (BidStrategyResponse, error) {
-	return BidStrategyResponse{ShouldBid: s.Response, ShouldWait: s.Wait}, nil
-}
-
-func (s *FixedBidStrategy) ShouldBidBasedOnUsage(
-	context.Context, BidStrategyRequest, model.ResourceUsageData) (BidStrategyResponse, error) {
-	return BidStrategyResponse{ShouldBid: s.Response, ShouldWait: s.Wait}, nil
 }

--- a/pkg/model/execution_state.go
+++ b/pkg/model/execution_state.go
@@ -97,6 +97,9 @@ type ExecutionState struct {
 	ComputeReference string `json:"ComputeReference"`
 	// State is the current state of the execution
 	State ExecutionStateType `json:"State"`
+	// Set to true iff the compute node accepted the ask for a bid, and intends
+	// to run the job if the bid is accepted by the requester.
+	AcceptedAskForBid bool `json:"AcceptedAskForBid"`
 	// an arbitrary status message
 	Status string `json:"Status,omitempty"`
 	// the proposed results for this execution
@@ -125,8 +128,8 @@ func (e ExecutionState) String() string {
 	return e.ID().String()
 }
 
-// HasAcceptedAskForBid returns true if the execution has been accepted by the node
-// we rely on the value of the ExecutionID to determine if the askForBid has been accepted
+// HasAcceptedAskForBid returns true iff the compute node has accepted an ask
+// for bid, else returns false.
 func (e ExecutionState) HasAcceptedAskForBid() bool {
-	return e.ComputeReference != ""
+	return e.AcceptedAskForBid
 }

--- a/pkg/requester/scheduler.go
+++ b/pkg/requester/scheduler.go
@@ -393,8 +393,9 @@ func (s *BaseScheduler) OnBidComplete(ctx context.Context, response compute.BidR
 			ExpectedState: model.ExecutionStateAskForBid,
 		},
 		NewValues: model.ExecutionState{
-			State:  newState,
-			Status: response.Reason,
+			AcceptedAskForBid: response.Accepted,
+			State:             newState,
+			Status:            response.Reason,
 		},
 	})
 	if err != nil {

--- a/pkg/test/compute/async_bid_test.go
+++ b/pkg/test/compute/async_bid_test.go
@@ -16,7 +16,7 @@ import (
 type AsyncBidSuite struct {
 	ComputeSuite
 
-	strategy *bidstrategy.FixedBidStrategy
+	strategy *bidstrategy.CallbackBidStrategy
 }
 
 func TestAsyncBidSuite(t *testing.T) {
@@ -40,7 +40,9 @@ func (s *AsyncBidSuite) TestAsyncReject() {
 func (s *AsyncBidSuite) runAsyncBidTest(response bool) {
 	job := generateJob()
 
-	s.strategy.Response = response
+	s.strategy.OnShouldBid = func(ctx context.Context, bsr bidstrategy.BidStrategyRequest) (bidstrategy.BidStrategyResponse, error) {
+		return bidstrategy.BidStrategyResponse{ShouldBid: response, ShouldWait: true}, nil
+	}
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/test/devstack/min_bids_test.go
+++ b/pkg/test/devstack/min_bids_test.go
@@ -3,9 +3,15 @@
 package devstack
 
 import (
+	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
+	"github.com/bacalhau-project/bacalhau/pkg/node"
+	"github.com/bacalhau-project/bacalhau/pkg/requester/retry"
 
 	"github.com/bacalhau-project/bacalhau/pkg/job"
 	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
@@ -28,23 +34,42 @@ type minBidsTestCase struct {
 	nodes          int
 	concurrency    int
 	minBids        int
+	errorNodes     uint32
 	expectedResult map[model.ExecutionStateType]int
 	submitChecker  scenario.CheckSubmitResponse
 	errorStates    []model.ExecutionStateType
 }
 
 func (s *MinBidsSuite) testMinBids(testCase minBidsTestCase) {
-	spec := scenario.WasmHelloWorld.Spec
+	responses := atomic.Uint32{}
+	computeConfig := node.DefaultComputeConfig
+	computeConfig.BidStrategy = &bidstrategy.CallbackBidStrategy{
+		OnShouldBid: func(ctx context.Context, bsr bidstrategy.BidStrategyRequest) (r bidstrategy.BidStrategyResponse, err error) {
+			r = bidstrategy.NewShouldBidResponse()
+			if num := responses.Add(1); num <= testCase.errorNodes {
+				s.T().Logf("Node ID %s will return an error response", bsr.NodeID)
+				err = fmt.Errorf("bad response")
+			}
+			return
+		},
+		OnShouldBidBasedOnUsage: func(ctx context.Context, bsr bidstrategy.BidStrategyRequest, rud model.ResourceUsageData) (bidstrategy.BidStrategyResponse, error) {
+			return bidstrategy.NewShouldBidResponse(), nil
+		},
+	}
+
+	// We have to turn off retries for this test so that we can check what
+	// happens when not enough bids are received If retries are switched on, the
+	// requester will just try again and receive an adequate number of bids
+	requesterConfig := node.DefaultRequesterConfig
+	requesterConfig.RetryStrategy = retry.NewFixedStrategy(retry.FixedStrategyParams{ShouldRetry: false})
 
 	testScenario := scenario.Scenario{
 		Stack: &scenario.StackConfig{
 			DevStackOptions: &devstack.DevStackOptions{NumberOfHybridNodes: testCase.nodes},
+			ComputeConfig:   node.NewComputeConfigWith(computeConfig),
+			RequesterConfig: node.NewRequesterConfigWith(requesterConfig),
 		},
-		Inputs: scenario.StoredFile(
-			prepareFolderWithFiles(s.T(), 1),
-			"/input",
-		),
-		Spec: spec,
+		Spec: scenario.WasmHelloWorld.Spec,
 		Deal: model.Deal{
 			Concurrency: testCase.concurrency,
 			MinBids:     testCase.minBids,
@@ -59,7 +84,7 @@ func (s *MinBidsSuite) testMinBids(testCase minBidsTestCase) {
 	s.RunScenario(testScenario)
 }
 
-func (s *MinBidsSuite) TestMinBids_0and1Node() {
+func (s *MinBidsSuite) Test0and1Node() {
 	// sanity test that with min bids at zero and 1 node we get the job through
 	s.testMinBids(minBidsTestCase{
 		nodes:       1,
@@ -74,7 +99,40 @@ func (s *MinBidsSuite) TestMinBids_0and1Node() {
 	})
 }
 
-func (s *MinBidsSuite) TestMinBids_isConcurrency() {
+func (s *MinBidsSuite) Test1and3Node() {
+	// sanity test that with min bids at number of nodes, all nodes receive a bid response
+	s.testMinBids(minBidsTestCase{
+		nodes:       3,
+		concurrency: 1,
+		minBids:     3,
+		expectedResult: map[model.ExecutionStateType]int{
+			model.ExecutionStateCompleted:   1,
+			model.ExecutionStateBidRejected: 2,
+		},
+		errorStates: []model.ExecutionStateType{
+			model.ExecutionStateFailed,
+		},
+	})
+}
+
+func (s *MinBidsSuite) TestCancelsJobIfNotEnoughBids() {
+	// test that when we have min bids and enough nodes fail to respond, we don't run
+	s.testMinBids(minBidsTestCase{
+		nodes:       3,
+		errorNodes:  2,
+		concurrency: 1,
+		minBids:     2,
+		expectedResult: map[model.ExecutionStateType]int{
+			model.ExecutionStateCanceled: 1,
+			model.ExecutionStateFailed:   2,
+		},
+		errorStates: []model.ExecutionStateType{
+			model.ExecutionStateCompleted,
+		},
+	})
+}
+
+func (s *MinBidsSuite) TestAtConcurrency() {
 	// test that when min bids is concurrency we get the job through
 	s.testMinBids(minBidsTestCase{
 		nodes:       3,
@@ -90,7 +148,7 @@ func (s *MinBidsSuite) TestMinBids_isConcurrency() {
 
 }
 
-func (s *MinBidsSuite) TestMinBids_noBids() {
+func (s *MinBidsSuite) TestNoBidsWhenNetworkTooSmall() {
 	// test that no bids are made because there are not enough nodes on the network
 	// to satisfy the min bids
 	s.testMinBids(minBidsTestCase{

--- a/pkg/test/logstream/stream_address_test.go
+++ b/pkg/test/logstream/stream_address_test.go
@@ -42,10 +42,11 @@ func (s *LogStreamTestSuite) TestStreamAddress() {
 
 	node.ComputeNode.ExecutionStore.CreateExecution(s.ctx, execution)
 	err = node.RequesterNode.JobStore.CreateExecution(s.ctx, model.ExecutionState{
-		State:            model.ExecutionStateBidAccepted,
-		JobID:            job.ID(),
-		ComputeReference: execution.ID,
-		NodeID:           node.Host.ID().Pretty(),
+		State:             model.ExecutionStateBidAccepted,
+		JobID:             job.ID(),
+		ComputeReference:  execution.ID,
+		AcceptedAskForBid: true,
+		NodeID:            node.Host.ID().Pretty(),
 	})
 	require.NoError(s.T(), err)
 

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -164,32 +164,32 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) (resultsDir string) {
 	s.Require().NoError(err)
 
 	// Check outputs
-	s.T().Log("Checking output")
-	results, err := apiClient.GetResults(s.Ctx, submittedJob.Metadata.ID)
-	s.Require().NoError(err)
-
-	resultsDir = s.T().TempDir()
-	swarmAddresses, err := stack.Nodes[0].IPFSClient.SwarmAddresses(s.Ctx)
-	s.Require().NoError(err)
-
-	downloaderSettings := &model.DownloaderSettings{
-		Timeout:        time.Second * 10,
-		OutputDir:      resultsDir,
-		IPFSSwarmAddrs: strings.Join(swarmAddresses, ","),
-		LocalIPFS:      true,
-	}
-
-	ipfsDownloader := ipfs.NewIPFSDownloader(cm, downloaderSettings)
-	s.Require().NoError(err)
-
-	downloaderProvider := model.NewMappedProvider(map[model.StorageSourceType]downloader.Downloader{
-		model.StorageSourceIPFS: ipfsDownloader,
-	})
-
-	err = downloader.DownloadResults(s.Ctx, results, downloaderProvider, downloaderSettings)
-	s.Require().NoError(err)
-
 	if scenario.ResultsChecker != nil {
+		s.T().Log("Checking output")
+		results, err := apiClient.GetResults(s.Ctx, submittedJob.Metadata.ID)
+		s.Require().NoError(err)
+
+		resultsDir = s.T().TempDir()
+		swarmAddresses, err := stack.Nodes[0].IPFSClient.SwarmAddresses(s.Ctx)
+		s.Require().NoError(err)
+
+		downloaderSettings := &model.DownloaderSettings{
+			Timeout:        time.Second * 10,
+			OutputDir:      resultsDir,
+			IPFSSwarmAddrs: strings.Join(swarmAddresses, ","),
+			LocalIPFS:      true,
+		}
+
+		ipfsDownloader := ipfs.NewIPFSDownloader(cm, downloaderSettings)
+		s.Require().NoError(err)
+
+		downloaderProvider := model.NewMappedProvider(map[model.StorageSourceType]downloader.Downloader{
+			model.StorageSourceIPFS: ipfsDownloader,
+		})
+
+		err = downloader.DownloadResults(s.Ctx, results, downloaderProvider, downloaderSettings)
+		s.Require().NoError(err)
+
 		err = scenario.ResultsChecker(resultsDir)
 		s.Require().NoError(err)
 	}


### PR DESCRIPTION
Due to a bug introduced in `e866a9`, the requester node was no longer able to remember if it had received enough accepted bids and assumed that any execution it knew about was accepted.

This commit restores the ability of the requester to remember bid responses and adds a test that ensures the requester cannot start the job until the min bid threshold has been reached, including that it cancels the job if necessary.

Uses a solution from @frrist discussed in #2261.