### PR TITLE
Storage cleanup of inputs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -325,7 +325,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/samber/lo v1.36.0 // indirect
+	github.com/samber/lo v1.36.0
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.9.4 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/pkg/storage/noop/noop.go
+++ b/pkg/storage/noop/noop.go
@@ -7,22 +7,22 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
-type StroageHandlerIsInstalled func(ctx context.Context) (bool, error)
-type StroageHandlerHasStorageLocally func(ctx context.Context, volume model.StorageSpec) (bool, error)
-type StroageHandlerGetVolumeSize func(ctx context.Context, volume model.StorageSpec) (uint64, error)
-type StroageHandlerPrepareStorage func(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error)
-type StroageHandlerCleanupStorage func(ctx context.Context, storageSpec model.StorageSpec, volume storage.StorageVolume) error
-type StroageHandlerUpload func(ctx context.Context, localPath string) (model.StorageSpec, error)
-type StroageHandlerExplode func(ctx context.Context, storageSpec model.StorageSpec) ([]model.StorageSpec, error)
+type StorageHandlerIsInstalled func(ctx context.Context) (bool, error)
+type StorageHandlerHasStorageLocally func(ctx context.Context, volume model.StorageSpec) (bool, error)
+type StorageHandlerGetVolumeSize func(ctx context.Context, volume model.StorageSpec) (uint64, error)
+type StorageHandlerPrepareStorage func(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error)
+type StorageHandlerCleanupStorage func(ctx context.Context, storageSpec model.StorageSpec, volume storage.StorageVolume) error
+type StorageHandlerUpload func(ctx context.Context, localPath string) (model.StorageSpec, error)
+type StorageHandlerExplode func(ctx context.Context, storageSpec model.StorageSpec) ([]model.StorageSpec, error)
 
 type StorageConfigExternalHooks struct {
-	IsInstalled       StroageHandlerIsInstalled
-	HasStorageLocally StroageHandlerHasStorageLocally
-	GetVolumeSize     StroageHandlerGetVolumeSize
-	PrepareStorage    StroageHandlerPrepareStorage
-	CleanupStorage    StroageHandlerCleanupStorage
-	Upload            StroageHandlerUpload
-	Explode           StroageHandlerExplode
+	IsInstalled       StorageHandlerIsInstalled
+	HasStorageLocally StorageHandlerHasStorageLocally
+	GetVolumeSize     StorageHandlerGetVolumeSize
+	PrepareStorage    StorageHandlerPrepareStorage
+	CleanupStorage    StorageHandlerCleanupStorage
+	Upload            StorageHandlerUpload
+	Explode           StorageHandlerExplode
 }
 
 type StorageConfig struct {

--- a/pkg/storage/parallel_test.go
+++ b/pkg/storage/parallel_test.go
@@ -1,0 +1,127 @@
+//go:build unit || !integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	executor_util "github.com/bacalhau-project/bacalhau/pkg/executor/util"
+	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
+	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/maps"
+)
+
+type ParallelStorageSuite struct {
+	suite.Suite
+
+	ctx      context.Context
+	cm       *system.CleanupManager
+	node     *ipfs.Node
+	cid      string
+	provider model.Provider[model.StorageSourceType, storage.Storage]
+}
+
+func TestParallelStorageSuite(t *testing.T) {
+	suite.Run(t, new(ParallelStorageSuite))
+}
+
+func (s *ParallelStorageSuite) SetupSuite() {
+	s.ctx = context.Background()
+	s.cm = system.NewCleanupManager()
+
+	// Setup required IPFS node and client
+	node, err := ipfs.NewLocalNode(s.ctx, s.cm, []string{})
+	require.NoError(s.T(), err)
+	s.node = node
+	client := s.node.Client()
+
+	s.cid, err = client.Put(s.ctx, "../../testdata/grep_file.txt")
+	require.NoError(s.T(), err)
+
+	s.provider, _ = executor_util.NewStandardStorageProvider(
+		s.ctx,
+		s.cm,
+		executor_util.StandardStorageProviderOptions{
+			API: client,
+		},
+	)
+}
+
+func (s *ParallelStorageSuite) TearDownSuite() {
+	s.cm.Cleanup(s.ctx)
+	_ = s.node.Close(s.ctx)
+}
+
+func (s *ParallelStorageSuite) TestIPFSCleanup() {
+	volumes, err := storage.ParallelPrepareStorage(s.ctx, s.provider, []model.StorageSpec{
+		{
+			StorageSource: model.StorageSourceIPFS,
+			Name:          "test",
+			CID:           s.cid,
+			Path:          "/inputs/test.txt",
+		},
+	})
+	require.NoError(s.T(), err)
+
+	// Make a list of which files we expect to find written to local disk and check they are
+	// there.
+	files := lo.Map(maps.Values(volumes), func(item storage.StorageVolume, index int) string {
+		return item.Source
+	})
+
+	// IPFS cleanup doesn't actually return an error as it deletes a folder
+	_ = storage.ParallelCleanStorage(s.ctx, s.provider, volumes)
+
+	// Check that all of the files have gone by statting them and expecting
+	// an error for each one
+	lo.ForEach(files, func(filepath string, index int) {
+		_, err := os.Stat(filepath)
+		require.Error(s.T(), err, "file still exists and we expected it to be deleted")
+	})
+}
+
+func (s *ParallelStorageSuite) TestURLCleanup() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, err := w.Write([]byte("hello world"))
+		s.NoError(err)
+	}))
+	defer ts.Close()
+
+	volumes, err := storage.ParallelPrepareStorage(s.ctx, s.provider, []model.StorageSpec{
+		{
+			StorageSource: model.StorageSourceURLDownload,
+			Name:          "test",
+			URL:           fmt.Sprintf("%s/test.txt", ts.URL),
+			Path:          "/inputs/test.txt",
+		},
+	})
+	require.NoError(s.T(), err)
+
+	// Make a list of which files we expect to find written to local disk and check they are
+	// there.
+	files := lo.Map(maps.Values(volumes), func(item storage.StorageVolume, index int) string {
+		return item.Source
+	})
+
+	// URL cleanup doesn't actually return an error as it deletes a folder
+	_ = storage.ParallelCleanStorage(s.ctx, s.provider, volumes)
+
+	// Check that all of the files have gone by statting them and expecting
+	// an error for each one
+	lo.ForEach(files, func(filepath string, index int) {
+		_, err := os.Stat(filepath)
+		require.Error(s.T(), err, "file still exists and we expected it to be deleted")
+	})
+}


### PR DESCRIPTION
Cleanup downloads after the executor's Run method has finished.

Currently each executor is responsible for performing the download of content and then mapping it to their equivalent of docker's volumes. Indirectly this has led to multiple ways of implementing it within the executors, and triggering the cleanup task is not straight-forward.  

This PR ensures it defers a function call so that the downloaded inputs are cleaned up in line with the implementation within the storage provider (e.g. some are noops). This implementation also now duplicates almost identifical code but this is resolved in #2466 which is a longer term solution to the problem of cleaning up resources.