### PR TITLE
enable local directory storage provider

### DIFF
--- a/cmd/bacalhau/devstack.go
+++ b/cmd/bacalhau/devstack.go
@@ -124,6 +124,10 @@ func newDevStackCmd() *cobra.Command {
 		&ODs.MemoryProfilingFile, "memory-profiling-file", ODs.MemoryProfilingFile,
 		"File to save memory profiling to",
 	)
+	devstackCmd.PersistentFlags().StringSliceVar(
+		&ODs.AllowListedLocalPaths, "allow-listed-local-paths", ODs.AllowListedLocalPaths,
+		"Local paths that are allowed to be mounted into jobs",
+	)
 
 	devstackCmd.Flags().AddFlagSet(JobSelectionCLIFlags(&OS.JobSelectionPolicy))
 	devstackCmd.Flags().AddFlagSet(DisabledFeatureCLIFlags(&ODs.DisabledFeatures))

--- a/cmd/bacalhau/serve.go
+++ b/cmd/bacalhau/serve.go
@@ -83,6 +83,7 @@ type ServeOptions struct {
 	Labels                                map[string]string        // Labels to apply to the node that can be used for node selection and filtering
 	IPFSSwarmAddresses                    []string                 // IPFS multiaddresses that the in-process IPFS should connect to
 	PrivateInternalIPFS                   bool                     // Whether the in-process IPFS should automatically discover other IPFS nodes
+	AllowListedLocalPaths                 []string                 // Local paths that are allowed to be mounted into jobs
 }
 
 func NewServeOptions() *ServeOptions {
@@ -255,6 +256,10 @@ func newServeCmd() *cobra.Command {
 		&OS.IPFSSwarmAddresses, "ipfs-swarm-addr", OS.IPFSSwarmAddresses,
 		"IPFS multiaddress to connect the in-process IPFS node to - cannot be used with --ipfs-connect.",
 	)
+	serveCmd.PersistentFlags().StringSliceVar(
+		&OS.AllowListedLocalPaths, "allow-listed-local-paths", OS.AllowListedLocalPaths,
+		"Local paths that are allowed to be mounted into jobs",
+	)
 	serveCmd.PersistentFlags().BoolVar(
 		&OS.PrivateInternalIPFS, "private-internal-ipfs", OS.PrivateInternalIPFS,
 		"Whether the in-process IPFS node should auto-discover other nodes, including the public IPFS network - "+
@@ -332,20 +337,21 @@ func serve(cmd *cobra.Command, OS *ServeOptions) error {
 	}
 	// Create node config from cmd arguments
 	nodeConfig := node.NodeConfig{
-		IPFSClient:           ipfsClient,
-		CleanupManager:       cm,
-		JobStore:             datastore,
-		Host:                 libp2pHost,
-		FilecoinUnsealedPath: OS.FilecoinUnsealedPath,
-		EstuaryAPIKey:        OS.EstuaryAPIKey,
-		DisabledFeatures:     OS.DisabledFeatures,
-		HostAddress:          OS.HostAddress,
-		APIPort:              apiPort,
-		ComputeConfig:        getComputeConfig(OS),
-		RequesterNodeConfig:  getRequesterConfig(OS),
-		IsComputeNode:        isComputeNode,
-		IsRequesterNode:      isRequesterNode,
-		Labels:               combinedMap,
+		IPFSClient:            ipfsClient,
+		CleanupManager:        cm,
+		JobStore:              datastore,
+		Host:                  libp2pHost,
+		FilecoinUnsealedPath:  OS.FilecoinUnsealedPath,
+		EstuaryAPIKey:         OS.EstuaryAPIKey,
+		DisabledFeatures:      OS.DisabledFeatures,
+		HostAddress:           OS.HostAddress,
+		APIPort:               apiPort,
+		ComputeConfig:         getComputeConfig(OS),
+		RequesterNodeConfig:   getRequesterConfig(OS),
+		IsComputeNode:         isComputeNode,
+		IsRequesterNode:       isRequesterNode,
+		Labels:                combinedMap,
+		AllowListedLocalPaths: OS.AllowListedLocalPaths,
 	}
 
 	if OS.LotusFilecoinStorageDuration != time.Duration(0) &&

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.31.1
 	github.com/aws/smithy-go v1.13.5
 	github.com/bacalhau-project/golang-mutex-tracer v0.0.0-20230214151516-bb996d6e8b46
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/davecgh/go-spew v1.1.1
 	github.com/didip/tollbooth/v7 v7.0.1

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -40,6 +40,7 @@ type DevStackOptions struct {
 	CPUProfilingFile           string
 	MemoryProfilingFile        string
 	DisabledFeatures           node.FeatureConfig
+	AllowListedLocalPaths      []string // Local paths that are allowed to be mounted into jobs
 }
 type DevStack struct {
 	Nodes          []*node.Node
@@ -270,8 +271,9 @@ func NewDevStack(
 				"id":   libp2pHost.ID().String(),
 				"env":  "devstack",
 			},
-			DependencyInjector: injector,
-			DisabledFeatures:   options.DisabledFeatures,
+			DependencyInjector:    injector,
+			DisabledFeatures:      options.DisabledFeatures,
+			AllowListedLocalPaths: options.AllowListedLocalPaths,
 		}
 
 		if lotus != nil {

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -20,6 +20,7 @@ import (
 	filecoinunsealed "github.com/bacalhau-project/bacalhau/pkg/storage/filecoin_unsealed"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/inline"
 	ipfs_storage "github.com/bacalhau-project/bacalhau/pkg/storage/ipfs"
+	localdirectory "github.com/bacalhau-project/bacalhau/pkg/storage/local_directory"
 	noop_storage "github.com/bacalhau-project/bacalhau/pkg/storage/noop"
 	repo "github.com/bacalhau-project/bacalhau/pkg/storage/repo"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/s3"
@@ -72,6 +73,11 @@ func NewStandardStorageProvider(
 		return nil, err
 	}
 
+	// TODO: inject allowed paths
+	localDirectoryStorage := localdirectory.NewStorageProvider(localdirectory.StorageProviderParams{
+		AllowedPaths: []string{""},
+	})
+
 	var useIPFSDriver storage.Storage = ipfsAPICopyStorage
 
 	// if we are using a FilecoinUnsealedPath then construct a combo
@@ -117,6 +123,7 @@ func NewStandardStorageProvider(
 		model.StorageSourceRepoClone:        tracing.Wrap(repoCloneStorage),
 		model.StorageSourceRepoCloneLFS:     tracing.Wrap(repoCloneStorage),
 		model.StorageSourceS3:               tracing.Wrap(s3Storage),
+		model.StorageSourceLocalDirectory:   tracing.Wrap(localDirectoryStorage),
 	}), nil
 }
 

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -30,10 +30,11 @@ import (
 )
 
 type StandardStorageProviderOptions struct {
-	API                  ipfs.Client
-	FilecoinUnsealedPath string
-	DownloadPath         string
-	EstuaryAPIKey        string
+	API                   ipfs.Client
+	FilecoinUnsealedPath  string
+	DownloadPath          string
+	EstuaryAPIKey         string
+	AllowListedLocalPaths []string
 }
 
 type StandardExecutorOptions struct {
@@ -73,10 +74,12 @@ func NewStandardStorageProvider(
 		return nil, err
 	}
 
-	// TODO: inject allowed paths
-	localDirectoryStorage := localdirectory.NewStorageProvider(localdirectory.StorageProviderParams{
-		AllowedPaths: []string{""},
+	localDirectoryStorage, err := localdirectory.NewStorageProvider(localdirectory.StorageProviderParams{
+		AllowedPaths: options.AllowListedLocalPaths,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	var useIPFSDriver storage.Storage = ipfsAPICopyStorage
 

--- a/pkg/job/parser.go
+++ b/pkg/job/parser.go
@@ -3,6 +3,7 @@ package job
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/clone"
@@ -57,6 +58,11 @@ func ParseStorageString(sourceURI, destinationPath string, options map[string]st
 			default:
 				return model.StorageSpec{}, fmt.Errorf("unknown option %s", key)
 			}
+		}
+	case "file":
+		res = model.StorageSpec{
+			StorageSource: model.StorageSourceLocalDirectory,
+			SourcePath:    filepath.Join(parsedURI.Host, parsedURI.Path),
 		}
 	case "git", "gitlfs":
 		u, err := clone.IsValidGitRepoURL(sourceURI)

--- a/pkg/node/factories.go
+++ b/pkg/node/factories.go
@@ -78,8 +78,9 @@ func (f *StandardStorageProvidersFactory) Get(
 		ctx,
 		nodeConfig.CleanupManager,
 		executor_util.StandardStorageProviderOptions{
-			API:                  nodeConfig.IPFSClient,
-			FilecoinUnsealedPath: nodeConfig.FilecoinUnsealedPath,
+			API:                   nodeConfig.IPFSClient,
+			FilecoinUnsealedPath:  nodeConfig.FilecoinUnsealedPath,
+			AllowListedLocalPaths: nodeConfig.AllowListedLocalPaths,
 		},
 	)
 	return model.NewConfiguredProvider[model.StorageSourceType, storage.Storage](
@@ -101,9 +102,10 @@ func (f *StandardExecutorsFactory) Get(ctx context.Context, nodeConfig NodeConfi
 		executor_util.StandardExecutorOptions{
 			DockerID: fmt.Sprintf("bacalhau-%s", nodeConfig.Host.ID().String()),
 			Storage: executor_util.StandardStorageProviderOptions{
-				API:                  nodeConfig.IPFSClient,
-				FilecoinUnsealedPath: nodeConfig.FilecoinUnsealedPath,
-				EstuaryAPIKey:        nodeConfig.EstuaryAPIKey,
+				API:                   nodeConfig.IPFSClient,
+				FilecoinUnsealedPath:  nodeConfig.FilecoinUnsealedPath,
+				EstuaryAPIKey:         nodeConfig.EstuaryAPIKey,
+				AllowListedLocalPaths: nodeConfig.AllowListedLocalPaths,
 			},
 		},
 	)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -61,6 +61,7 @@ type NodeConfig struct {
 	Labels                    map[string]string
 	NodeInfoPublisherInterval time.Duration
 	DependencyInjector        NodeDependencyInjector
+	AllowListedLocalPaths     []string
 }
 
 // Lazy node dependency injector that generate instances of different

--- a/pkg/storage/local_directory/storage.go
+++ b/pkg/storage/local_directory/storage.go
@@ -5,31 +5,27 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
+type StorageProviderParams struct {
+	AllowedPaths []string
+}
 type StorageProvider struct {
-	LocalDirectoryPath string
+	allowedPaths []string
 }
 
-func NewStorage(_ *system.CleanupManager, localDirectoryPath string) (*StorageProvider, error) {
+func NewStorageProvider(params StorageProviderParams) *StorageProvider {
 	storageHandler := &StorageProvider{
-		LocalDirectoryPath: localDirectoryPath,
+		allowedPaths: params.AllowedPaths,
 	}
-	log.Debug().Msgf("Local directory driver createde: %s", localDirectoryPath)
+	log.Debug().Msgf("Local directory driver created with allowedPaths: %s", storageHandler.allowedPaths)
 
-	// check if the localDirectoryPath exists and error if it doesn't
-	if _, err := os.Stat(localDirectoryPath); errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("local directory path %s does not exist", localDirectoryPath)
-	}
-
-	return storageHandler, nil
+	return storageHandler
 }
 
 func (driver *StorageProvider) IsInstalled(context.Context) (bool, error) {
@@ -37,35 +33,33 @@ func (driver *StorageProvider) IsInstalled(context.Context) (bool, error) {
 }
 
 func (driver *StorageProvider) HasStorageLocally(_ context.Context, volume model.StorageSpec) (bool, error) {
-	localPath, err := driver.getPathToVolume(volume)
-	if err != nil {
-		return false, err
+	if !driver.isInAllowedPaths(volume.SourcePath) {
+		return false, nil
 	}
-	if _, err := os.Stat(localPath); errors.Is(err, os.ErrNotExist) {
+
+	if _, err := os.Stat(volume.SourcePath); errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	return true, nil
 }
 
 func (driver *StorageProvider) GetVolumeSize(_ context.Context, volume model.StorageSpec) (uint64, error) {
-	localPath, err := driver.getPathToVolume(volume)
-	if err != nil {
-		return 0, err
+	if !driver.isInAllowedPaths(volume.SourcePath) {
+		return 0, errors.New("volume not in allowed paths")
 	}
-	return util.DirSize(localPath)
+	return util.DirSize(volume.SourcePath)
 }
 
 func (driver *StorageProvider) PrepareStorage(
 	_ context.Context,
 	storageSpec model.StorageSpec,
 ) (storage.StorageVolume, error) {
-	localPath, err := driver.getPathToVolume(storageSpec)
-	if err != nil {
-		return storage.StorageVolume{}, err
+	if !driver.isInAllowedPaths(storageSpec.SourcePath) {
+		return storage.StorageVolume{}, errors.New("volume not in allowed paths")
 	}
 	return storage.StorageVolume{
 		Type:   storage.StorageVolumeConnectorBind,
-		Source: localPath,
+		Source: storageSpec.SourcePath,
 		Target: storageSpec.Path,
 	}, nil
 }
@@ -78,17 +72,9 @@ func (driver *StorageProvider) Upload(context.Context, string) (model.StorageSpe
 	return model.StorageSpec{}, fmt.Errorf("not implemented")
 }
 
-func (driver *StorageProvider) Explode(_ context.Context, spec model.StorageSpec) ([]model.StorageSpec, error) {
-	return []model.StorageSpec{
-		spec,
-	}, nil
-}
-
-func (driver *StorageProvider) getPathToVolume(volume model.StorageSpec) (string, error) {
-	// join the driver.LocalDirectoryPath with the volume.SourcePath
-	// use the os.PathSeparator to make sure we are using the correct separator for the OS
-	localPath := filepath.Join(driver.LocalDirectoryPath, volume.SourcePath)
-	return localPath, nil
+func (driver *StorageProvider) isInAllowedPaths(path string) bool {
+	// TODO: check if path is in allowed paths
+	return true
 }
 
 // Compile time interface check:

--- a/pkg/storage/local_directory/storage_test.go
+++ b/pkg/storage/local_directory/storage_test.go
@@ -11,29 +11,15 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-var ctx context.Context
-var tempDir string
-var driver *StorageProvider
-var cm *system.CleanupManager
-
 type LocalDirectorySuite struct {
 	suite.Suite
-}
-
-func (suite *LocalDirectorySuite) prepareStorageSpec(sourcePath string) model.StorageSpec {
-	err := os.MkdirAll(sourcePath, os.ModePerm)
-	require.NoError(suite.T(), err)
-	return model.StorageSpec{
-		// source path is some kind of sub-path
-		// inside our local folder
-		SourcePath: sourcePath,
-		Path:       "/path/inside/the/container",
-	}
+	tempDir string
+	driver  *StorageProvider
 }
 
 // In order for 'go test' to run this suite, we need to create
@@ -42,51 +28,185 @@ func TestLocalDirectorySuite(t *testing.T) {
 	suite.Run(t, new(LocalDirectorySuite))
 }
 
+// Before the suite
+func (s *LocalDirectorySuite) SetupSuite() {
+	logger.ConfigureTestLogging(s.T())
+}
+
 // Before each test
-func (suite *LocalDirectorySuite) SetupTest() {
+func (s *LocalDirectorySuite) SetupTest() {
 	var setupErr error
-	logger.ConfigureTestLogging(suite.T())
-	cm = system.NewCleanupManager()
-	ctx = context.Background()
-	tempDir = suite.T().TempDir()
-	driver = NewStorageProvider(StorageProviderParams{AllowedPaths: []string{tempDir}})
-	require.NoError(suite.T(), setupErr)
+	s.tempDir = s.T().TempDir()
+	s.driver, setupErr = NewStorageProvider(StorageProviderParams{AllowedPaths: []string{s.tempDir}})
+	require.NoError(s.T(), setupErr)
 }
 
-func (suite *LocalDirectorySuite) TestIsInstalled() {
-	installed, err := driver.IsInstalled(ctx)
-	require.NoError(suite.T(), err)
-	require.True(suite.T(), installed)
+func (s *LocalDirectorySuite) TestIsInstalled() {
+	for _, tc := range []struct {
+		name         string
+		allowedPaths []string
+		isInstalled  bool
+	}{
+		{name: "single allowed path", allowedPaths: []string{"tmp"}, isInstalled: true},
+		{name: "asterisk allowed path", allowedPaths: []string{".*"}, isInstalled: true},
+		{name: "multiple allowed paths", allowedPaths: []string{"tmp", "tmp2"}, isInstalled: true},
+		{name: "no allowed paths", allowedPaths: []string{}, isInstalled: false},
+	} {
+		s.Run(tc.name, func() {
+			storageProvider, err := NewStorageProvider(StorageProviderParams{AllowedPaths: tc.allowedPaths})
+			require.NoError(s.T(), err)
+
+			installed, err := storageProvider.IsInstalled(context.Background())
+			require.NoError(s.T(), err)
+			require.Equal(s.T(), tc.isInstalled, installed)
+		})
+	}
 }
 
-func (suite *LocalDirectorySuite) TestHasStorageLocally() {
-	folderPath := filepath.Join(tempDir, "apples/oranges")
-	spec := suite.prepareStorageSpec(folderPath)
-	hasStorageTrue, err := driver.HasStorageLocally(ctx, spec)
-	require.NoError(suite.T(), err)
-	require.True(suite.T(), hasStorageTrue, "file that exists should return true for HasStorageLocally")
-	spec.SourcePath = "apples/pears"
-	hasStorageFalse, err := driver.HasStorageLocally(ctx, spec)
-	require.NoError(suite.T(), err)
-	require.False(suite.T(), hasStorageFalse, "file that does not exist should return false for HasStorageLocally")
+func (s *LocalDirectorySuite) TestHasStorageLocally() {
+	tmpDir := s.T().TempDir()
+	tmpFile := filepath.Join(tmpDir, "file1")
+	file, err := os.Create(tmpFile)
+	s.Require().NoError(err)
+	s.Require().NoError(file.Close())
+
+	for _, tc := range []struct {
+		name              string
+		sourcePath        string
+		allowedPaths      []string
+		hasStorageLocally bool
+	}{
+		{
+			name:              "path matches allowed path",
+			sourcePath:        tmpFile,
+			allowedPaths:      []string{tmpFile},
+			hasStorageLocally: true,
+		},
+		{
+			name:              "path descendant of an allowed path",
+			sourcePath:        tmpFile,
+			allowedPaths:      []string{tmpDir},
+			hasStorageLocally: true,
+		},
+		{
+			name:              "path is a directory",
+			sourcePath:        tmpDir,
+			allowedPaths:      []string{tmpDir},
+			hasStorageLocally: true,
+		},
+		{
+			name:              "asterisk allowed path",
+			sourcePath:        tmpFile,
+			allowedPaths:      []string{".*"},
+			hasStorageLocally: true,
+		},
+		{
+			name:              "path outside of allowed paths",
+			sourcePath:        filepath.Dir(tmpDir),
+			allowedPaths:      []string{tmpDir},
+			hasStorageLocally: false,
+		},
+		{
+			name:              "no allowed paths",
+			allowedPaths:      []string{},
+			hasStorageLocally: false,
+		},
+		{
+			name:              "file doesn't exist",
+			sourcePath:        filepath.Join(tmpDir, "unknown"),
+			allowedPaths:      []string{".*"},
+			hasStorageLocally: false,
+		},
+	} {
+		s.Run(tc.name, func() {
+			storageProvider, err := NewStorageProvider(StorageProviderParams{AllowedPaths: tc.allowedPaths})
+			require.NoError(s.T(), err)
+
+			hasStorageLocally, err := storageProvider.HasStorageLocally(context.Background(), s.prepareStorageSpec(tc.sourcePath))
+			require.NoError(s.T(), err)
+			require.Equal(s.T(), tc.hasStorageLocally, hasStorageLocally)
+		})
+	}
 }
 
-func (suite *LocalDirectorySuite) TestGetVolumeSize() {
-	folderPath := filepath.Join(tempDir, "apples/oranges")
-	fileContents := "hello world"
-	spec := suite.prepareStorageSpec(folderPath)
-	filePath := filepath.Join(folderPath, "file")
-	err := os.WriteFile(filePath, []byte(fileContents), 0644)
-	require.NoError(suite.T(), err)
-	volumeSize, err := driver.GetVolumeSize(ctx, spec)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), uint64(len(fileContents)), volumeSize, "the volume size should be the size of the file")
+func (s *LocalDirectorySuite) TestGetVolumeSize() {
+	tmpDir := s.T().TempDir()
+	file1 := filepath.Join(tmpDir, "file1")
+	file2 := filepath.Join(tmpDir, "file2")
+	s.Require().NoError(os.WriteFile(file1, []byte("1234"), 0644))
+	s.Require().NoError(os.WriteFile(file2, []byte("12345678"), 0644))
+
+	for _, tc := range []struct {
+		name               string
+		sourcePath         string
+		allowedPaths       []string
+		expectedVolumeSize uint64
+		shouldFail         bool
+	}{
+		{
+			name:               "size of file1",
+			sourcePath:         file1,
+			allowedPaths:       []string{tmpDir},
+			expectedVolumeSize: 0,
+		},
+		{
+			name:               "size of file2",
+			sourcePath:         file2,
+			allowedPaths:       []string{tmpDir},
+			expectedVolumeSize: 0,
+		},
+		{
+			name:               "size of parent directory",
+			sourcePath:         tmpDir,
+			allowedPaths:       []string{tmpDir},
+			expectedVolumeSize: 0,
+		},
+		{
+			name:         "path outside of allowed paths",
+			sourcePath:   file2,
+			allowedPaths: []string{file1},
+			shouldFail:   true,
+		},
+		{
+			name:         "no allowed paths",
+			sourcePath:   file2,
+			allowedPaths: []string{},
+			shouldFail:   true,
+		},
+		{
+			name:         "file doesn't exist",
+			sourcePath:   filepath.Join(tmpDir, "unknown"),
+			allowedPaths: []string{tmpDir},
+			shouldFail:   true,
+		},
+	} {
+		s.Run(tc.name, func() {
+			storageProvider, err := NewStorageProvider(StorageProviderParams{AllowedPaths: tc.allowedPaths})
+			require.NoError(s.T(), err)
+
+			volumeSize, err := storageProvider.GetVolumeSize(context.Background(), s.prepareStorageSpec(tc.sourcePath))
+			if tc.shouldFail {
+				require.Error(s.T(), err)
+				return
+			}
+			require.Equal(s.T(), tc.expectedVolumeSize, volumeSize)
+		})
+	}
 }
 
-func (suite *LocalDirectorySuite) TestPrepareStorage() {
-	folderPath := filepath.Join(tempDir, "apples/oranges")
-	spec := suite.prepareStorageSpec(folderPath)
-	volume, err := driver.PrepareStorage(ctx, spec)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), volume.Source, folderPath, "the volume source is correct")
+func (s *LocalDirectorySuite) TestPrepareStorage() {
+	folderPath := filepath.Join(s.tempDir, "sub/path")
+	spec := s.prepareStorageSpec(folderPath)
+	volume, err := s.driver.PrepareStorage(context.Background(), spec)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), volume.Source, folderPath)
+	require.Equal(s.T(), volume.Target, spec.Path)
+	require.Equal(s.T(), volume.Type, storage.StorageVolumeConnectorBind)
+}
+
+func (s *LocalDirectorySuite) prepareStorageSpec(sourcePath string) model.StorageSpec {
+	return model.StorageSpec{
+		SourcePath: sourcePath,
+		Path:       "/path/inside/the/container",
+	}
 }


### PR DESCRIPTION
Allow defining local paths in the compute nodes as job inputs, which can be useful to process logs generated on the compute nodes.

### Compute Nodes
Compute nodes can define an allow list of local paths that can be exposed and mounted to jobs using glob patterns as follows:
```
bacalhau serve --allow-listed-local-paths <path1>[,<path2>...]

# examples:
# expose all files and subdirectories under /var/logs/ directory
bacalhau serve --allow-listed-local-paths /var/logs/**

# only expose compressed bacalhau logs
bacalhau serve --allow-listed-local-paths /var/logs/**/bacalhau*.tar.gz
```

### Job Submission
Jobs can define local inputs using `--input/-i` flags as follows:
```
bacalhau docker run  -i file:///var/log/ ubuntu ls /inputs
```

### Label Selector
Most likely label selectors will be needed to route jobs to the compute nodes with the local data as follows:
```
# spin up compute node with local directory access and labeled with name=IAmYourFather
bacalhau serve --allow-listed-local-paths /var/logs/** --labels name=IAmYourFather

# run job to query logs on that compute node
bacalhau docker run  -s name=IAmYourFather -i file:///var/log/ ubuntu ls /inputs
```

