### PR TITLE
Fix examples for 1.0.0 Python SDK

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -60,8 +60,7 @@ from bacalhau_apiclient.models.storage_spec import StorageSpec
 from bacalhau_apiclient.models.spec import Spec
 from bacalhau_apiclient.models.job_spec_language import JobSpecLanguage
 from bacalhau_apiclient.models.job_spec_docker import JobSpecDocker
-from bacalhau_apiclient.models.job_sharding_config import JobShardingConfig
-from bacalhau_apiclient.models.job_execution_plan import JobExecutionPlan
+from bacalhau_apiclient.models.publisher_spec import PublisherSpec
 from bacalhau_apiclient.models.deal import Deal
 
 
@@ -71,7 +70,7 @@ data = dict(
     Spec=Spec(
         engine="Docker",
         verifier="Noop",
-        publisher="Estuary",
+        publisher_spec=PublisherSpec(type="Estuary"),
         docker=JobSpecDocker(
             image="ubuntu",
             entrypoint=["echo", "Hello World!"],

--- a/python/examples/submit_job.py
+++ b/python/examples/submit_job.py
@@ -3,10 +3,9 @@
 import pprint
 
 from bacalhau_apiclient.models.deal import Deal
-from bacalhau_apiclient.models.job_execution_plan import JobExecutionPlan
-from bacalhau_apiclient.models.job_sharding_config import JobShardingConfig
 from bacalhau_apiclient.models.job_spec_docker import JobSpecDocker
 from bacalhau_apiclient.models.job_spec_language import JobSpecLanguage
+from bacalhau_apiclient.models.publisher_spec import PublisherSpec
 from bacalhau_apiclient.models.spec import Spec
 from bacalhau_apiclient.models.storage_spec import StorageSpec
 
@@ -19,7 +18,7 @@ data = dict(
     Spec=Spec(
         engine="Docker",
         verifier="Noop",
-        publisher="Estuary",
+        publisher_spec=PublisherSpec(type="ipfs"),
         docker=JobSpecDocker(
             image="ubuntu",
             entrypoint=["echo", "Hello World!"],
@@ -35,11 +34,6 @@ data = dict(
                 path="/outputs",
             )
         ],
-        sharding=JobShardingConfig(
-            batch_size=1,
-            glob_pattern_base_path="/inputs",
-        ),
-        execution_plan=JobExecutionPlan(shards_total=0),
         deal=Deal(concurrency=1, confidence=0, min_bids=0),
         do_not_track=False,
     ),

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -21,14 +21,14 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "bacalhau-apiclient"
-version = "0.3.23.post8"
+version = "1.0.0"
 description = "A Python client for the Bacalhau public API - https://github.com/bacalhau-project/bacalhau/tree/main/clients/python"
 category = "main"
 optional = false
 python-versions = ">=3.6.2"
 files = [
-    {file = "bacalhau_apiclient-0.3.23.post8-py3-none-any.whl", hash = "sha256:9dd815fe85d6c274830f7beb88d71f50612c32cbdd009186f16a40fcc10dc168"},
-    {file = "bacalhau_apiclient-0.3.23.post8.tar.gz", hash = "sha256:5fa7d7264156a4a7ed71d94dad540ef7ac771e48dd95dfa704b8f6536d3de50c"},
+    {file = "bacalhau_apiclient-1.0.0-py3-none-any.whl", hash = "sha256:3223b8c139dc4b0e8931ed00d497d71b493928d8620db8197b15ef95c851e34f"},
+    {file = "bacalhau_apiclient-1.0.0.tar.gz", hash = "sha256:e5a798ca86da8d104f579c984f31be9f56af74361d67e655b9e7a2ff641b4c38"},
 ]
 
 [[package]]
@@ -1743,4 +1743,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "ca99c52f5f2bad671dcfa114b4dc5a70ab70dbf9f1d377b1d3c859023511559f"
+content-hash = "63043381b33cb3e869f98881a34ea3510c52b2582832cdf846a6b7211d2fae1e"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,7 +42,7 @@ pycryptodome = "^3.16.0"
 cryptography = "^39.0.1"
 six = "^1.16.0"
 types-six = "^1.16.21.4"
-bacalhau-apiclient = "*"
+bacalhau-apiclient = "1.0.0"
 
 [tool.poetry.extras]
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -118,10 +118,9 @@ def test_sign_for_client():
 
     from bacalhau_apiclient.api import job_api
     from bacalhau_apiclient.models.deal import Deal
-    from bacalhau_apiclient.models.job_execution_plan import JobExecutionPlan
-    from bacalhau_apiclient.models.job_sharding_config import JobShardingConfig
     from bacalhau_apiclient.models.job_spec_docker import JobSpecDocker
     from bacalhau_apiclient.models.job_spec_language import JobSpecLanguage
+    from bacalhau_apiclient.models.publisher_spec import PublisherSpec
     from bacalhau_apiclient.models.spec import Spec
     from bacalhau_apiclient.models.storage_spec import StorageSpec
     from Crypto.Hash import SHA256
@@ -137,7 +136,7 @@ def test_sign_for_client():
         spec=Spec(
             engine="Docker",
             verifier="Noop",
-            publisher="Estuary",
+            publisher=PublisherSpec(type="Estuary"),
             docker=JobSpecDocker(
                 image="ubuntu",
                 entrypoint=["date"],
@@ -153,11 +152,6 @@ def test_sign_for_client():
                     path="/outputs",
                 )
             ],
-            sharding=JobShardingConfig(
-                batch_size=1,
-                glob_pattern_base_path="/inputs",
-            ),
-            execution_plan=JobExecutionPlan(shards_total=0),
             deal=Deal(concurrency=1, confidence=0, min_bids=0),
             do_not_track=False,
         ),


### PR DESCRIPTION
When running against bacalhau_apiclient==1.0.0 the examples did not work due to server side changes.  This PR makes sure it runs against 1.0 and fixes the example to use the new approach.

Resolves #2469 