### PR TITLE
Improve performance of wasm logging

### DIFF
--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -143,6 +143,7 @@ func (e *Executor) makeFsFromStorage(ctx context.Context, jobResultsDir string, 
 	return rootFs, nil
 }
 
+//nolint:funlen
 func (e *Executor) Run(ctx context.Context, executionID string, job model.Job, jobResultsDir string) (*model.RunCommandResult, error) {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.Executor.Run")
 	defer span.End()
@@ -237,6 +238,7 @@ func (e *Executor) Run(ctx context.Context, executionID string, job model.Job, j
 	entryFunc := instance.ExportedFunction(job.Spec.Wasm.EntryPoint)
 	exitCode := -1
 	_, wasmErr := entryFunc.Call(ctx)
+
 	var errExit *sys.ExitError
 	if errors.As(wasmErr, &errExit) {
 		exitCode = int(errExit.ExitCode())
@@ -248,7 +250,6 @@ func (e *Executor) Run(ctx context.Context, executionID string, job model.Job, j
 	logs.Drain()
 
 	stdoutReader, stderrReader := logs.GetDefaultReaders(false)
-
 	return executor.WriteJobResults(jobResultsDir, stdoutReader, stderrReader, exitCode, wasmErr)
 }
 

--- a/pkg/logger/wasm/logreader.go
+++ b/pkg/logger/wasm/logreader.go
@@ -136,7 +136,9 @@ func (r *LogReader) readFile(b []byte) (int, error) {
 		}
 
 		// It's possible the caller wants a different transforms of the
-		// LogMessage than returning the message data.
+		// LogMessage than just returning the message data. If we were
+		// given one of those functions, use it to transform the data
+		// into a format we want.
 		if r.rawMessageTransformer != nil {
 			data := r.rawMessageTransformer(&msg)
 			copied := copy(b, data)

--- a/pkg/logger/wasm/logwriter.go
+++ b/pkg/logger/wasm/logwriter.go
@@ -1,8 +1,6 @@
 package wasmlogs
 
-import (
-	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
-)
+import "github.com/bacalhau-project/bacalhau/pkg/util/generic"
 
 type LogWriterTransform func([]byte) *LogMessage
 
@@ -12,11 +10,11 @@ type LogWriter struct {
 }
 
 func NewLogWriter(
-	b *generic.RingBuffer[*LogMessage],
+	buffer *generic.RingBuffer[*LogMessage],
 	transformer LogWriterTransform,
 ) *LogWriter {
 	return &LogWriter{
-		buffer:      b,
+		buffer:      buffer,
 		transformer: transformer,
 	}
 }
@@ -25,4 +23,8 @@ func (w *LogWriter) Write(b []byte) (int, error) {
 	transformed := w.transformer(b)
 	w.buffer.Enqueue(transformed)
 	return len(b), nil
+}
+
+func (w *LogWriter) Close() error {
+	return nil
 }

--- a/pkg/util/generic/ringbuffer.go
+++ b/pkg/util/generic/ringbuffer.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-const DefaultRingBufferSize = 8192
+const DefaultRingBufferSize = 16384
 
 type RingBuffer[T any] struct {
 	writeR     *ring.Ring
@@ -63,6 +63,9 @@ func (r *RingBuffer[T]) Dequeue() T {
 }
 
 func (r *RingBuffer[T]) Drain() []T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	count := r.wroteCount - r.readCount
 	if count <= 0 {
 		return nil


### PR DESCRIPTION
Improves the performance of the webassembly logging by ensuring that the ring buffer is large enough, ensuring that we sync the file to disk before it is consumed, and removing unnecessary json marshalling in favour of a simpler sprintf.