### PR TITLE
Allow network traffic to RPC Endpoints (Polygon, Ethereum, Binance, and Filecoin)

### DIFF
--- a/ops/terraform/remote_files/scripts/http-domain-allowlist.txt
+++ b/ops/terraform/remote_files/scripts/http-domain-allowlist.txt
@@ -120,3 +120,9 @@ scheduler.einsteinathome.org
 einstein.phys.uwm.edu
 einstein-dl.syr.edu
 .aei.uni-hannover.de
+
+# RPC Endpoints
+polygon-rpc.com
+eth.public-rpc.com
+bscrpc.com
+filecoin.public-rpc.com


### PR DESCRIPTION
Enable network traffic to RPC endpoints on Polygon, Ethereum, Binance, and Filecoin networks to allow containers to access on-chain information for use cases like chain analysis and oracles.