### PR TITLE
Record Canary Jobs in Postgres Database

### DIFF
--- a/dashboard/api/pkg/model/job_event_handler.go
+++ b/dashboard/api/pkg/model/job_event_handler.go
@@ -72,23 +72,6 @@ func (handler *jobEventHandler) readEvent(ctx context.Context, event bacalhau_mo
 	}
 
 	if event.EventName == bacalhau_model.JobEventCreated {
-		isCanary := false
-		for _, label := range event.Spec.Annotations {
-			if label == "canary" {
-				isCanary = true
-				break
-			}
-		}
-		for _, entrypointPart := range event.Spec.Docker.Entrypoint {
-			if entrypointPart == "hello λ!" {
-				isCanary = true
-				break
-			}
-		}
-		if isCanary {
-			eventBuffer.ignore = true
-			return nil
-		}
 		eventBuffer.exists = true
 		err := handler.writeEventToDatabase(ctx, event)
 		if err != nil {

--- a/dashboard/api/pkg/test/api_test.go
+++ b/dashboard/api/pkg/test/api_test.go
@@ -35,6 +35,38 @@ func (s *APITestSuite) TestJobsCountInitiallyZero() {
 	s.Equal(0, count)
 }
 
+func (s *APITestSuite) TestCanaryJobsStored() {
+	jobEvent := v1beta1.JobEvent{
+		JobID:     "testjob",
+		EventName: v1beta1.JobEventCreated,
+		Spec: v1beta1.Spec{
+			Annotations: []string{"canary"},
+		},
+	}
+	s.Require().NoError(s.api.AddEvent(jobEvent))
+
+	info, err := s.api.GetJobInfo(s.ctx, jobEvent.JobID)
+	s.Require().NoError(err)
+	s.Require().Contains(info.Job.Spec.Annotations, "canary")
+}
+
+func (s *APITestSuite) TestHelloLambdaJobsStored() {
+	jobEvent := v1beta1.JobEvent{
+		JobID:     "testjob",
+		EventName: v1beta1.JobEventCreated,
+		Spec: v1beta1.Spec{
+			Docker: v1beta1.JobSpecDocker{
+				Entrypoint: []string{"hello λ!"},
+			},
+		},
+	}
+	s.Require().NoError(s.api.AddEvent(jobEvent))
+
+	info, err := s.api.GetJobInfo(s.ctx, jobEvent.JobID)
+	s.Require().NoError(err)
+	s.Require().Contains(info.Job.Spec.Docker.Entrypoint, "hello λ!")
+}
+
 func (s *APITestSuite) TestModerateBidRequest() {
 	for _, shouldApprove := range []bool{true, false} {
 		s.Run(fmt.Sprintf("moderator approves is %t", shouldApprove), func() {


### PR DESCRIPTION
We want to be recording canary jobs in the database and dashboard, with the option to filter them out further down the line, so removed canary filters, but ensured that their conditions would appear in the database so that they can be indentified at a later date. Only affects new canary jobs.