### PR TITLE
fix: network config validation

### DIFF
--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -7,14 +7,15 @@ import (
 	"net"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/config"
-	"github.com/bacalhau-project/bacalhau/pkg/logger"
-	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.uber.org/multierr"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
 )
 
 const (
@@ -121,6 +122,10 @@ func (e *Executor) createHTTPGateway(
 		return nil, nil, errors.Wrap(err, "error getting network subnet")
 	}
 	subnet := internalNetwork.IPAM.Config[0].Subnet
+
+	if len(job.Spec.Network.DomainSet()) == 0 {
+		return nil, nil, fmt.Errorf("invalid networking configuration, at least one domain is required when %s networking is enabled", model.NetworkHTTP)
+	}
 
 	// Create the gateway container initially attached to the *host* network
 	domainList, derr := json.Marshal(job.Spec.Network.DomainSet())

--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -113,6 +113,9 @@ func (n NetworkConfig) IsValid() (err error) {
 // expected by our Docker HTTP gateway, which complains and/or fails to start if
 // these requirements are not met.
 func (n NetworkConfig) DomainSet() []string {
+	if n.Domains == nil {
+		return []string{}
+	}
 	domains := slices.Clone(n.Domains)
 	slices.SortFunc(domains, func(a, b string) bool {
 		// If the domains "match", the match may be the result of a wildcard. We


### PR DESCRIPTION
- NetworkConfig with HTTP networking enabled but empty Domain set is invalid.
- Motivated by conversation here: https://filecoinproject.slack.com/archives/C02RLM3JHUY/p1682548637776789

For example Users requesting networking who do not specify a domain will now see the following error message:

```bash
$ bacalhau docker run ghcr.io/kelindi/fvm-pricing-oracle:sha-4250033 --network=http

Error verifying job: invalid networking configuration, at least one domain is required when networking type HTTP is enabled
```