### PR TITLE
enable mounting writable local paths

### DIFF
--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -150,9 +150,8 @@ func (e *Executor) Run(
 			log.Ctx(ctx).Trace().Msgf("Input Volume: %+v %+v", spec, volumeMount)
 
 			mounts = append(mounts, mount.Mount{
-				Type: mount.TypeBind,
-				// this is an input volume so is read only
-				ReadOnly: true,
+				Type:     mount.TypeBind,
+				ReadOnly: volumeMount.ReadOnly,
 				Source:   volumeMount.Source,
 				Target:   volumeMount.Target,
 			})

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -72,7 +72,7 @@ func NewStandardStorageProvider(
 	}
 
 	localDirectoryStorage, err := localdirectory.NewStorageProvider(localdirectory.StorageProviderParams{
-		AllowedPaths: options.AllowListedLocalPaths,
+		AllowedPaths: localdirectory.ParseAllowPaths(options.AllowListedLocalPaths),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/model/storage_spec.go
+++ b/pkg/model/storage_spec.go
@@ -28,6 +28,9 @@ type StorageSpec struct {
 	// The path of the host data if we are using local directory paths
 	SourcePath string `json:"SourcePath,omitempty"`
 
+	// Allow write access for locally mounted inputs
+	ReadWrite bool `json:"ReadWrite"`
+
 	// The path that the spec's data should be mounted on, where it makes
 	// sense (for example, in a Docker storage spec this will be a filesystem
 	// path).

--- a/pkg/storage/local_directory/types.go
+++ b/pkg/storage/local_directory/types.go
@@ -1,0 +1,44 @@
+package localdirectory
+
+import "strings"
+
+type AllowedPath struct {
+	Path      string
+	ReadWrite bool
+}
+
+// string representation of the object.
+func (obj AllowedPath) String() string {
+	suffix := "ro"
+	if obj.ReadWrite {
+		suffix = "rw"
+	}
+	return obj.Path + ":" + suffix
+}
+
+func ParseAllowPath(path string) AllowedPath {
+	if strings.HasSuffix(path, ":rw") {
+		return AllowedPath{
+			Path:      strings.TrimSuffix(path, ":rw"),
+			ReadWrite: true,
+		}
+	} else if strings.HasSuffix(path, ":ro") {
+		return AllowedPath{
+			Path:      strings.TrimSuffix(path, ":ro"),
+			ReadWrite: false,
+		}
+	} else {
+		return AllowedPath{
+			Path:      path,
+			ReadWrite: false,
+		}
+	}
+}
+
+func ParseAllowPaths(paths []string) []AllowedPath {
+	allowedPaths := make([]AllowedPath, len(paths))
+	for i, path := range paths {
+		allowedPaths[i] = ParseAllowPath(path)
+	}
+	return allowedPaths
+}

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -34,7 +34,8 @@ type Storage interface {
 // put simply - the nature of a storage volume depends on it's use by the
 // executor engine
 type StorageVolume struct {
-	Type   StorageVolumeConnectorType `json:"type"`
-	Source string                     `json:"source"`
-	Target string                     `json:"target"`
+	Type     StorageVolumeConnectorType `json:"type"`
+	ReadOnly bool                       `json:"readOnly"`
+	Source   string                     `json:"source"`
+	Target   string                     `json:"target"`
 }


### PR DESCRIPTION
Allow Bacalhau jobs to have write access to allow-listed paths. A use case where this is helpful is when jobs need to checkpoint their progress so that future invocations/retries can resume instead of starting over, such as when processing local log files or local sensor data.