### PR TITLE
Add dashes in name and memory of the GPUs

### DIFF
--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -499,9 +499,11 @@ func AutoOutputLabels() map[string]string {
 		gpuNames, gpuMemory := gpuList()
 		// Print the GPU names
 		for i, name := range gpuNames {
+			name = strings.Replace(name, " ", "-", -1) // Replace spaces with dashes
 			key := fmt.Sprintf("GPU-%d", i)
 			m[key] = name
 			key = fmt.Sprintf("GPU-%d-Memory", i)
+			memory := strings.Replace(gpuMemory[i], " ", "-", -1) // Replace spaces with dashes
 			m[key] = gpuMemory[i]
 		}
 	}


### PR DESCRIPTION
The GPU name and the memory value doesn't get parsed when there is " " in between the GPU name

For Example GPU name is Tesla T4 this gets parsed as only Tesla If we add "-" instead of spaces it will get parsed in the client