### PR TITLE
Allows bprotocol to process errors with responses 

### DIFF
--- a/pkg/transport/bprotocol/compute_handler_test.go
+++ b/pkg/transport/bprotocol/compute_handler_test.go
@@ -5,7 +5,6 @@ package bprotocol
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
@@ -80,10 +79,9 @@ func (s *ComputeProxyTestSuite) getRoutingMetadataForCompute() compute.RoutingMe
 }
 
 func (s *ComputeProxyTestSuite) TestSimpleRequest() {
-	response, err := s.proxy.AskForBid(s.ctx, compute.AskForBidRequest{
+	_, err := s.proxy.AskForBid(s.ctx, compute.AskForBidRequest{
 		RoutingMetadata: s.getRoutingMetadataForCompute(),
 	})
 
-	require.NoError(s.T(), err)
-	fmt.Printf("%+v\n", response)
+	require.Error(s.T(), err)
 }

--- a/pkg/transport/bprotocol/compute_handler_test.go
+++ b/pkg/transport/bprotocol/compute_handler_test.go
@@ -45,10 +45,10 @@ func (s *ComputeProxyTestSuite) SetupSuite() {
 type TestEndpoint struct{}
 
 func (t *TestEndpoint) AskForBid(context.Context, compute.AskForBidRequest) (compute.AskForBidResponse, error) {
-	return compute.AskForBidResponse{}, errors.New("No test implemenation")
+	return compute.AskForBidResponse{}, errors.New("error raised by AskForBid")
 }
 func (t *TestEndpoint) BidAccepted(context.Context, compute.BidAcceptedRequest) (compute.BidAcceptedResponse, error) {
-	return compute.BidAcceptedResponse{}, errors.New("No test implemenation")
+	return compute.BidAcceptedResponse{ExecutionMetadata: compute.ExecutionMetadata{ExecutionID: "test"}}, nil
 }
 func (t *TestEndpoint) BidRejected(context.Context, compute.BidRejectedRequest) (compute.BidRejectedResponse, error) {
 	return compute.BidRejectedResponse{}, errors.New("No test implemenation")
@@ -78,10 +78,22 @@ func (s *ComputeProxyTestSuite) getRoutingMetadataForCompute() compute.RoutingMe
 	}
 }
 
-func (s *ComputeProxyTestSuite) TestSimpleRequest() {
+func (s *ComputeProxyTestSuite) TestSimpleError() {
 	_, err := s.proxy.AskForBid(s.ctx, compute.AskForBidRequest{
 		RoutingMetadata: s.getRoutingMetadataForCompute(),
 	})
 
 	require.Error(s.T(), err)
+	require.Equal(s.T(), "error raised by AskForBid", err.Error())
+}
+
+func (s *ComputeProxyTestSuite) TestSimpleSuccess() {
+	response, err := s.proxy.BidAccepted(s.ctx, compute.BidAcceptedRequest{
+		RoutingMetadata: s.getRoutingMetadataForCompute(),
+	})
+
+	// Expect a BidAcceptedResponse, err result.
+
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "test", response.ExecutionID)
 }

--- a/pkg/transport/bprotocol/compute_handler_test.go
+++ b/pkg/transport/bprotocol/compute_handler_test.go
@@ -1,0 +1,89 @@
+//go:build unit || !integration
+
+package bprotocol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ComputeProxyTestSuite struct {
+	suite.Suite
+	ctx     context.Context
+	handler *ComputeHandler
+	proxy   *ComputeProxy
+}
+
+func TestComputeProxyTestSuite(t *testing.T) {
+	suite.Run(t, new(ComputeProxyTestSuite))
+}
+
+func (s *ComputeProxyTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+
+	computeNode, err := libp2p.NewHostForTest(s.ctx)
+	require.NoError(s.T(), err)
+
+	proxyNode, err := libp2p.NewHostForTest(s.ctx, computeNode)
+	require.NoError(s.T(), err)
+
+	s.handler = NewComputeHandler(ComputeHandlerParams{
+		Host:            computeNode,
+		ComputeEndpoint: &TestEndpoint{},
+	})
+	s.proxy = NewComputeProxy(ComputeProxyParams{
+		Host: proxyNode,
+	})
+}
+
+type TestEndpoint struct{}
+
+func (t *TestEndpoint) AskForBid(context.Context, compute.AskForBidRequest) (compute.AskForBidResponse, error) {
+	return compute.AskForBidResponse{}, errors.New("No test implemenation")
+}
+func (t *TestEndpoint) BidAccepted(context.Context, compute.BidAcceptedRequest) (compute.BidAcceptedResponse, error) {
+	return compute.BidAcceptedResponse{}, errors.New("No test implemenation")
+}
+func (t *TestEndpoint) BidRejected(context.Context, compute.BidRejectedRequest) (compute.BidRejectedResponse, error) {
+	return compute.BidRejectedResponse{}, errors.New("No test implemenation")
+}
+func (t *TestEndpoint) ResultAccepted(context.Context, compute.ResultAcceptedRequest) (compute.ResultAcceptedResponse, error) {
+	return compute.ResultAcceptedResponse{}, errors.New("No test implemenation")
+}
+func (t *TestEndpoint) ResultRejected(context.Context, compute.ResultRejectedRequest) (compute.ResultRejectedResponse, error) {
+	return compute.ResultRejectedResponse{}, errors.New("No test implemenation")
+}
+func (t *TestEndpoint) CancelExecution(context.Context, compute.CancelExecutionRequest) (compute.CancelExecutionResponse, error) {
+	return compute.CancelExecutionResponse{}, errors.New("No test implemenation")
+}
+func (t *TestEndpoint) ExecutionLogs(context.Context, compute.ExecutionLogsRequest) (compute.ExecutionLogsResponse, error) {
+	return compute.ExecutionLogsResponse{}, errors.New("No test implemenation")
+}
+
+func (s *ComputeProxyTestSuite) TeardownSuite() {
+	s.proxy.host.Close()
+}
+
+// Gets the metadata for calling the compute node of the test
+func (s *ComputeProxyTestSuite) getRoutingMetadataForCompute() compute.RoutingMetadata {
+	return compute.RoutingMetadata{
+		SourcePeerID: s.proxy.host.ID().Pretty(),
+		TargetPeerID: s.handler.host.ID().Pretty(),
+	}
+}
+
+func (s *ComputeProxyTestSuite) TestSimpleRequest() {
+	response, err := s.proxy.AskForBid(s.ctx, compute.AskForBidRequest{
+		RoutingMetadata: s.getRoutingMetadataForCompute(),
+	})
+
+	require.NoError(s.T(), err)
+	fmt.Printf("%+v\n", response)
+}

--- a/pkg/transport/bprotocol/types.go
+++ b/pkg/transport/bprotocol/types.go
@@ -1,0 +1,6 @@
+package bprotocol
+
+type Result[T any] struct {
+	Response T
+	Error    string
+}

--- a/pkg/transport/bprotocol/types.go
+++ b/pkg/transport/bprotocol/types.go
@@ -1,6 +1,18 @@
 package bprotocol
 
+import "errors"
+
 type Result[T any] struct {
 	Response T
 	Error    string
+}
+
+func (r *Result[T]) Rehydrate() (T, error) {
+	var e error = nil
+
+	if r.Error != "" {
+		e = errors.New(r.Error)
+	}
+
+	return r.Response, e
 }


### PR DESCRIPTION
Currently the compute node end of the bprotocol is unable to return
errors to the requester node, resulting in the requester node generating
errors about decoding the request object.

What we want to happen is to allow the Compute Proxy (and the Callback
Proxy) to receive errors from the other process, so that we can log
useful error messages in the requester.

Should resolve #2371 