### PR TITLE
Simplify caches further by creating directly

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -42,7 +42,6 @@ func (s *CacheSuite) createTestCache(
 	name string, maxCost uint64, freq clock.Duration,
 ) (*cache.Cache[string], error) {
 	c, err := cache.NewCache[string](
-		name,
 		cache.NewCacheOptionsWithFactories(
 			maxCost, freq, s.clock.Ticker, s.clock.Now,
 		),


### PR DESCRIPTION
Removes the cache of caches referenced by name to just allow other packages to manage them directly.