### PR TITLE
Disable requester node docker caching until we can address issues

### DIFF
--- a/pkg/executor/docker/bidstrategy/semantic/image_platform.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform.go
@@ -41,9 +41,7 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 	var ierr error = nil
 	var manifest docker.ImageManifest
 
-	// TODO: Re-enable
-	// manifest, found := (*ManifestCache).Get(request.Job.Spec.Docker.Image)
-	found := false
+	manifest, found := (*ManifestCache).Get(request.Job.Spec.Docker.Image)
 	if !found {
 		log.Ctx(ctx).Debug().Str("Image", request.Job.Spec.Docker.Image).Msg("Image not found in manifest cache")
 
@@ -69,18 +67,17 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 	// TODO: Once we have an LRU cache we can use that instead and not worry
 	// about managing eviction. In the meantime we get this through calling
 	// Set even when don't have to, to reset the expiry time.
-	// TODO: Re-enable
-	// err = (*ManifestCache).Set(
-	// 	request.Job.Spec.Docker.Image, manifest, 1, oneDayInSeconds,
-	// ) //nolint:gomnd
-	// if err != nil {
-	// 	// Log the error but continue as it is not serious enough to stop
-	// 	// processing
-	// 	log.Ctx(ctx).Warn().
-	// 		Str("Image", request.Job.Spec.Docker.Image).
-	// 		Str("Error", err.Error()).
-	// 		Msg("Failed to save to manifest cache")
-	// }
+	err = (*ManifestCache).Set(
+		request.Job.Spec.Docker.Image, manifest, 1, oneDayInSeconds,
+	) //nolint:gomnd
+	if err != nil {
+		// Log the error but continue as it is not serious enough to stop
+		// processing
+		log.Ctx(ctx).Warn().
+			Str("Image", request.Job.Spec.Docker.Image).
+			Str("Error", err.Error()).
+			Msg("Failed to save to manifest cache")
+	}
 
 	for _, canRun := range supported {
 		for _, imageHas := range manifest.Platforms {

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/cache"
+	"github.com/bacalhau-project/bacalhau/pkg/cache/fake"
 	"github.com/bacalhau-project/bacalhau/pkg/docker"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/docker/bidstrategy/semantic"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -51,39 +53,38 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 		require.Equal(t, false, response.ShouldBid)
 	})
 
-	// TODO: Re-enable
-	// t.Run("cached manifest response for duplicate call", func(t *testing.T) {
+	t.Run("cached manifest response for duplicate call", func(t *testing.T) {
 
-	// 	previousCache := semantic.ManifestCache
+		previousCache := semantic.ManifestCache
 
-	// 	var fc *fake.FakeCache[docker.ImageManifest] = fake.NewFakeCache[docker.ImageManifest]()
-	// 	var cc cache.Cache[docker.ImageManifest] = fc
-	// 	semantic.ManifestCache = &cc
+		var fc *fake.FakeCache[docker.ImageManifest] = fake.NewFakeCache[docker.ImageManifest]()
+		var cc cache.Cache[docker.ImageManifest] = fc
+		semantic.ManifestCache = &cc
 
-	// 	response, err := strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
-	// 		Job: jobForDockerImage("ubuntu:latest"),
-	// 	})
+		response, err := strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
+			Job: jobForDockerImage("ubuntu:latest"),
+		})
 
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, true, response.ShouldBid)
+		require.NoError(t, err)
+		require.Equal(t, true, response.ShouldBid)
 
-	// 	// Second time we expect should be cached
-	// 	response, err = strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
-	// 		Job: jobForDockerImage("ubuntu:latest"),
-	// 	})
+		// Second time we expect should be cached
+		response, err = strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
+			Job: jobForDockerImage("ubuntu:latest"),
+		})
 
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, true, response.ShouldBid)
+		require.NoError(t, err)
+		require.Equal(t, true, response.ShouldBid)
 
-	// 	// We expect the cache to contain one item,
-	// 	// and have called Set twice, and Get twice with
-	// 	// one successful and one failed lookup.
-	// 	require.Equal(t, 1, fc.ItemCount())
-	// 	require.Equal(t, 2, fc.SetCalls)
-	// 	require.Equal(t, 2, fc.GetCalls)
-	// 	require.Equal(t, 1, fc.SuccessfulGetCalls)
+		// We expect the cache to contain one item,
+		// and have called Set twice, and Get twice with
+		// one successful and one failed lookup.
+		require.Equal(t, 1, fc.ItemCount())
+		require.Equal(t, 2, fc.SetCalls)
+		require.Equal(t, 2, fc.GetCalls)
+		require.Equal(t, 1, fc.SuccessfulGetCalls)
 
-	// 	// Reset the cache to the default impl
-	// 	semantic.ManifestCache = previousCache
-	// })
+		// Reset the cache to the default impl
+		semantic.ManifestCache = previousCache
+	})
 }


### PR DESCRIPTION
Disables docker caching until we can identify a path to solve short development cycles that requires pushing to docker.