### PR TITLE
Use content-disposition for downloads where available

### DIFF
--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -146,6 +146,10 @@ func (sp *StorageProvider) PrepareStorage(ctx context.Context, storageSpec model
 			if fileName == "" {
 				fileName = params["filename"]
 			}
+
+			if fileName != "" {
+				fileName = filepath.Base(fileName)
+			}
 		}
 	}
 

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -265,6 +265,21 @@ func (s *StorageSuite) TestPrepareStorageURL() {
 			expectedContent:  "i'm not putting an image here",
 			expectedFilename: "300.jpg",
 		},
+		{
+			name: "redirects.r.us - without redirect",
+			requests: []dummyRequest{
+				{
+					path:    "/img/300.jpg",
+					code:    200,
+					content: "i'm not putting an image here",
+					headers: &map[string]string{
+						"content-disposition": "attachment; filename*=UTF-8''300.jpg; filename=\"dodgy.bin\";",
+					},
+				},
+			},
+			expectedContent:  "i'm not putting an image here",
+			expectedFilename: "300.jpg",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -225,6 +225,46 @@ func (s *StorageSuite) TestPrepareStorageURL() {
 			expectedContent:  "i'm not putting an image here",
 			expectedFilename: "300.jpg",
 		},
+		{
+			name: "redirects.r.us - malicious",
+			requests: []dummyRequest{
+				{
+					path:    "/img/300.jpg",
+					code:    302,
+					content: "/cdn/300/",
+				},
+				{
+					path:    "/cdn/300/",
+					code:    200,
+					content: "i'm not putting an image here",
+					headers: &map[string]string{
+						"content-disposition": "attachment; filename*=UTF-8''300.jpg; filename=\"../../300.jpg\";",
+					},
+				},
+			},
+			expectedContent:  "i'm not putting an image here",
+			expectedFilename: "300.jpg",
+		},
+		{
+			name: "redirects.r.us - malicious part II",
+			requests: []dummyRequest{
+				{
+					path:    "/img/300.jpg",
+					code:    302,
+					content: "/cdn/300/",
+				},
+				{
+					path:    "/cdn/300/",
+					code:    200,
+					content: "i'm not putting an image here",
+					headers: &map[string]string{
+						"content-disposition": "attachment; filename*=UTF-8''300.jpg; filename=\"/etc/300.jpg\";",
+					},
+				},
+			},
+			expectedContent:  "i'm not putting an image here",
+			expectedFilename: "300.jpg",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Occassionally we get strange behavious where the filename during a download is set to a strange value, because the original URL redirects to a CDN which uses a different name. In these cases the response often contains a content-disposition telling us the intended filename.

This PR reads the content-disposition and uses it for the filename when it is available.

Fixes #1374 