### PR TITLE
Ensure all nodes have announced before running devstack tests

### DIFF
--- a/pkg/model/nodeinfo.go
+++ b/pkg/model/nodeinfo.go
@@ -26,7 +26,7 @@ type NodeInfo struct {
 	PeerInfo        peer.AddrInfo     `json:"PeerInfo"`
 	NodeType        NodeType          `json:"NodeType"`
 	Labels          map[string]string `json:"Labels"`
-	ComputeNodeInfo ComputeNodeInfo   `json:"ComputeNodeInfo"`
+	ComputeNodeInfo *ComputeNodeInfo  `json:"ComputeNodeInfo"`
 }
 
 // IsComputeNode returns true if the node is a compute node

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -36,6 +36,7 @@ type Requester struct {
 	// Visible for testing
 	Endpoint           requester.Endpoint
 	JobStore           jobstore.Store
+	NodeDiscoverer     requester.NodeDiscoverer
 	computeProxy       *bprotocol.ComputeProxy
 	localCallback      compute.Callback
 	requesterAPIServer *requester_publicapi.RequesterAPIServer
@@ -190,7 +191,9 @@ func NewRequesterNode(
 	}
 
 	// register debug info providers for the /debug endpoint
-	debugInfoProviders := []model.DebugInfoProvider{}
+	debugInfoProviders := []model.DebugInfoProvider{
+		discovery.NewDebugInfoProvider(nodeDiscoveryChain),
+	}
 
 	// register requester public http apis
 	requesterAPIServer := requester_publicapi.NewRequesterAPIServer(requester_publicapi.RequesterAPIServerParams{
@@ -265,6 +268,7 @@ func NewRequesterNode(
 	return &Requester{
 		Endpoint:           endpoint,
 		localCallback:      scheduler,
+		NodeDiscoverer:     nodeDiscoveryChain,
 		JobStore:           jobStore,
 		computeProxy:       standardComputeProxy,
 		cleanupFunc:        cleanupFunc,

--- a/pkg/requester/discovery/chained.go
+++ b/pkg/requester/discovery/chained.go
@@ -35,7 +35,10 @@ func (c *Chain) ListNodes(ctx context.Context) ([]model.NodeInfo, error) {
 	return c.ChainDiscovery(ctx, func(r requester.NodeDiscoverer) ([]model.NodeInfo, error) { return r.ListNodes(ctx) })
 }
 
-func (c *Chain) ChainDiscovery(ctx context.Context, getNodes func(requester.NodeDiscoverer) ([]model.NodeInfo, error)) ([]model.NodeInfo, error) {
+func (c *Chain) ChainDiscovery(
+	ctx context.Context,
+	getNodes func(requester.NodeDiscoverer) ([]model.NodeInfo, error),
+) ([]model.NodeInfo, error) {
 	var err error
 	uniqueNodes := make(map[peer.ID]model.NodeInfo, 0)
 	for _, discoverer := range c.discoverers {

--- a/pkg/requester/discovery/chained.go
+++ b/pkg/requester/discovery/chained.go
@@ -2,12 +2,14 @@ package discovery
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/requester"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 )
 
 type Chain struct {
@@ -26,29 +28,34 @@ func (c *Chain) Add(discoverer ...requester.NodeDiscoverer) {
 }
 
 func (c *Chain) FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo, error) {
+	return c.ChainDiscovery(ctx, func(r requester.NodeDiscoverer) ([]model.NodeInfo, error) { return r.FindNodes(ctx, job) })
+}
+
+func (c *Chain) ListNodes(ctx context.Context) ([]model.NodeInfo, error) {
+	return c.ChainDiscovery(ctx, func(r requester.NodeDiscoverer) ([]model.NodeInfo, error) { return r.ListNodes(ctx) })
+}
+
+func (c *Chain) ChainDiscovery(ctx context.Context, getNodes func(requester.NodeDiscoverer) ([]model.NodeInfo, error)) ([]model.NodeInfo, error) {
+	var err error
 	uniqueNodes := make(map[peer.ID]model.NodeInfo, 0)
 	for _, discoverer := range c.discoverers {
-		nodeInfos, err := discoverer.FindNodes(ctx, job)
-		if err != nil {
-			if !c.ignoreErrors {
-				return nil, err
-			} else {
-				log.Ctx(ctx).Warn().Err(err).Msgf("ignoring error finding nodes by %s", reflect.TypeOf(discoverer))
-			}
-		}
+		nodeInfos, discoverErr := getNodes(discoverer)
+		err = multierr.Append(err, errors.Wrapf(discoverErr, "error finding nodes from %T", discoverer))
 		currentNodesCount := len(uniqueNodes)
 		for _, nodeInfo := range nodeInfos {
 			if _, ok := uniqueNodes[nodeInfo.PeerInfo.ID]; !ok {
 				uniqueNodes[nodeInfo.PeerInfo.ID] = nodeInfo
 			}
 		}
-		log.Ctx(ctx).Debug().Msgf("found %d more nodes by %s", len(uniqueNodes)-currentNodesCount, reflect.TypeOf(discoverer))
+		log.Ctx(ctx).Debug().Msgf("found %d more nodes by %T", len(uniqueNodes)-currentNodesCount, discoverer)
 	}
-	nodeInfos := make([]model.NodeInfo, 0, len(uniqueNodes))
-	for _, nodeInfo := range uniqueNodes {
-		nodeInfos = append(nodeInfos, nodeInfo)
+
+	if err != nil && c.ignoreErrors {
+		log.Ctx(ctx).Warn().Err(err).Msg("ignoring error finding nodes")
+		err = nil
 	}
-	return nodeInfos, nil
+
+	return maps.Values(uniqueNodes), err
 }
 
 // compile-time interface assertions

--- a/pkg/requester/discovery/chained_test.go
+++ b/pkg/requester/discovery/chained_test.go
@@ -57,9 +57,8 @@ func (s *ChainedSuite) TestHandle_Error() {
 	s.chain.Add(newFixedDiscoverer(s.peerID1, s.peerID2))
 	s.chain.Add(newBadDiscoverer())
 	s.chain.Add(newFixedDiscoverer(s.peerID3))
-	peerIDs, err := s.chain.FindNodes(context.Background(), model.Job{})
+	_, err := s.chain.FindNodes(context.Background(), model.Job{})
 	s.Error(err)
-	s.Empty(peerIDs)
 }
 
 func (s *ChainedSuite) TestHandle_IgnoreError() {

--- a/pkg/requester/discovery/chained_test.go
+++ b/pkg/requester/discovery/chained_test.go
@@ -88,6 +88,10 @@ func (f *fixedDiscoverer) FindNodes(context.Context, model.Job) ([]model.NodeInf
 	return f.peerIDs, nil
 }
 
+func (f *fixedDiscoverer) ListNodes(context.Context) ([]model.NodeInfo, error) {
+	return f.peerIDs, nil
+}
+
 // node discoverer that always returns an error
 type badDiscoverer struct{}
 
@@ -96,5 +100,9 @@ func newBadDiscoverer() *badDiscoverer {
 }
 
 func (b *badDiscoverer) FindNodes(context.Context, model.Job) ([]model.NodeInfo, error) {
+	return nil, errors.New("bad discoverer")
+}
+
+func (b *badDiscoverer) ListNodes(context.Context) ([]model.NodeInfo, error) {
 	return nil, errors.New("bad discoverer")
 }

--- a/pkg/requester/discovery/identity.go
+++ b/pkg/requester/discovery/identity.go
@@ -25,7 +25,7 @@ func NewIdentityNodeDiscoverer(params IdentityNodeDiscovererParams) *IdentityNod
 	}
 }
 
-func (d *IdentityNodeDiscoverer) FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo, error) {
+func (d *IdentityNodeDiscoverer) ListNodes(ctx context.Context) ([]model.NodeInfo, error) {
 	var peers []peer.ID
 
 	// check local protocols in case the current node is also a compute node
@@ -59,6 +59,11 @@ func (d *IdentityNodeDiscoverer) FindNodes(ctx context.Context, job model.Job) (
 		}
 	}
 	return nodeInfos, nil
+}
+
+// ListNodes implements requester.NodeDiscoverer
+func (d *IdentityNodeDiscoverer) FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo, error) {
+	return d.ListNodes(ctx)
 }
 
 // compile time check that IdentityNodeDiscoverer implements NodeDiscoverer

--- a/pkg/requester/discovery/identity.go
+++ b/pkg/requester/discovery/identity.go
@@ -55,7 +55,7 @@ func (d *IdentityNodeDiscoverer) ListNodes(ctx context.Context) ([]model.NodeInf
 		nodeInfos[i] = model.NodeInfo{
 			PeerInfo:        d.host.Peerstore().PeerInfo(peerID),
 			NodeType:        model.NodeTypeCompute,
-			ComputeNodeInfo: model.ComputeNodeInfo{},
+			ComputeNodeInfo: nil,
 		}
 	}
 	return nodeInfos, nil

--- a/pkg/requester/discovery/info_provider.go
+++ b/pkg/requester/discovery/info_provider.go
@@ -1,0 +1,26 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/requester"
+)
+
+type discoveredNodesProvider struct {
+	discoverer requester.NodeDiscoverer
+}
+
+func NewDebugInfoProvider(discoverer requester.NodeDiscoverer) model.DebugInfoProvider {
+	return &discoveredNodesProvider{discoverer: discoverer}
+}
+
+// GetDebugInfo implements model.DebugInfoProvider
+func (p *discoveredNodesProvider) GetDebugInfo(ctx context.Context) (info model.DebugInfo, err error) {
+	nodes, err := p.discoverer.ListNodes(ctx)
+	info.Component = "DiscoveredNodes"
+	info.Info = nodes
+	return info, err
+}
+
+var _ model.DebugInfoProvider = (*discoveredNodesProvider)(nil)

--- a/pkg/requester/discovery/store.go
+++ b/pkg/requester/discovery/store.go
@@ -28,5 +28,10 @@ func (d *StoreNodeDiscoverer) FindNodes(ctx context.Context, job model.Job) ([]m
 	return d.store.ListForEngine(ctx, job.Spec.Engine)
 }
 
+// ListNodes implements requester.NodeDiscoverer
+func (d *StoreNodeDiscoverer) ListNodes(ctx context.Context) ([]model.NodeInfo, error) {
+	return d.store.List(ctx)
+}
+
 // compile time check that StoreNodeDiscoverer implements NodeDiscoverer
 var _ requester.NodeDiscoverer = (*StoreNodeDiscoverer)(nil)

--- a/pkg/requester/discovery/store_test.go
+++ b/pkg/requester/discovery/store_test.go
@@ -69,7 +69,7 @@ func generateNodeInfo(id string, engines ...model.Engine) model.NodeInfo {
 			},
 		},
 		NodeType: model.NodeTypeCompute,
-		ComputeNodeInfo: model.ComputeNodeInfo{
+		ComputeNodeInfo: &model.ComputeNodeInfo{
 			ExecutionEngines: engines,
 		},
 	}

--- a/pkg/requester/ranking/features_test.go
+++ b/pkg/requester/ranking/features_test.go
@@ -23,31 +23,31 @@ func (s *FeatureNodeRankerSuite) Nodes() []model.NodeInfo {
 	return []model.NodeInfo{
 		{
 			PeerInfo:        peer.AddrInfo{ID: peer.ID("docker")},
-			ComputeNodeInfo: model.ComputeNodeInfo{ExecutionEngines: []model.Engine{model.EngineDocker}},
+			ComputeNodeInfo: &model.ComputeNodeInfo{ExecutionEngines: []model.Engine{model.EngineDocker}},
 		},
 		{
 			PeerInfo:        peer.AddrInfo{ID: peer.ID("wasm")},
-			ComputeNodeInfo: model.ComputeNodeInfo{ExecutionEngines: []model.Engine{model.EngineWasm}},
+			ComputeNodeInfo: &model.ComputeNodeInfo{ExecutionEngines: []model.Engine{model.EngineWasm}},
 		},
 		{
 			PeerInfo:        peer.AddrInfo{ID: peer.ID("ipfs")},
-			ComputeNodeInfo: model.ComputeNodeInfo{StorageSources: []model.StorageSourceType{model.StorageSourceIPFS}},
+			ComputeNodeInfo: &model.ComputeNodeInfo{StorageSources: []model.StorageSourceType{model.StorageSourceIPFS}},
 		},
 		{
 			PeerInfo:        peer.AddrInfo{ID: peer.ID("url")},
-			ComputeNodeInfo: model.ComputeNodeInfo{StorageSources: []model.StorageSourceType{model.StorageSourceURLDownload}},
+			ComputeNodeInfo: &model.ComputeNodeInfo{StorageSources: []model.StorageSourceType{model.StorageSourceURLDownload}},
 		},
 		{
 			PeerInfo:        peer.AddrInfo{ID: peer.ID("deterministic")},
-			ComputeNodeInfo: model.ComputeNodeInfo{Verifiers: []model.Verifier{model.VerifierDeterministic}},
+			ComputeNodeInfo: &model.ComputeNodeInfo{Verifiers: []model.Verifier{model.VerifierDeterministic}},
 		},
 		{
 			PeerInfo:        peer.AddrInfo{ID: peer.ID("estuary")},
-			ComputeNodeInfo: model.ComputeNodeInfo{Publishers: []model.Publisher{model.PublisherEstuary}},
+			ComputeNodeInfo: &model.ComputeNodeInfo{Publishers: []model.Publisher{model.PublisherEstuary}},
 		},
 		{
 			PeerInfo: peer.AddrInfo{ID: peer.ID("combo")},
-			ComputeNodeInfo: model.ComputeNodeInfo{
+			ComputeNodeInfo: &model.ComputeNodeInfo{
 				ExecutionEngines: []model.Engine{model.EngineDocker, model.EngineWasm},
 				Verifiers:        []model.Verifier{model.VerifierNoop, model.VerifierDeterministic},
 				Publishers:       []model.Publisher{model.PublisherIpfs, model.PublisherEstuary},

--- a/pkg/requester/ranking/max_usage.go
+++ b/pkg/requester/ranking/max_usage.go
@@ -26,7 +26,7 @@ func (s *MaxUsageNodeRanker) RankNodes(ctx context.Context, job model.Job, nodes
 	jobResourceUsageSet := !jobResourceUsage.IsZero()
 	for i, node := range nodes {
 		rank := 0
-		if jobResourceUsageSet {
+		if jobResourceUsageSet && node.ComputeNodeInfo != nil {
 			if jobResourceUsage.LessThanEq(node.ComputeNodeInfo.MaxJobRequirements) {
 				rank = 10
 			} else {

--- a/pkg/requester/ranking/max_usage_test.go
+++ b/pkg/requester/ranking/max_usage_test.go
@@ -22,15 +22,15 @@ type MaxUsageNodeRankerSuite struct {
 func (s *MaxUsageNodeRankerSuite) SetupSuite() {
 	s.smallPeer = model.NodeInfo{
 		PeerInfo:        peer.AddrInfo{ID: peer.ID("small")},
-		ComputeNodeInfo: model.ComputeNodeInfo{MaxJobRequirements: model.ResourceUsageData{CPU: 1}},
+		ComputeNodeInfo: &model.ComputeNodeInfo{MaxJobRequirements: model.ResourceUsageData{CPU: 1}},
 	}
 	s.medPeer = model.NodeInfo{
 		PeerInfo:        peer.AddrInfo{ID: peer.ID("med")},
-		ComputeNodeInfo: model.ComputeNodeInfo{MaxJobRequirements: model.ResourceUsageData{CPU: 2}},
+		ComputeNodeInfo: &model.ComputeNodeInfo{MaxJobRequirements: model.ResourceUsageData{CPU: 2}},
 	}
 	s.largePeer = model.NodeInfo{
 		PeerInfo:        peer.AddrInfo{ID: peer.ID("large")},
-		ComputeNodeInfo: model.ComputeNodeInfo{MaxJobRequirements: model.ResourceUsageData{CPU: 3}},
+		ComputeNodeInfo: &model.ComputeNodeInfo{MaxJobRequirements: model.ResourceUsageData{CPU: 3}},
 	}
 }
 

--- a/pkg/requester/types.go
+++ b/pkg/requester/types.go
@@ -33,6 +33,7 @@ type Queue interface {
 
 // NodeDiscoverer discovers nodes in the network that are suitable to execute a job.
 type NodeDiscoverer interface {
+	ListNodes(ctx context.Context) ([]model.NodeInfo, error)
 	FindNodes(ctx context.Context, job model.Job) ([]model.NodeInfo, error)
 }
 

--- a/pkg/routing/inmemory/inmemory.go
+++ b/pkg/routing/inmemory/inmemory.go
@@ -49,19 +49,23 @@ func (r *NodeInfoStore) Add(ctx context.Context, nodeInfo model.NodeInfo) error 
 	// delete node from previous engines if it already exists to replace old engines with new ones if they've changed
 	existingNodeInfo, ok := r.nodeInfoMap[nodeInfo.PeerInfo.ID]
 	if ok {
-		for _, engine := range existingNodeInfo.ComputeNodeInfo.ExecutionEngines {
-			delete(r.engineNodeIDMap[engine], nodeInfo.PeerInfo.ID)
+		if existingNodeInfo.ComputeNodeInfo != nil {
+			for _, engine := range existingNodeInfo.ComputeNodeInfo.ExecutionEngines {
+				delete(r.engineNodeIDMap[engine], nodeInfo.PeerInfo.ID)
+			}
 		}
 	} else {
 		log.Ctx(ctx).Debug().Msgf("Adding new node %s to in-memory nodeInfo store", nodeInfo.PeerInfo.ID)
 	}
 
 	// TODO: use data structure that maintains nodes in descending order based on available capacity.
-	for _, engine := range nodeInfo.ComputeNodeInfo.ExecutionEngines {
-		if _, ok := r.engineNodeIDMap[engine]; !ok {
-			r.engineNodeIDMap[engine] = make(map[peer.ID]struct{})
+	if nodeInfo.ComputeNodeInfo != nil {
+		for _, engine := range nodeInfo.ComputeNodeInfo.ExecutionEngines {
+			if _, ok := r.engineNodeIDMap[engine]; !ok {
+				r.engineNodeIDMap[engine] = make(map[peer.ID]struct{})
+			}
+			r.engineNodeIDMap[engine][nodeInfo.PeerInfo.ID] = struct{}{}
 		}
-		r.engineNodeIDMap[engine][nodeInfo.PeerInfo.ID] = struct{}{}
 	}
 
 	// add or update the node info

--- a/pkg/routing/inmemory/inmemory_test.go
+++ b/pkg/routing/inmemory/inmemory_test.go
@@ -167,7 +167,7 @@ func generateNodeInfo(id string, engines ...model.Engine) model.NodeInfo {
 			ID: peer.ID(id),
 		},
 		NodeType: model.NodeTypeCompute,
-		ComputeNodeInfo: model.ComputeNodeInfo{
+		ComputeNodeInfo: &model.ComputeNodeInfo{
 			ExecutionEngines: engines,
 		},
 	}

--- a/pkg/routing/node_info_provider.go
+++ b/pkg/routing/node_info_provider.go
@@ -50,8 +50,9 @@ func (n *NodeInfoProvider) GetNodeInfo(ctx context.Context) model.NodeInfo {
 		Labels: n.labels,
 	}
 	if n.computeInfoProvider != nil {
+		info := n.computeInfoProvider.GetComputeInfo(ctx)
 		res.NodeType = model.NodeTypeCompute
-		res.ComputeNodeInfo = n.computeInfoProvider.GetComputeInfo(ctx)
+		res.ComputeNodeInfo = &info
 	}
 	return res
 }


### PR DESCRIPTION
Since we switched to async node advertisement, our tests have been very flaky because sometimes the node advertisement occurs after the job has been submitted, and we have no synchronisation around waiting for it to have happened.

Now, we ensure that we have complete information for all the nodes in the stack before proceeding with the test.

This also makes clear when the ComputeNodeInfo has been provided or not, which allows ranking strategies to better distinguish between nodes that don't support anything and nodes that haven't announced.

Resolves #2405 (hopefully). 