### PR TITLE
WIP: Run executors in an 'environment'

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
 	"github.com/bacalhau-project/bacalhau/pkg/verifier"
 	"github.com/rs/zerolog/log"
@@ -20,6 +21,7 @@ type BaseExecutorParams struct {
 	Callback        Callback
 	Store           store.ExecutionStore
 	Executors       executor.ExecutorProvider
+	Storage         storage.StorageProvider
 	Verifiers       verifier.VerifierProvider
 	Publishers      publisher.PublisherProvider
 	SimulatorConfig model.SimulatorConfigCompute
@@ -33,6 +35,7 @@ type BaseExecutor struct {
 	store           store.ExecutionStore
 	cancellers      generic.SyncMap[string, context.CancelFunc]
 	executors       executor.ExecutorProvider
+	storage         storage.StorageProvider
 	verifiers       verifier.VerifierProvider
 	publishers      publisher.PublisherProvider
 	simulatorConfig model.SimulatorConfigCompute
@@ -104,7 +107,7 @@ func (e *BaseExecutor) Run(ctx context.Context, execution store.Execution) (err 
 
 	// Create a new execution environment for the provided execution and using the
 	// storage provider that the job executor was provided with earlier
-	env, err := executor.NewEnvironment(execution, jobExecutor.GetStorageProvider(ctx))
+	env, err := executor.NewEnvironment(execution, e.storage)
 	if err != nil {
 		return errors.Join(
 			fmt.Errorf("failed to initialize environment for compute"),

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -70,10 +70,6 @@ func NewExecutor(
 	return de, nil
 }
 
-func (e *Executor) GetStorageProvider(ctx context.Context) storage.StorageProvider {
-	return e.StorageProvider
-}
-
 func (e *Executor) getStorage(ctx context.Context, engine model.StorageSourceType) (storage.Storage, error) {
 	return e.StorageProvider.Get(ctx, engine)
 }

--- a/pkg/executor/environment.go
+++ b/pkg/executor/environment.go
@@ -1,0 +1,112 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
+	"github.com/bacalhau-project/bacalhau/pkg/verifier"
+	"github.com/rs/zerolog/log"
+)
+
+type Environment struct {
+	Execution       store.Execution
+	InputVolumes    map[*model.StorageSpec]storage.StorageVolume
+	OutputFolder    string
+	OutputVolumes   map[*model.StorageSpec]storage.StorageVolume
+	StorageProvider storage.StorageProvider
+}
+
+func NewEnvironment(execution store.Execution, storageProvider storage.StorageProvider) (*Environment, error) {
+	return &Environment{
+		Execution:       execution,
+		InputVolumes:    make(map[*model.StorageSpec]storage.StorageVolume),
+		OutputVolumes:   make(map[*model.StorageSpec]storage.StorageVolume),
+		StorageProvider: storageProvider,
+	}, nil
+}
+
+func (e *Environment) Build(
+	ctx context.Context,
+	verifier verifier.Verifier) error {
+	// Ensure output path is created
+	outputFolder, err := verifier.GetResultPath(ctx, e.Execution.ID, e.Execution.Job)
+	if err != nil {
+		return err
+	}
+	e.OutputFolder = outputFolder
+
+	// For specific outputs in spec, make sure the directory exists under output
+	// folder ready for mounting by the executor
+	for i := range e.Execution.Job.Spec.Outputs {
+		output := e.Execution.Job.Spec.Outputs[i]
+
+		if output.Name == "" {
+			err = fmt.Errorf("output volume has no name: %+v", output)
+			return err
+		}
+
+		if output.Path == "" {
+			err = fmt.Errorf("output volume has no path: %+v", output)
+			return err
+		}
+
+		srcd := filepath.Join(e.OutputFolder, output.Name)
+		err = os.Mkdir(srcd, util.OS_ALL_R|util.OS_ALL_X|util.OS_USER_W)
+		if err != nil {
+			return err
+		}
+
+		e.OutputVolumes[&output] = storage.StorageVolume{
+			Type:   storage.StorageVolumeConnectorBind,
+			Source: srcd,
+			Target: output.Path,
+		}
+	}
+
+	// Process inputs
+	e.InputVolumes, err = storage.ParallelPrepareStorage(ctx, e.StorageProvider, e.Execution.Job.Spec.Inputs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *Environment) Destroy(ctx context.Context) error {
+	// Can clean up inputs, but not allowed to clean up output as it will be used
+	// later by Publish which will take responsibility for publishing the output
+	for specification, volume := range e.InputVolumes {
+		spec := specification
+
+		// we can tell it to cleanup the storage at the end of the execution.
+		provider, err := e.StorageProvider.Get(ctx, spec.StorageSource)
+		if err != nil {
+			log.Ctx(ctx).Error().
+				Err(err).
+				Str("Source", spec.StorageSource.String()).
+				Msg("failed to get storage provider in cleanup")
+			return err
+		}
+
+		log.Ctx(ctx).Debug().
+			Str("Execution", e.Execution.ID).
+			Msg("cleaning up inputs for execution")
+
+		// May be noop depending on the storage provider
+		err = provider.CleanupStorage(ctx, *spec, volume)
+		if err != nil {
+			log.Ctx(ctx).Error().
+				Err(err).
+				Str("Source", spec.StorageSource.String()).
+				Msg("failed to cleanup volume")
+		}
+	}
+
+	return nil
+}

--- a/pkg/executor/environment.go
+++ b/pkg/executor/environment.go
@@ -41,6 +41,14 @@ func (e *Environment) Build(
 	}
 	e.OutputFolder = outputFolder
 
+	// Noop won't have a storage provider and so we shouldn't try and download
+	// anything.  It tells us this with a nil pointer :(
+	// TODO: We need to understand what happens if the nop executor has a handler
+	// installed.
+	if e.StorageProvider == nil {
+		return nil
+	}
+
 	// For specific outputs in spec, make sure the directory exists under output
 	// folder ready for mounting by the executor
 	for i := range e.Execution.Job.Spec.Outputs {

--- a/pkg/executor/language/executor.go
+++ b/pkg/executor/language/executor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/resource"
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
@@ -56,6 +57,10 @@ func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSp
 	return true, nil
 }
 
+func (e *Executor) GetStorageProvider(ctx context.Context) storage.StorageProvider {
+	return nil
+}
+
 func (e *Executor) GetVolumeSize(ctx context.Context, volumes model.StorageSpec) (uint64, error) {
 	return 0, nil
 }
@@ -70,16 +75,16 @@ func (e *Executor) GetResourceBidStrategy(ctx context.Context) (bidstrategy.Reso
 
 func (e *Executor) Run(
 	ctx context.Context,
-	executionID string,
-	job model.Job,
-	jobResultsDir string,
+	env *executor.Environment,
 ) (*model.RunCommandResult, error) {
+	job := env.Execution.Job
+
 	executor, err := e.getDelegateExecutor(ctx, job)
 	if err != nil {
 		return nil, err
 	}
-	e.delegatedExecutors.Put(executionID, executor)
-	return executor.Run(ctx, executionID, job, jobResultsDir)
+	e.delegatedExecutors.Put(env.Execution.ID, executor)
+	return executor.Run(ctx, env)
 }
 
 func (e *Executor) GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error) {

--- a/pkg/executor/language/executor.go
+++ b/pkg/executor/language/executor.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/resource"
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
-	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
@@ -55,10 +54,6 @@ func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
 
 func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSpec) (bool, error) {
 	return true, nil
-}
-
-func (e *Executor) GetStorageProvider(ctx context.Context) storage.StorageProvider {
-	return nil
 }
 
 func (e *Executor) GetVolumeSize(ctx context.Context, volumes model.StorageSpec) (uint64, error) {

--- a/pkg/executor/noop/executor.go
+++ b/pkg/executor/noop/executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
 type ExecutorHandlerIsInstalled func(ctx context.Context) (bool, error)
@@ -19,7 +18,6 @@ type ExecutorHandlerHasStorageLocally func(ctx context.Context, volume model.Sto
 type ExecutorHandlerGetVolumeSize func(ctx context.Context, volume model.StorageSpec) (uint64, error)
 type ExecutorHandlerGetBidStrategy func(ctx context.Context) (bidstrategy.BidStrategy, error)
 type ExecutorHandlerJobHandler func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error)
-type ExecutorHandlerGetStorageProvider func(ctx context.Context) storage.StorageProvider
 
 func ErrorJobHandler(err error) ExecutorHandlerJobHandler {
 	return func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
@@ -35,12 +33,11 @@ func DelayedJobHandler(sleep time.Duration) ExecutorHandlerJobHandler {
 }
 
 type ExecutorConfigExternalHooks struct {
-	IsInstalled        ExecutorHandlerIsInstalled
-	HasStorageLocally  ExecutorHandlerHasStorageLocally
-	GetVolumeSize      ExecutorHandlerGetVolumeSize
-	GetBidStrategy     ExecutorHandlerGetBidStrategy
-	GetStorageProvider ExecutorHandlerGetStorageProvider
-	JobHandler         ExecutorHandlerJobHandler
+	IsInstalled       ExecutorHandlerIsInstalled
+	HasStorageLocally ExecutorHandlerHasStorageLocally
+	GetVolumeSize     ExecutorHandlerGetVolumeSize
+	GetBidStrategy    ExecutorHandlerGetBidStrategy
+	JobHandler        ExecutorHandlerJobHandler
 }
 
 type ExecutorConfig struct {
@@ -79,16 +76,6 @@ func (e *NoopExecutor) HasStorageLocally(ctx context.Context, volume model.Stora
 		return handler(ctx, volume)
 	}
 	return true, nil
-}
-
-func (e *NoopExecutor) GetStorageProvider(ctx context.Context) storage.StorageProvider {
-	if e.Config.ExternalHooks.GetStorageProvider != nil {
-		handler := e.Config.ExternalHooks.GetStorageProvider
-		return handler(ctx)
-	}
-
-	// TODO: Find a non-nil storage provider we can use
-	return nil
 }
 
 func (e *NoopExecutor) GetVolumeSize(ctx context.Context, volume model.StorageSpec) (uint64, error) {

--- a/pkg/executor/python_wasm/executor.go
+++ b/pkg/executor/python_wasm/executor.go
@@ -16,7 +16,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
 type Executor struct {
@@ -44,14 +43,6 @@ func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
 
 func (e *Executor) HasStorageLocally(context.Context, model.StorageSpec) (bool, error) {
 	return true, nil
-}
-
-func (e *Executor) GetStorageProvider(ctx context.Context) storage.StorageProvider {
-	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
-	if err != nil {
-		return nil
-	}
-	return dockerExecutor.GetStorageProvider(ctx)
 }
 
 func (e *Executor) GetVolumeSize(context.Context, model.StorageSpec) (uint64, error) {

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
 // Returns a executor for the given engine type
@@ -36,9 +35,6 @@ type Executor interface {
 
 	// GetOutputStream retrieves a muxed stream from the executor
 	GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error)
-
-	// GetStorageProvider retrieves the storage provider used by the executor
-	GetStorageProvider(ctx context.Context) storage.StorageProvider
 
 	// run the given job - it's expected that we have already prepared the job
 	// this will return a local filesystem path to the jobs results

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
 // Returns a executor for the given engine type
@@ -36,12 +37,12 @@ type Executor interface {
 	// GetOutputStream retrieves a muxed stream from the executor
 	GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error)
 
+	// GetStorageProvider retrieves the storage provider used by the executor
+	GetStorageProvider(ctx context.Context) storage.StorageProvider
+
 	// run the given job - it's expected that we have already prepared the job
 	// this will return a local filesystem path to the jobs results
 	Run(
-		ctx context.Context,
-		executionID string,
-		job model.Job,
-		resultsDir string,
+		ctx context.Context, env *Environment,
 	) (*model.RunCommandResult, error)
 }

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -59,10 +59,6 @@ func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSp
 	return s.HasStorageLocally(ctx, volume)
 }
 
-func (e *Executor) GetStorageProvider(ctx context.Context) storage.StorageProvider {
-	return e.StorageProvider
-}
-
 func (e *Executor) GetVolumeSize(ctx context.Context, volume model.StorageSpec) (uint64, error) {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.Executor.GetVolumeSize")
 	defer span.End()

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -39,6 +39,7 @@ type Compute struct {
 	Capacity            capacity.Tracker
 	ExecutionStore      store.ExecutionStore
 	Executors           executor.ExecutorProvider
+	Storage             storage.StorageProvider
 	LogServer           *logstream.LogStreamServer
 	Bidder              compute.Bidder
 	computeCallback     *bprotocol.CallbackProxy
@@ -107,6 +108,7 @@ func NewComputeNode(
 		Store:           executionStore,
 		Executors:       executors,
 		Verifiers:       verifiers,
+		Storage:         storages,
 		Publishers:      publishers,
 		SimulatorConfig: config.SimulatorConfig,
 	})
@@ -281,6 +283,7 @@ func NewComputeNode(
 		Capacity:            runningCapacityTracker,
 		ExecutionStore:      executionStore,
 		Executors:           executors,
+		Storage:             storages,
 		Bidder:              bidder,
 		LogServer:           logserver,
 		computeCallback:     standardComputeCallback,

--- a/pkg/node/factories.go
+++ b/pkg/node/factories.go
@@ -80,6 +80,7 @@ func (f *StandardStorageProvidersFactory) Get(
 		executor_util.StandardStorageProviderOptions{
 			API:                   nodeConfig.IPFSClient,
 			FilecoinUnsealedPath:  nodeConfig.FilecoinUnsealedPath,
+			EstuaryAPIKey:         nodeConfig.EstuaryAPIKey,
 			AllowListedLocalPaths: nodeConfig.AllowListedLocalPaths,
 		},
 	)

--- a/pkg/storage/noop/noop.go
+++ b/pkg/storage/noop/noop.go
@@ -7,22 +7,22 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
-type StroageHandlerIsInstalled func(ctx context.Context) (bool, error)
-type StroageHandlerHasStorageLocally func(ctx context.Context, volume model.StorageSpec) (bool, error)
-type StroageHandlerGetVolumeSize func(ctx context.Context, volume model.StorageSpec) (uint64, error)
-type StroageHandlerPrepareStorage func(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error)
-type StroageHandlerCleanupStorage func(ctx context.Context, storageSpec model.StorageSpec, volume storage.StorageVolume) error
-type StroageHandlerUpload func(ctx context.Context, localPath string) (model.StorageSpec, error)
-type StroageHandlerExplode func(ctx context.Context, storageSpec model.StorageSpec) ([]model.StorageSpec, error)
+type StorageHandlerIsInstalled func(ctx context.Context) (bool, error)
+type StorageHandlerHasStorageLocally func(ctx context.Context, volume model.StorageSpec) (bool, error)
+type StorageHandlerGetVolumeSize func(ctx context.Context, volume model.StorageSpec) (uint64, error)
+type StorageHandlerPrepareStorage func(ctx context.Context, storageSpec model.StorageSpec) (storage.StorageVolume, error)
+type StorageHandlerCleanupStorage func(ctx context.Context, storageSpec model.StorageSpec, volume storage.StorageVolume) error
+type StorageHandlerUpload func(ctx context.Context, localPath string) (model.StorageSpec, error)
+type StorageHandlerExplode func(ctx context.Context, storageSpec model.StorageSpec) ([]model.StorageSpec, error)
 
 type StorageConfigExternalHooks struct {
-	IsInstalled       StroageHandlerIsInstalled
-	HasStorageLocally StroageHandlerHasStorageLocally
-	GetVolumeSize     StroageHandlerGetVolumeSize
-	PrepareStorage    StroageHandlerPrepareStorage
-	CleanupStorage    StroageHandlerCleanupStorage
-	Upload            StroageHandlerUpload
-	Explode           StroageHandlerExplode
+	IsInstalled       StorageHandlerIsInstalled
+	HasStorageLocally StorageHandlerHasStorageLocally
+	GetVolumeSize     StorageHandlerGetVolumeSize
+	PrepareStorage    StorageHandlerPrepareStorage
+	CleanupStorage    StorageHandlerCleanupStorage
+	Upload            StorageHandlerUpload
+	Explode           StorageHandlerExplode
 }
 
 type StorageConfig struct {

--- a/pkg/storage/parallel.go
+++ b/pkg/storage/parallel.go
@@ -25,6 +25,7 @@ func ParallelPrepareStorage(
 		addStorageSpec := func() error {
 			var storageProvider Storage
 			var volumeMount StorageVolume
+
 			storageProvider, err := provider.Get(ctx, spec.StorageSource)
 			if err != nil {
 				return err

--- a/pkg/test/executor/test_runner.go
+++ b/pkg/test/executor/test_runner.go
@@ -35,6 +35,8 @@ func RunTestCase(
 	executor, err := stack.Nodes[0].ComputeNode.Executors.Get(ctx, spec.Engine)
 	require.NoError(t, err)
 
+	storageProvider := stack.Nodes[0].ComputeNode.Storage
+
 	isInstalled, err := executor.IsInstalled(ctx)
 	require.NoError(t, err)
 	require.True(t, isInstalled)
@@ -79,7 +81,7 @@ func RunTestCase(
 		Job: job,
 	}
 
-	env, err := exec.NewEnvironment(execution, executor.GetStorageProvider(ctx))
+	env, err := exec.NewEnvironment(execution, storageProvider)
 	require.NoError(t, err)
 
 	cm := system.NewCleanupManager()

--- a/pkg/test/logstream/setup_test.go
+++ b/pkg/test/logstream/setup_test.go
@@ -49,8 +49,9 @@ func waitForOutputStream(ctx context.Context, executionID string, withHistory bo
 				return nil, err
 			}
 
-			time.Sleep(time.Duration(500) * time.Millisecond)
+			time.Sleep(time.Duration(200) * time.Millisecond)
 		}
+
 		if reader != nil {
 			return reader, nil
 		}

--- a/pkg/test/logstream/stream_address_test.go
+++ b/pkg/test/logstream/stream_address_test.go
@@ -3,10 +3,15 @@
 package logstream
 
 import (
+	"context"
+
 	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
 	"github.com/bacalhau-project/bacalhau/pkg/docker"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/requester"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	noop_verifier "github.com/bacalhau-project/bacalhau/pkg/verifier/noop"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,9 +34,27 @@ func (s *LogStreamTestSuite) TestStreamAddress() {
 	require.NoError(s.T(), err)
 
 	go func() {
+		cm := system.NewCleanupManager()
+		s.T().Cleanup(func() { cm.Cleanup(context.Background()) })
+
+		result := s.T().TempDir()
+
+		verifierMock, err := noop_verifier.NewNoopVerifierWithConfig(context.Background(), cm, noop_verifier.VerifierConfig{
+			ExternalHooks: noop_verifier.VerifierExternalHooks{
+				GetResultPath: func(ctx context.Context, executionID string, job model.Job) (string, error) {
+					return result, nil
+				},
+			},
+		})
+		require.NoError(s.T(), err)
+
+		ex, _ := node.ComputeNode.Executors.Get(s.ctx, model.EngineDocker)
+		env, _ := executor.NewEnvironment(execution, ex.GetStorageProvider(s.ctx))
+		env.Build(s.ctx, verifierMock)
+
 		// Run the job.  We won't ever get a result because of the
 		// entrypoint we chose, but we might get timed-out.
-		_, _ = exec.Run(s.ctx, execution.ID, job, "/tmp")
+		_, _ = exec.Run(s.ctx, env)
 	}()
 
 	// Wait for the docker container to be running so we know it'll be there when

--- a/pkg/test/logstream/stream_address_test.go
+++ b/pkg/test/logstream/stream_address_test.go
@@ -48,8 +48,7 @@ func (s *LogStreamTestSuite) TestStreamAddress() {
 		})
 		require.NoError(s.T(), err)
 
-		ex, _ := node.ComputeNode.Executors.Get(s.ctx, model.EngineDocker)
-		env, _ := executor.NewEnvironment(execution, ex.GetStorageProvider(s.ctx))
+		env, _ := executor.NewEnvironment(execution, node.ComputeNode.Storage)
 		env.Build(s.ctx, verifierMock)
 
 		// Run the job.  We won't ever get a result because of the

--- a/pkg/test/logstream/stream_docker_test.go
+++ b/pkg/test/logstream/stream_docker_test.go
@@ -60,8 +60,7 @@ func (s *LogStreamTestSuite) TestDockerOutputStream() {
 		})
 		require.NoError(s.T(), err)
 
-		ex, _ := node.ComputeNode.Executors.Get(s.ctx, model.EngineDocker)
-		env, _ := executor.NewEnvironment(execution, ex.GetStorageProvider(s.ctx))
+		env, _ := executor.NewEnvironment(execution, node.ComputeNode.Storage)
 		env.Build(s.ctx, verifierMock)
 		// Run the job.  We won't ever get a result because of the
 		// entrypoint we chose, but we might get timed-out.

--- a/pkg/test/logstream/stream_wasm_test.go
+++ b/pkg/test/logstream/stream_wasm_test.go
@@ -80,8 +80,7 @@ func (s *LogStreamTestSuite) TestWasmOutputStream() {
 		})
 		require.NoError(s.T(), err)
 
-		ex, _ := node.ComputeNode.Executors.Get(s.ctx, model.EngineDocker)
-		env, _ := executor.NewEnvironment(execution, ex.GetStorageProvider(s.ctx))
+		env, _ := executor.NewEnvironment(execution, node.ComputeNode.Storage)
 		env.Build(s.ctx, verifierMock)
 
 		<-ready

--- a/pkg/test/logstream/stream_wasm_test.go
+++ b/pkg/test/logstream/stream_wasm_test.go
@@ -3,15 +3,33 @@
 package logstream
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/testdata/wasm/cat"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/test/scenario"
+	noop_verifier "github.com/bacalhau-project/bacalhau/pkg/verifier/noop"
+	"github.com/bacalhau-project/bacalhau/testdata/wasm/logtest"
 	"github.com/stretchr/testify/require"
 	"github.com/vincent-petithory/dataurl"
 )
+
+func (s *LogStreamTestSuite) initStorage(source, target string) []model.StorageSpec {
+	clients := s.stack.IPFSClients()
+	s.Require().GreaterOrEqual(len(clients), 1, "No IPFS clients to upload to?")
+
+	getStorage := scenario.StoredFile(source, target)
+	storageList, stErr := getStorage(s.ctx, model.StorageSourceIPFS, clients...)
+	s.Require().NoError(stErr)
+
+	return storageList
+}
 
 func (s *LogStreamTestSuite) TestWasmOutputStream() {
 	node := s.stack.Nodes[0]
@@ -27,24 +45,59 @@ func (s *LogStreamTestSuite) TestWasmOutputStream() {
 		},
 		Spec: model.Spec{
 			Engine: model.EngineWasm,
+			Inputs: s.initStorage(
+				"../../../testdata/wasm/logtest/inputs/cosmic_computer.txt", "/inputs/file.txt",
+			),
 			Wasm: model.JobSpecWasm{
 				EntryPoint: "_start",
+				Parameters: []string{"/inputs/file.txt"},
 				EntryModule: model.StorageSpec{
 					StorageSource: model.StorageSourceInline,
-					URL:           dataurl.EncodeBytes(cat.Program()),
+					URL:           dataurl.EncodeBytes(logtest.Program()),
 				},
 			},
 		},
 	}
 
+	ready := make(chan struct{})
+
 	go func() {
+		cm := system.NewCleanupManager()
+		s.T().Cleanup(func() { cm.Cleanup(context.Background()) })
+
+		result := s.T().TempDir()
+
+		execution := store.Execution{
+			ID:  "test-execution",
+			Job: job,
+		}
+		verifierMock, err := noop_verifier.NewNoopVerifierWithConfig(context.Background(), cm, noop_verifier.VerifierConfig{
+			ExternalHooks: noop_verifier.VerifierExternalHooks{
+				GetResultPath: func(ctx context.Context, executionID string, job model.Job) (string, error) {
+					return result, nil
+				},
+			},
+		})
+		require.NoError(s.T(), err)
+
+		ex, _ := node.ComputeNode.Executors.Get(s.ctx, model.EngineDocker)
+		env, _ := executor.NewEnvironment(execution, ex.GetStorageProvider(s.ctx))
+		env.Build(s.ctx, verifierMock)
+
+		<-ready
+
 		// Run the job.  We won't ever get a result because of the
 		// entrypoint we chose, but we might get timed-out.
-		dir, _ := os.MkdirTemp("", "test")
-		_, err = exec.Run(ctx, "test-execution", job, dir)
+		res, err := exec.Run(ctx, env)
 		require.NoError(s.T(), err)
 	}()
 
-	_, err = waitForOutputStream(ctx, "test-execution", true, true, exec)
-	require.NotNil(s.T(), err)
+	ready <- struct{}{}
+
+	r, err := waitForOutputStream(ctx, "test-execution", true, true, exec)
+	require.NotNil(s.T(), r)
+
+	sc := bufio.NewScanner(r)
+	sc.Scan()
+	require.Contains(s.T(), sc.Text(), "The Project Gutenberg EBook of The Cosmic Computer, by Henry Beam Piper")
 }


### PR DESCRIPTION
Currently executors have reponsibility for executing 'code', but also has responsibility for preparing the environment where it runs. This leads to a situation where each of the executors performs it's own retrieval from storage and it's own mapping onto whatever mechanism it uses to make the data available.  This makes it difficult to have a single location where we can ensure we clean up that environment as StorageProviders are attached directly to the executor.

This commit introduces an `executor.Environment` (cyclic dependencies made `compute.Environment` untenable) which can prepare the storage before providing enough information to the executor to map the data into it's compute-space. This new environment can also ensure that any resources created by the execution can be cleaned up once the process has completed.

Current blockers:

* DiskUsageCalculator depends on the executor being able to get the volume size - this should be the environment's responsibility 
* Scenario tests are ending up with nil StorageProviders and it's not straight-forward to unpick the dep injection alongside the factories to figure out why
* 

