### PR TITLE
Implement a simple cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 // indirect
-	github.com/benbjohnson/clock v1.3.0 // indirect
+	github.com/benbjohnson/clock v1.3.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -93,6 +93,11 @@ func (c *Cache[T]) Delete(key string) {
 	c.items.Delete(key)
 }
 
+func (c *Cache[T]) Close() {
+	close(c.closer)
+	delete(caches, c.name)
+}
+
 func (c *Cache[T]) cleanup(frequency time.Duration) {
 	ticker := time.NewTicker(frequency)
 	defer ticker.Stop()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -102,7 +102,12 @@ func (c *Cache[T]) cleanup(frequency time.Duration) {
 		case <-c.closer:
 			return
 		case <-ticker.C:
+			// Stop the ticker whilst we process evictions
+			// otherwise we'll be constrained to finishing
+			// evictions in <frequency
+			ticker.Stop()
 			c.evict()
+			ticker.Reset(frequency)
 		}
 	}
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
+)
+
+type Cache[T any] struct {
+	name     string
+	items    generic.SyncMap[string, CacheItem[T]]
+	cost     int64
+	count    int64
+	maxCost  int64
+	maxItems int64
+	closer   chan struct{}
+}
+
+type CacheItem[T any] struct {
+	contents  T
+	cost      int64
+	expiresAt int64
+}
+
+var caches map[string]interface{} = make(map[string]interface{})
+
+// GetOrCreateCache
+func GetOrCreateCache[T any](name string, options CacheOptions) (*Cache[T], error) {
+	if cache, ok := caches[name]; ok {
+		if cast, ok := cache.(*Cache[T]); ok {
+			return cast, nil
+		}
+		return nil, errWrongCacheType
+	}
+
+	cache, err := NewCache[T](name, options)
+	if err != nil {
+		return nil, err
+	}
+
+	caches[name] = cache
+	return cache, nil
+}
+
+func NewCache[T any](name string, options CacheOptions) (c *Cache[T], err error) {
+	c = &Cache[T]{
+		name:     name,
+		closer:   make(chan struct{}),
+		cost:     0,
+		count:    0,
+		maxCost:  options.maxCost,
+		maxItems: options.maxItems,
+	}
+
+	go c.cleanup(options.cleanupFrequency)
+	return c, nil
+}
+
+func (c *Cache[T]) Get(key string) (T, bool) {
+	result, exists := c.items.Get(key)
+	if !exists {
+		return *new(T), false
+	}
+
+	return result.contents, true
+}
+
+func (c *Cache[T]) Set(key string, value T, cost int64, ttl time.Duration) error {
+	expires := time.Now().Add(ttl).Unix()
+
+	item := CacheItem[T]{
+		contents:  value,
+		cost:      cost,
+		expiresAt: expires,
+	}
+
+	if item.cost+c.cost > c.maxCost {
+		return errTooCostly
+	}
+
+	if c.count == c.maxItems {
+		return errTooFull
+	}
+
+	c.count += 1
+	c.cost += cost
+	c.items.Put(key, item)
+
+	return nil
+}
+
+func (c *Cache[T]) Delete(key string) {
+	c.items.Delete(key)
+}
+
+func (c *Cache[T]) cleanup(frequency time.Duration) {
+	ticker := time.NewTicker(frequency)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.closer:
+			return
+		case <-ticker.C:
+			c.evict()
+		}
+	}
+}
+
+func (c *Cache[T]) evict() {
+	now := time.Now().Unix()
+
+	c.items.Iter(func(key string, item CacheItem[T]) bool {
+		if item.expiresAt != 0 && item.expiresAt <= now {
+			c.items.Delete(key)
+			c.count -= 1
+		}
+		return true
+	})
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,84 @@
+//go:build unit || !integration
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CacheSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *CacheSuite) SetupSuite() {
+	s.ctx = context.Background()
+}
+
+func TestCacheSuite(t *testing.T) {
+	suite.Run(t, new(CacheSuite))
+}
+
+const (
+	oneSecond  = time.Duration(1) * time.Second
+	halfSecond = time.Duration(500) * time.Millisecond
+	oneHour    = oneSecond * 3600
+)
+
+func (s *CacheSuite) TestBasicCache() {
+	k := "test"
+
+	c, err := GetOrCreateCache[string]("TestBasicCache", NewCacheOptions(2, 2, oneHour))
+	require.NoError(s.T(), err)
+
+	err = c.Set(k, "value", 1, time.Duration(2)*time.Second)
+	require.NoError(s.T(), err)
+
+	v, found := c.Get(k)
+	require.Equal(s.T(), true, found)
+	require.Equal(s.T(), "value", v)
+}
+
+func (s *CacheSuite) TestTooCostly() {
+	k := "test"
+
+	c, err := GetOrCreateCache[string]("TestTooCostly", NewCacheOptions(2, 1, oneHour))
+	require.NoError(s.T(), err)
+
+	err = c.Set(k, "value", 10, time.Duration(2)*time.Second)
+	require.Error(s.T(), err)
+	require.Equal(s.T(), errTooCostly, err)
+}
+
+func (s *CacheSuite) TestTooMany() {
+	k := "test"
+
+	c, err := GetOrCreateCache[string]("TestTooMany", NewCacheOptions(1, 10, oneHour))
+	require.NoError(s.T(), err)
+
+	err = c.Set(k, "value", 1, time.Duration(2)*time.Second)
+	require.NoError(s.T(), err)
+
+	err = c.Set(k, "value", 1, time.Duration(2)*time.Second)
+	require.Error(s.T(), err)
+	require.Equal(s.T(), errTooFull, err)
+}
+
+func (s *CacheSuite) TestExpiry() {
+	k := "test"
+
+	c, err := GetOrCreateCache[string]("TestExpiry", NewCacheOptions(1, 1, halfSecond))
+	require.NoError(s.T(), err)
+
+	err = c.Set(k, "value", 1, time.Duration(1)*time.Second)
+	require.NoError(s.T(), err)
+
+	time.Sleep(2 * time.Second)
+	_, found := c.Get(k)
+	require.Equal(s.T(), false, found)
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,23 +1,32 @@
 //go:build unit || !integration
 
-package cache
+package cache_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/cache"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type CacheSuite struct {
 	suite.Suite
-	ctx context.Context
+	ctx   context.Context
+	clock *clock.Mock
 }
 
 func (s *CacheSuite) SetupSuite() {
 	s.ctx = context.Background()
+}
+
+func (s *CacheSuite) SetupTest() {
+	s.clock = clock.NewMock()
+	s.clock.Set(time.Now())
 }
 
 func TestCacheSuite(t *testing.T) {
@@ -25,18 +34,32 @@ func TestCacheSuite(t *testing.T) {
 }
 
 const (
-	oneSecond  = time.Duration(1) * time.Second
-	halfSecond = time.Duration(500) * time.Millisecond
-	oneHour    = oneSecond * 3600
+	oneSecond = 1
+	oneHour   = 3600
 )
+
+func (s *CacheSuite) createTestCache(
+	name string, maxCount uint64, maxCost uint64, freq clock.Duration,
+) (*cache.Cache[string], error) {
+	c, err := cache.NewCache[string](
+		name,
+		cache.NewCacheOptionsWithFactories(
+			maxCount, maxCost, freq, s.clock.Ticker, s.clock.Now,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
 
 func (s *CacheSuite) TestBasicCache() {
 	k := "test"
 
-	c, err := GetOrCreateCache[string]("TestBasicCache", NewCacheOptions(2, 2, oneHour))
+	c, err := s.createTestCache("TestBasicCache", 2, 2, oneHour)
 	require.NoError(s.T(), err)
 
-	err = c.Set(k, "value", 1, time.Duration(2)*time.Second)
+	err = c.Set(k, "value", 1, oneSecond)
 	require.NoError(s.T(), err)
 
 	v, found := c.Get(k)
@@ -47,38 +70,44 @@ func (s *CacheSuite) TestBasicCache() {
 func (s *CacheSuite) TestTooCostly() {
 	k := "test"
 
-	c, err := GetOrCreateCache[string]("TestTooCostly", NewCacheOptions(2, 1, oneHour))
+	c, err := s.createTestCache("TestTooCostly", 2, 1, oneHour)
 	require.NoError(s.T(), err)
 
-	err = c.Set(k, "value", 10, time.Duration(2)*time.Second)
+	err = c.Set(k, "value", 10, oneSecond)
 	require.Error(s.T(), err)
-	require.Equal(s.T(), errTooCostly, err)
+	require.Equal(s.T(), cache.ErrCacheTooCostly, err)
 }
 
 func (s *CacheSuite) TestTooMany() {
 	k := "test"
 
-	c, err := GetOrCreateCache[string]("TestTooMany", NewCacheOptions(1, 10, oneHour))
+	c, err := s.createTestCache("TestTooMany", 1, 10, oneHour)
 	require.NoError(s.T(), err)
 
-	err = c.Set(k, "value", 1, time.Duration(2)*time.Second)
+	err = c.Set(k, "value", 1, oneHour)
 	require.NoError(s.T(), err)
 
-	err = c.Set(k, "value", 1, time.Duration(2)*time.Second)
+	err = c.Set(k, "value", 1, oneHour)
 	require.Error(s.T(), err)
-	require.Equal(s.T(), errTooFull, err)
+	require.Equal(s.T(), cache.ErrCacheFull, err)
 }
 
 func (s *CacheSuite) TestExpiry() {
 	k := "test"
 
-	c, err := GetOrCreateCache[string]("TestExpiry", NewCacheOptions(1, 1, halfSecond))
+	c, err := s.createTestCache("TestExpiry", 1, 1, oneHour)
 	require.NoError(s.T(), err)
 
-	err = c.Set(k, "value", 1, time.Duration(1)*time.Second)
+	err = c.Set(k, "value", 1, oneHour)
 	require.NoError(s.T(), err)
 
-	time.Sleep(2 * time.Second)
+	// After moving the block past expiry (one hour) we would
+	// expect it to be removed shortly
+	runtime.Gosched()
+	s.clock.Add(oneHour * 2)
+
+	runtime.Gosched()
+
 	_, found := c.Get(k)
 	require.Equal(s.T(), false, found)
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -39,12 +39,12 @@ const (
 )
 
 func (s *CacheSuite) createTestCache(
-	name string, maxCount uint64, maxCost uint64, freq clock.Duration,
+	name string, maxCost uint64, freq clock.Duration,
 ) (*cache.Cache[string], error) {
 	c, err := cache.NewCache[string](
 		name,
 		cache.NewCacheOptionsWithFactories(
-			maxCount, maxCost, freq, s.clock.Ticker, s.clock.Now,
+			maxCost, freq, s.clock.Ticker, s.clock.Now,
 		),
 	)
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *CacheSuite) createTestCache(
 func (s *CacheSuite) TestBasicCache() {
 	k := "test"
 
-	c, err := s.createTestCache("TestBasicCache", 2, 2, oneHour)
+	c, err := s.createTestCache("TestBasicCache", 2, oneHour)
 	require.NoError(s.T(), err)
 
 	err = c.Set(k, "value", 1, oneSecond)
@@ -70,7 +70,7 @@ func (s *CacheSuite) TestBasicCache() {
 func (s *CacheSuite) TestTooCostly() {
 	k := "test"
 
-	c, err := s.createTestCache("TestTooCostly", 2, 1, oneHour)
+	c, err := s.createTestCache("TestTooCostly", 1, oneHour)
 	require.NoError(s.T(), err)
 
 	err = c.Set(k, "value", 10, oneSecond)
@@ -78,24 +78,10 @@ func (s *CacheSuite) TestTooCostly() {
 	require.Equal(s.T(), cache.ErrCacheTooCostly, err)
 }
 
-func (s *CacheSuite) TestTooMany() {
-	k := "test"
-
-	c, err := s.createTestCache("TestTooMany", 1, 10, oneHour)
-	require.NoError(s.T(), err)
-
-	err = c.Set(k, "value", 1, oneHour)
-	require.NoError(s.T(), err)
-
-	err = c.Set(k, "value", 1, oneHour)
-	require.Error(s.T(), err)
-	require.Equal(s.T(), cache.ErrCacheFull, err)
-}
-
 func (s *CacheSuite) TestExpiry() {
 	k := "test"
 
-	c, err := s.createTestCache("TestExpiry", 1, 1, oneHour)
+	c, err := s.createTestCache("TestExpiry", 1, oneHour)
 	require.NoError(s.T(), err)
 
 	err = c.Set(k, "value", 1, oneHour)

--- a/pkg/cache/counter.go
+++ b/pkg/cache/counter.go
@@ -1,0 +1,42 @@
+package cache
+
+import "sync/atomic"
+
+type Counter struct {
+	// current must be first element in the struct to ensure
+	// alignment on 32bit systems.
+	current uint64
+	maximum uint64
+}
+
+func NewCounter(max uint64) Counter {
+	return Counter{
+		current: 0,
+		maximum: max,
+	}
+}
+
+func (c *Counter) Inc(by uint64) {
+	atomic.AddUint64(&c.current, by)
+}
+
+func (c *Counter) Dec(by uint64) {
+	atomic.AddUint64(&c.current, ^uint64(by-1)) //nolint:unconvert
+}
+
+func (c *Counter) Current() uint64 {
+	return atomic.LoadUint64(&c.current)
+}
+
+func (c *Counter) Reset(max uint64) {
+	atomic.StoreUint64(&c.current, 0)
+	c.maximum = max
+}
+
+func (c *Counter) HasSpaceFor(i uint64) bool {
+	return c.Current()+i <= c.maximum
+}
+
+func (c *Counter) IsFull() bool {
+	return c.Current() == c.maximum
+}

--- a/pkg/cache/counter_test.go
+++ b/pkg/cache/counter_test.go
@@ -1,0 +1,74 @@
+//go:build unit || !integration
+
+package cache_test
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/cache"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CounterSuite struct {
+	suite.Suite
+}
+
+func TestCounterSuite(t *testing.T) {
+	suite.Run(t, new(CounterSuite))
+}
+
+func (s *CounterSuite) TestSimpleAdd() {
+	c := cache.NewCounter(100)
+	c.Inc(1)
+	require.Equal(s.T(), uint64(1), c.Current())
+
+	c.Inc(10)
+	require.Equal(s.T(), uint64(11), c.Current())
+
+	c.Dec(10)
+	require.Equal(s.T(), uint64(1), c.Current())
+
+	require.Equal(s.T(), true, c.HasSpaceFor(99))
+	require.Equal(s.T(), false, c.HasSpaceFor(100))
+
+	c.Inc(99)
+	require.Equal(s.T(), true, c.IsFull())
+}
+
+func BenchmarkCounter(b *testing.B) {
+	b.StopTimer()
+
+	c := cache.NewCounter(math.MaxInt64)
+
+	var start, end sync.WaitGroup
+	start.Add(1)
+	end.Add(100)
+
+	n := b.N / 100
+
+	for i := 0; i < 100; i++ {
+		go func() {
+			start.Wait()
+			for p := 0; p < n; p++ {
+				c.Inc(10)
+				c.Dec(9)
+			}
+			end.Done()
+		}()
+	}
+
+	b.StartTimer()
+
+	// Start the test
+	start.Done()
+
+	// wait for all routines to finish
+	end.Wait()
+
+	// Each of the 100 routines run will result in a counter with
+	// current == 1 (total 100) total of n times.
+	require.Equal(b, uint64(n*100), c.Current())
+}

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"errors"
+	"time"
+)
+
+var errWrongCacheType error = errors.New("requested cache type did not match previous cache with that name")
+var errTooCostly error = errors.New("item too costly for cache")
+var errTooFull error = errors.New("cache is full")
+
+type CacheOptions struct {
+	maxItems         int64
+	maxCost          int64
+	cleanupFrequency time.Duration
+}
+
+// NewCacheOptions creates options describing a new in-memory cache.
+//
+// expectedItemTotal - gives an indication of how many items we expect
+// to hold (maximum).
+//
+// maximumCost - is the actual cache capacity measured in some unit,
+// where that unit is controlled by whoever is writing values to
+// the cache. e.g. if we set this to 1048576 (bytes) and each
+// write specifies it's size, then we have implemented a 1MiB
+// maximum capacity.
+func NewCacheOptions(
+	maxItems int64,
+	maximumCost int64,
+	cleanupFrequency time.Duration,
+) CacheOptions {
+	return CacheOptions{
+		maxItems:         maxItems,
+		maxCost:          maximumCost,
+		cleanupFrequency: cleanupFrequency,
+	}
+}

--- a/pkg/cache/types.go
+++ b/pkg/cache/types.go
@@ -51,31 +51,3 @@ func NewCacheOptionsWithFactories(
 		nowFactory:       nowFunc,
 	}
 }
-
-type Counter struct {
-	current uint64
-	maximum uint64
-}
-
-func NewCounter(max uint64) Counter {
-	return Counter{
-		current: 0,
-		maximum: max,
-	}
-}
-
-func (c *Counter) Inc(by uint64) {
-	c.current += by
-}
-
-func (c *Counter) Dec(by uint64) {
-	c.current -= by
-}
-
-func (c *Counter) HasSpaceFor(i uint64) bool {
-	return c.current+i <= c.maximum
-}
-
-func (c *Counter) IsFull() bool {
-	return c.current == c.maximum
-}


### PR DESCRIPTION
Implements a simple, cost-based  cache that allows us to store items in-memory and mark them as expired after a configured period of time.   When a cache is created, a single goroutine is run to manage the eviction of expired items who will have had their expiry time specified on insertion into the cache. 
