### PR TITLE
add api versioning, and launch api v1

### DIFF
--- a/pkg/compute/publicapi/server.go
+++ b/pkg/compute/publicapi/server.go
@@ -38,8 +38,14 @@ func NewComputeAPIServer(params ComputeAPIServerParams) *ComputeAPIServer {
 
 func (s *ComputeAPIServer) RegisterAllHandlers() error {
 	handlerConfigs := []publicapi.HandlerConfig{
-		{URI: "/" + APIPrefix + APIDebugSuffix, Handler: http.HandlerFunc(s.debug)},
-		{URI: "/" + APIPrefix + APIApproveSuffix, Handler: http.HandlerFunc(s.approve)},
+		{Path: "/" + APIPrefix + APIDebugSuffix, Handler: http.HandlerFunc(s.debug)},
+		{Path: "/" + APIPrefix + APIApproveSuffix, Handler: http.HandlerFunc(s.approve)},
 	}
-	return s.apiServer.RegisterHandlers(handlerConfigs...)
+	// register URIs at root prefix for backward compatibility before migrating to API versioning
+	// we should remove these eventually, or have throttling limits shared across versions
+	err := s.apiServer.RegisterHandlers(publicapi.LegacyAPIPrefix, handlerConfigs...)
+	if err != nil {
+		return err
+	}
+	return s.apiServer.RegisterHandlers(publicapi.V1APIPrefix, handlerConfigs...)
 }

--- a/pkg/publicapi/client.go
+++ b/pkg/publicapi/client.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// APIClient is a utility for interacting with a node's API server.
+// APIClient is a utility for interacting with a node's API server against v1 APIs.
 type APIClient struct {
 	BaseURI        *url.URL
 	DefaultHeaders map[string]string
@@ -28,10 +28,15 @@ type APIClient struct {
 	Client *http.Client
 }
 
-// NewAPIClient returns a new client for a node's API server.
+// NewAPIClient returns a new client for a node's API server against v1 APIs
+// the client will use /api/v1 path by default is no custom path is defined
 func NewAPIClient(host string, port uint16, path ...string) *APIClient {
+	baseURI := system.MustParseURL(fmt.Sprintf("http://%s:%d", host, port)).JoinPath(path...)
+	if len(path) == 0 {
+		baseURI = baseURI.JoinPath(V1APIPrefix)
+	}
 	return &APIClient{
-		BaseURI:        system.MustParseURL(fmt.Sprintf("http://%s:%d", host, port)).JoinPath(path...),
+		BaseURI:        baseURI,
 		DefaultHeaders: map[string]string{},
 
 		Client: &http.Client{

--- a/pkg/publicapi/constants.go
+++ b/pkg/publicapi/constants.go
@@ -1,0 +1,4 @@
+package publicapi
+
+const LegacyAPIPrefix = ""
+const V1APIPrefix = "/api/v1"

--- a/pkg/publicapi/server_test.go
+++ b/pkg/publicapi/server_test.go
@@ -84,7 +84,7 @@ func (s *ServerSuite) TestVarz() {
 func (s *ServerSuite) TestTimeout() {
 	config := APIServerConfig{
 		RequestHandlerTimeoutByURI: map[string]time.Duration{
-			"/logz": 10 * time.Nanosecond,
+			V1APIPrefix + "/logz": 10 * time.Nanosecond,
 		},
 	}
 	s.client = setupNodeForTestWithConfig(s.T(), s.cleanupManager, config)

--- a/pkg/requester/publicapi/server.go
+++ b/pkg/requester/publicapi/server.go
@@ -47,16 +47,22 @@ func NewRequesterAPIServer(params RequesterAPIServerParams) *RequesterAPIServer 
 
 func (s *RequesterAPIServer) RegisterAllHandlers() error {
 	handlerConfigs := []publicapi.HandlerConfig{
-		{URI: "/" + APIPrefix + "list", Handler: http.HandlerFunc(s.list)},
-		{URI: "/" + APIPrefix + "states", Handler: http.HandlerFunc(s.states)},
-		{URI: "/" + APIPrefix + "results", Handler: http.HandlerFunc(s.results)},
-		{URI: "/" + APIPrefix + "events", Handler: http.HandlerFunc(s.events)},
-		{URI: "/" + APIPrefix + "submit", Handler: http.HandlerFunc(s.submit)},
-		{URI: "/" + APIPrefix + ApprovalRoute, Handler: http.HandlerFunc(s.approve)},
-		{URI: "/" + APIPrefix + "cancel", Handler: http.HandlerFunc(s.cancel)},
-		{URI: "/" + APIPrefix + "websocket/events", Handler: http.HandlerFunc(s.websocketJobEvents), Raw: true},
-		{URI: "/" + APIPrefix + "logs", Handler: http.HandlerFunc(s.logs), Raw: true},
-		{URI: "/" + APIPrefix + "debug", Handler: http.HandlerFunc(s.debug)},
+		{Path: "/" + APIPrefix + "list", Handler: http.HandlerFunc(s.list)},
+		{Path: "/" + APIPrefix + "states", Handler: http.HandlerFunc(s.states)},
+		{Path: "/" + APIPrefix + "results", Handler: http.HandlerFunc(s.results)},
+		{Path: "/" + APIPrefix + "events", Handler: http.HandlerFunc(s.events)},
+		{Path: "/" + APIPrefix + "submit", Handler: http.HandlerFunc(s.submit)},
+		{Path: "/" + APIPrefix + ApprovalRoute, Handler: http.HandlerFunc(s.approve)},
+		{Path: "/" + APIPrefix + "cancel", Handler: http.HandlerFunc(s.cancel)},
+		{Path: "/" + APIPrefix + "websocket/events", Handler: http.HandlerFunc(s.websocketJobEvents), Raw: true},
+		{Path: "/" + APIPrefix + "logs", Handler: http.HandlerFunc(s.logs), Raw: true},
+		{Path: "/" + APIPrefix + "debug", Handler: http.HandlerFunc(s.debug)},
 	}
-	return s.apiServer.RegisterHandlers(handlerConfigs...)
+	// register URIs at root prefix for backward compatibility before migrating to API versioning
+	// we should remove these eventually, or have throttling limits shared across versions
+	err := s.apiServer.RegisterHandlers(publicapi.LegacyAPIPrefix, handlerConfigs...)
+	if err != nil {
+		return err
+	}
+	return s.apiServer.RegisterHandlers(publicapi.V1APIPrefix, handlerConfigs...)
 }


### PR DESCRIPTION
HTTP APIs are now prefixed with `/api/v1` for easier future migrations and maintaining backward compatibility. Existing APIs still point to root path as well to avoid breaking existing clients.

e.g. you can query node_info either through the existing `/node_info` path, or the new `/api/v1/node_info` `/node_info`

### Testing
deployed to staging and verified the canaries which are calling the old APIs are still working, and verified manually the new APIs are working and the CLI is not broken