### PR TITLE
Show Client ID in `bacalhau id` output

### DIFF
--- a/cmd/bacalhau/id.go
+++ b/cmd/bacalhau/id.go
@@ -5,11 +5,13 @@ import (
 	"os"
 
 	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/spf13/cobra"
 )
 
 type IDInfo struct {
-	ID string `json:"ID"`
+	ID       string `json:"ID"`
+	ClientID string `json:"ClientID"`
 }
 
 func newIDCmd() *cobra.Command {
@@ -39,7 +41,8 @@ func id(_ *cobra.Command, OS *ServeOptions) error {
 	}
 
 	info := IDInfo{
-		ID: libp2pHost.ID().String(),
+		ID:       libp2pHost.ID().String(),
+		ClientID: system.GetClientID(),
 	}
 	_ = libp2pHost.Close()
 


### PR DESCRIPTION
The client id is currently useful as a persistent ID associated with every client, and is used for things like authorisation and stats tracking. Previously, the only way to learn one's client ID was to submit a job to the network and get it back with `bacalhau describe`. Now, the client id is included in output from `bacalhau id`.