### PR TITLE
Make log-follower wait for container to exist

### DIFF
--- a/pkg/compute/logstream/server.go
+++ b/pkg/compute/logstream/server.go
@@ -111,6 +111,13 @@ func (s *LogStreamServer) Handle(stream network.Stream) {
 		return
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			log.Ctx(s.ctx).Error().Msgf("source stream went away when sending logs to client")
+			_ = stream.Reset()
+		}
+	}()
+
 	_, err = io.Copy(stream, reader)
 	if err != nil {
 		log.Ctx(s.ctx).Error().Msgf("problem reading from executor streams: %s", err)


### PR DESCRIPTION
It's possible to follow the logs on an execution that has not actually started running yet (it's pre-processing things), and so attempts to follow the log fail in unfortunate ways.

This PR introduces a flag (channel) that is used to mark, within the docker executor, that the container actually exists. Any requests to follow the logs will block waiting for the container to be created.

An issue remains, if the container is created and immediately causes an error, it can be at the end of it's lifetime (and cleaning up) leaving the log streaming trying to read from a non-existent source when following a 'docker run'.  In these cases running the logs command will show the output (with the usual caveat about completed tasks).