### PR TITLE
Allow the simulator to return errors more gracefully too

### DIFF
--- a/pkg/transport/simulator/compute_proxy.go
+++ b/pkg/transport/simulator/compute_proxy.go
@@ -159,14 +159,17 @@ func proxyRequest[Request any, Response any](
 		return *response, fmt.Errorf("%s: failed to write request to peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
 
-	// Now we read the response that was sent from the dest peer
-	err = json.NewDecoder(stream).Decode(response)
+	// The handler will have wrapped the response in a Result[T] along with
+	// any error that occurred, so we will decode it and pass the
+	// inner response/error on to the caller.
+	result := &bprotocol.Result[Response]{}
+	err = json.NewDecoder(stream).Decode(result)
 	if err != nil {
 		_ = stream.Reset()
 		return *response, fmt.Errorf("%s: failed to decode response from peer %s: %w", reflect.TypeOf(request), destPeerID, err)
 	}
 
-	return *response, nil
+	return result.Rehydrate()
 }
 
 // Compile-time interface check:


### PR DESCRIPTION
Although the standard compute_proxy is able to handle errors returned by a compute node, the simulator one does not.