### PR TITLE
Cache docker manifests for compute node bidding

### DIFF
--- a/pkg/cache/fake/cache.go
+++ b/pkg/cache/fake/cache.go
@@ -3,7 +3,11 @@ package fake
 // MockCache is a simple map-based cache useable
 // in tests without using a real cache.
 type FakeCache[T any] struct {
-	inner map[string]FakeCacheItem[T]
+	inner              map[string]FakeCacheItem[T]
+	GetCalls           int
+	SetCalls           int
+	SuccessfulGetCalls int
+	FailedGetCalls     int
 }
 
 type FakeCacheItem[T any] struct {
@@ -12,21 +16,25 @@ type FakeCacheItem[T any] struct {
 	Expiry int64
 }
 
-func NewFakeCache[T any]() FakeCache[T] {
-	return FakeCache[T]{
+func NewFakeCache[T any]() *FakeCache[T] {
+	return &FakeCache[T]{
 		inner: make(map[string]FakeCacheItem[T]),
 	}
 }
 
-func (m FakeCache[T]) Get(key string) (T, bool) {
+func (m *FakeCache[T]) Get(key string) (T, bool) {
+	m.GetCalls += 1
 	v, ok := m.inner[key]
 	if ok {
+		m.SuccessfulGetCalls += 1
 		return v.Value, ok
 	}
+	m.FailedGetCalls += 1
 	return *new(T), ok
 }
 
-func (m FakeCache[T]) Set(key string, value T, cost uint64, expiresInSeconds int64) error {
+func (m *FakeCache[T]) Set(key string, value T, cost uint64, expiresInSeconds int64) error {
+	m.SetCalls += 1
 	m.inner[key] = FakeCacheItem[T]{
 		Value:  value,
 		Cost:   cost,
@@ -35,8 +43,12 @@ func (m FakeCache[T]) Set(key string, value T, cost uint64, expiresInSeconds int
 	return nil
 }
 
-func (m FakeCache[T]) Delete(key string) {
+func (m *FakeCache[T]) Delete(key string) {
 	delete(m.inner, key)
 }
 
-func (m FakeCache[T]) Close() {}
+func (m *FakeCache[T]) Close() {}
+
+func (m *FakeCache[T]) ItemCount() int {
+	return len(m.inner)
+}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -330,14 +330,15 @@ func (c *Client) ImageDistribution(
 	authToken := getAuthToken(ctx, image, creds)
 	dist, err := c.DistributionInspect(ctx, image, authToken)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, DistributionInspectError, image)
 	}
 
 	obj := dist.Descriptor.Digest
 	manifest := &ImageManifest{
-		Digest: obj,
+		Digest:    obj,
+		Platforms: append([]v1.Platform(nil), dist.Platforms...),
 	}
-	copy(manifest.Platforms, dist.Platforms)
+
 	return manifest, nil
 }
 

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -315,8 +315,8 @@ func (c *Client) ImageDistribution(
 			}
 
 			return &ImageManifest{
-				digest: digest,
-				platforms: []v1.Platform{
+				Digest: digest,
+				Platforms: []v1.Platform{
 					{
 						Architecture: info.Architecture,
 						OS:           info.Os,
@@ -335,9 +335,9 @@ func (c *Client) ImageDistribution(
 
 	obj := dist.Descriptor.Digest
 	manifest := &ImageManifest{
-		digest: obj,
+		Digest: obj,
 	}
-	copy(manifest.platforms, dist.Platforms)
+	copy(manifest.Platforms, dist.Platforms)
 	return manifest, nil
 }
 

--- a/pkg/docker/image_resolver.go
+++ b/pkg/docker/image_resolver.go
@@ -48,7 +48,7 @@ func (r *ImageResolver) Resolve(ctx context.Context, resolver imageResolverFunc,
 	}
 
 	cloned, _ := NewImageID(r.source.String())
-	cloned.tag = DigestTag(manifest.digest)
+	cloned.tag = DigestTag(manifest.Digest)
 	r.resolved = cloned.String()
 
 	// Save a copy of the digest in the local cache for a set period of time

--- a/pkg/docker/image_resolver_test.go
+++ b/pkg/docker/image_resolver_test.go
@@ -37,7 +37,7 @@ func fullResolver() imageResolverFunc {
 func valueResolver(val string) imageResolverFunc {
 	return func(c context.Context, i string, creds config.DockerCredentials) (*ImageManifest, error) {
 		digest, _ := digest.Parse(fmt.Sprintf("sha256:%s", val))
-		return &ImageManifest{digest: digest}, nil
+		return &ImageManifest{Digest: digest}, nil
 	}
 }
 

--- a/pkg/docker/types.go
+++ b/pkg/docker/types.go
@@ -13,6 +13,6 @@ type imageResolverFunc func(context.Context, string, config.DockerCredentials) (
 
 type ImageManifest struct {
 	// We only ever expect the digest to be the `algorithm:hash`
-	digest    digest.Digest
-	platforms []v1.Platform
+	Digest    digest.Digest
+	Platforms []v1.Platform
 }

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform.go
@@ -47,7 +47,9 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 
 		var m *docker.ImageManifest
 		m, ierr = s.client.ImageDistribution(ctx, request.Job.Spec.Docker.Image, config.GetDockerCredentials())
-		manifest = *m
+		if m != nil {
+			manifest = *m
+		}
 	} else {
 		log.Ctx(ctx).Debug().Str("Image", request.Job.Spec.Docker.Image).Msg("Image found in manifest cache")
 	}

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform.go
@@ -6,12 +6,18 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/cache"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/docker"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/rs/zerolog/log"
 )
 
+const oneDayInSeconds = int64(86400)
+
 var _ bidstrategy.SemanticBidStrategy = (*ImagePlatformBidStrategy)(nil)
+
+var ManifestCache *cache.Cache[docker.ImageManifest] = &docker.DockerManifestCache
 
 func NewImagePlatformBidStrategy(client *docker.Client) *ImagePlatformBidStrategy {
 	return &ImagePlatformBidStrategy{client: client}
@@ -31,7 +37,21 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 	}
 
 	supported, serr := s.client.SupportedPlatforms(ctx)
-	platforms, ierr := s.client.ImagePlatforms(ctx, request.Job.Spec.Docker.Image, config.GetDockerCredentials())
+
+	var ierr error = nil
+	var manifest docker.ImageManifest
+
+	manifest, found := (*ManifestCache).Get(request.Job.Spec.Docker.Image)
+	if !found {
+		log.Ctx(ctx).Debug().Str("Image", request.Job.Spec.Docker.Image).Msg("Image not found in manifest cache")
+
+		var m *docker.ImageManifest
+		m, ierr = s.client.ImageDistribution(ctx, request.Job.Spec.Docker.Image, config.GetDockerCredentials())
+		manifest = *m
+	} else {
+		log.Ctx(ctx).Debug().Str("Image", request.Job.Spec.Docker.Image).Msg("Image found in manifest cache")
+	}
+
 	err := multierr.Combine(serr, ierr)
 	if err != nil {
 		return bidstrategy.BidStrategyResponse{
@@ -40,8 +60,25 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 		}, nil
 	}
 
+	// Cache the platform info for this image tag for a day. We could cache
+	// for longer but we only have in-memory caches with time-based eviction.
+	// TODO: Once we have an LRU cache we can use that instead and not worry
+	// about managing eviction. In the meantime we get this through calling
+	// Set even when don't have to, to reset the expiry time.
+	err = (*ManifestCache).Set(
+		request.Job.Spec.Docker.Image, manifest, 1, oneDayInSeconds,
+	) //nolint:gomnd
+	if err != nil {
+		// Log the error but continue as it is not serious enough to stop
+		// processing
+		log.Ctx(ctx).Warn().
+			Str("Image", request.Job.Spec.Docker.Image).
+			Str("Error", err.Error()).
+			Msg("Failed to save to manifest cache")
+	}
+
 	for _, canRun := range supported {
-		for _, imageHas := range platforms {
+		for _, imageHas := range manifest.Platforms {
 			if canRun.OS == imageHas.OS && canRun.Architecture == imageHas.Architecture {
 				return bidstrategy.NewShouldBidResponse(), nil
 			}

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/cache"
+	"github.com/bacalhau-project/bacalhau/pkg/cache/fake"
 	"github.com/bacalhau-project/bacalhau/pkg/docker"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/docker/bidstrategy/semantic"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -49,5 +51,35 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, false, response.ShouldBid)
+	})
+
+	t.Run("cached manifest response for duplicate call", func(t *testing.T) {
+
+		var fc *fake.FakeCache[docker.ImageManifest] = fake.NewFakeCache[docker.ImageManifest]()
+		var cc cache.Cache[docker.ImageManifest] = fc
+		semantic.ManifestCache = &cc
+
+		response, err := strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
+			Job: jobForDockerImage("ubuntu:latest"),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, true, response.ShouldBid)
+
+		// Second time we expect should be cached
+		response, err = strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
+			Job: jobForDockerImage("ubuntu:latest"),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, true, response.ShouldBid)
+
+		// We expect the cache to contain one item,
+		// and have called Set twice, and Get twice with
+		// one successful and one failed lookup.
+		require.Equal(t, 1, fc.ItemCount())
+		require.Equal(t, 2, fc.SetCalls)
+		require.Equal(t, 2, fc.GetCalls)
+		require.Equal(t, 1, fc.SuccessfulGetCalls)
 	})
 }

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
@@ -55,6 +55,8 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 
 	t.Run("cached manifest response for duplicate call", func(t *testing.T) {
 
+		previousCache := semantic.ManifestCache
+
 		var fc *fake.FakeCache[docker.ImageManifest] = fake.NewFakeCache[docker.ImageManifest]()
 		var cc cache.Cache[docker.ImageManifest] = fc
 		semantic.ManifestCache = &cc
@@ -81,5 +83,8 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 		require.Equal(t, 2, fc.SetCalls)
 		require.Equal(t, 2, fc.GetCalls)
 		require.Equal(t, 1, fc.SuccessfulGetCalls)
+
+		// Reset the cache to the default impl
+		semantic.ManifestCache = previousCache
 	})
 }


### PR DESCRIPTION
During bidding for jobs, each compute node queries the local store, and then the remote docker hub API to determine if the image is available for it's platform.  This happens frequently and uses our rate limit, and so ideally we would not need to request the details for each image very frequently.

This PR adds a small cache for caching this information, meaning that each compute node should only need to query each image digest once ever 24 hours or so, with the result being held in RAM until it is required in the next bid.