### PR TITLE
Reset the disk size EU only allows 1TB

### DIFF
--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -220,7 +220,7 @@ resource "google_compute_disk" "bacalhau_disk" {
   count    = var.protect_resources ? var.instance_count : 0
   type     = "pd-ssd"
   zone     = var.num_gpu_machines > 1 && count.index == (var.instance_count - 1) ? "europe-west4-a" : var.zone
-  size     = var.volume_size_gb
+  size     = count.index == 4  ? 1000 : var.volume_size_gb
   snapshot = count.index == 4 ? "bacalhau-disk-4-migration" : var.restore_from_backup
   lifecycle {
     prevent_destroy = true
@@ -233,7 +233,7 @@ resource "google_compute_disk" "bacalhau_disk_unprotected" {
   count    = var.protect_resources ? 0 : var.instance_count
   type     = "pd-ssd"
   zone     = var.num_gpu_machines > 1 && count.index == (var.instance_count - 1) ? "europe-west4-a" : var.zone
-  size     = var.volume_size_gb
+  size     = count.index == 4 ? 1000 : var.volume_size_gb 
   snapshot = var.restore_from_backup
 }
 

--- a/ops/terraform/production.tfvars
+++ b/ops/terraform/production.tfvars
@@ -19,7 +19,7 @@ zone                        = "us-east4-c"
 # on the virtual machine. If `df -h` shows only 1000, then `sudo resize2fs /dev/sdb` 
 # will resize the /data (/dev/sdb) drive to use all of the space. Do not use for 
 # boot disk.
-volume_size_gb              = 2000 # when increasing this value you need to claim the new space manually
+volume_size_gb              = 1000 # when increasing this value you need to claim the new space manually
 boot_disk_size_gb           = 1000
 machine_type                = "e2-standard-16"
 protect_resources           = true

--- a/ops/terraform/production.tfvars
+++ b/ops/terraform/production.tfvars
@@ -19,7 +19,7 @@ zone                        = "us-east4-c"
 # on the virtual machine. If `df -h` shows only 1000, then `sudo resize2fs /dev/sdb` 
 # will resize the /data (/dev/sdb) drive to use all of the space. Do not use for 
 # boot disk.
-volume_size_gb              = 1000 # when increasing this value you need to claim the new space manually
+volume_size_gb              = 2000 # when increasing this value you need to claim the new space manually
 boot_disk_size_gb           = 1000
 machine_type                = "e2-standard-16"
 protect_resources           = true


### PR DESCRIPTION
It appears that EU instances are only allowed 1TB of disk, and so this PR increases the disk size for US instances only. 