### PR TITLE
Update path when generating swagger-docs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,10 +478,14 @@ jobs:
       - run:
           name: Install Swagger
           command:
+            export GOBIN=${HOME}/bin
+            export PATH=$GOBIN:$PATH
             go install github.com/swaggo/swag/cmd/swag@v1.8.10
       - run:
           name: Build Swagger Docs
           command:
+            export GOBIN=${HOME}/bin
+            export PATH=$GOBIN:$PATH
             make swagger-docs
       - persist_to_workspace:
           root: docs


### PR DESCRIPTION
Currently swag sometimes is not found after is has been `go install`ed and so this commit will ensure it is installed into a known location that is in the path.