### PR TITLE
Revert removal of python and wasm_python executors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,12 @@ test-devstack:
 test-commands:
 	go test -v -count 1 -timeout 3000s -run '^Test\w+Suite$$' github.com/bacalhau-project/bacalhau/cmd/bacalhau/
 
+# .PHONY: test-pythonwasm
+# test-pythonwasm:
+# # TestSimplestPythonWasmDashC
+# 	LOG_LEVEL=debug go test -v -count 1 -timeout 3000s -run ^TestSimplePythonWasm$$ github.com/bacalhau-project/bacalhau/pkg/test/devstack/
+# #	LOG_LEVEL=debug go test -v -count 1 -timeout 3000s -run ^TestSimplestPythonWasmDashC$$ github.com/bacalhau-project/bacalhau/pkg/test/devstack/
+
 ################################################################################
 # Target: devstack
 ################################################################################

--- a/clients/python/docs/JobSpecLanguage.md
+++ b/clients/python/docs/JobSpecLanguage.md
@@ -1,0 +1,14 @@
+# JobSpecLanguage
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**command** | **str** | optional program specified on commandline, like python -c \&quot;print(1+1)\&quot; | [optional]
+**deterministic_execution** | **bool** | must this job be run in a deterministic context? | [optional]
+**job_context** | **AllOfJobSpecLanguageJobContext** | context is a tar file stored in ipfs, containing e.g. source code and requirements | [optional]
+**language** | **str** | e.g. python | [optional]
+**language_version** | **str** | e.g. 3.8 | [optional]
+**program_path** | **str** | optional program path relative to the context dir. one of Command or ProgramPath must be specified | [optional]
+**requirements_path** | **str** | optional requirements.txt (or equivalent) path relative to the context dir | [optional]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/cmd/bacalhau/run.go
+++ b/cmd/bacalhau/run.go
@@ -11,5 +11,6 @@ func newRunCmd() *cobra.Command {
 		PreRun:            applyPorcelainLogLevel,
 		PersistentPreRunE: checkVersion,
 	}
+	runCmd.AddCommand(newRunPythonCmd())
 	return runCmd
 }

--- a/cmd/bacalhau/run_python.go
+++ b/cmd/bacalhau/run_python.go
@@ -1,0 +1,226 @@
+package bacalhau
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/cmd/bacalhau/opts"
+	"github.com/bacalhau-project/bacalhau/pkg/downloader/util"
+	"github.com/bacalhau-project/bacalhau/pkg/job"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/inline"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/i18n"
+)
+
+var (
+	languageRunLong = templates.LongDesc(i18n.T(`
+		Runs a job by compiling language file to WASM on the node.
+		`))
+
+	languageRunExample = templates.Examples(i18n.T(`
+		# Run a simple "Hello, World" script within the current directory
+		bacalhau run python -- hello-world.py
+		`))
+)
+
+// LanguageRunOptions declares the arguments accepted by the `'language' run` command
+type LanguageRunOptions struct {
+	Deterministic bool            // Execute this job deterministically
+	Inputs        opts.StorageOpt // Array of inputs
+	OutputVolumes []string        // Array of output volumes in 'name:mount point' form
+	Env           []string        // Array of environment variables
+	Concurrency   int             // Number of concurrent jobs to run
+	Confidence    int             // Minimum number of nodes that must agree on a verification result
+	MinBids       int             // Minimum number of bids that must be received before any are accepted (at random)
+	Timeout       float64         // Job execution timeout in seconds
+	Labels        []string        // Labels for the job on the Bacalhau network (for searching)
+
+	Command          string // Command to execute
+	RequirementsPath string // Path for requirements.txt for executing with Python
+	ContextPath      string // ContextPath (code) for executing with Python
+
+	// CPU string
+	// Memory string
+	// GPU string
+	// WorkingDir string // Working directory for docker
+
+	RuntimeSettings  RunTimeSettings
+	DownloadSettings model.DownloaderSettings
+}
+
+func NewLanguageRunOptions() *LanguageRunOptions {
+	return &LanguageRunOptions{
+		Deterministic:    true,
+		Inputs:           opts.StorageOpt{},
+		OutputVolumes:    []string{},
+		Env:              []string{},
+		Concurrency:      1,
+		Confidence:       0,
+		MinBids:          0, // 0 means no minimum before bidding
+		Timeout:          DefaultTimeout.Seconds(),
+		Labels:           []string{},
+		Command:          "",
+		RequirementsPath: "",
+		ContextPath:      ".",
+		RuntimeSettings:  *NewRunTimeSettings(),
+		DownloadSettings: *util.NewDownloadSettings(),
+	}
+}
+
+// TODO: move the adapter code (from wasm to docker) into a wasm executor, so
+// that the compute node can verify the job knowing that it was run properly,
+// rather than doing the translation in, and thereby trusting, the client (to
+// set up the wasm environment to be deterministic)
+
+func newRunPythonCmd() *cobra.Command {
+	OLR := NewLanguageRunOptions()
+
+	runPythonCmd := &cobra.Command{
+		Use:     "python",
+		Short:   "Run a python job on the network",
+		Long:    languageRunLong,
+		Example: languageRunExample,
+		Args:    cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error { //nolint
+			return runPython(cmd, cmdArgs, OLR)
+		},
+	}
+
+	// determinism flag
+	runPythonCmd.PersistentFlags().BoolVar(
+		&OLR.Deterministic, "deterministic", OLR.Deterministic,
+		`Enforce determinism: run job in a single-threaded wasm runtime with `+
+			`no sources of entropy. NB: this will make the python runtime execute`+
+			`in an environment where only some libraries are supported, see `+
+			`https://pyodide.org/en/stable/usage/packages-in-pyodide.html`,
+	)
+	runPythonCmd.PersistentFlags().VarP(&OLR.Inputs, "input", "i", inputUsageMsg)
+
+	runPythonCmd.PersistentFlags().StringSliceVarP(
+		&OLR.OutputVolumes, "output-volumes", "o", OLR.OutputVolumes,
+		`name:path of the output data volumes`,
+	)
+	runPythonCmd.PersistentFlags().StringSliceVarP(
+		&OLR.Env, "env", "e", OLR.Env,
+		`The environment variables to supply to the job (e.g. --env FOO=bar --env BAR=baz)`,
+	)
+	// TODO: concurrency should be factored out (at least up to run, maybe
+	// shared with docker and wasm raw commands too)
+	runPythonCmd.PersistentFlags().IntVar(
+		&OLR.Concurrency, "concurrency", OLR.Concurrency,
+		`How many nodes should run the job`,
+	)
+	runPythonCmd.PersistentFlags().IntVar(
+		&OLR.Confidence, "confidence", OLR.Confidence,
+		`The minimum number of nodes that must agree on a verification result`,
+	)
+	runPythonCmd.PersistentFlags().IntVar(
+		&OLR.MinBids, "min-bids", OLR.MinBids,
+		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`,
+	)
+	runPythonCmd.PersistentFlags().Float64Var(
+		&OLR.Timeout, "timeout", OLR.Timeout,
+		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
+	)
+	runPythonCmd.PersistentFlags().StringVarP(
+		&OLR.Command, "command", "c", OLR.Command,
+		`Program passed in as string (like python)`,
+	)
+	runPythonCmd.PersistentFlags().StringVarP(
+		&OLR.RequirementsPath, "requirement", "r", OLR.RequirementsPath,
+		`Install from the given requirements file. (like pip)`, // TODO: This option can be used multiple times.
+	)
+	runPythonCmd.PersistentFlags().StringVar(
+		// TODO: consider replacing this with context-glob, default to
+		// "./**/*.py|./requirements.txt", OR .bacalhau_ignore
+		&OLR.ContextPath, "context-path", OLR.ContextPath,
+		"Path to context (e.g. python code) to send to server (via public IPFS network) "+
+			"for execution (max 10MiB). Set to empty string to disable",
+	)
+	runPythonCmd.PersistentFlags().StringSliceVarP(
+		&OLR.Labels, "labels", "l", OLR.Labels,
+		`List of labels for the job. Enter multiple in the format '-l a -l 2'. All characters not matching /a-zA-Z0-9_:|-/ and all emojis will be stripped.`, //nolint:lll // Documentation, ok if long.
+	)
+
+	runPythonCmd.PersistentFlags().AddFlagSet(NewRunTimeSettingsFlags(&OLR.RuntimeSettings))
+	runPythonCmd.PersistentFlags().AddFlagSet(NewIPFSDownloadFlags(&OLR.DownloadSettings))
+	return runPythonCmd
+}
+
+func runPython(cmd *cobra.Command, cmdArgs []string, OLR *LanguageRunOptions) error {
+	ctx := cmd.Context()
+
+	cm := ctx.Value(systemManagerKey).(*system.CleanupManager)
+
+	// error if determinism is false
+	if !OLR.Deterministic {
+		Fatal(cmd, "Determinism=false not supported yet "+
+			"(languages only support wasm backend with forced determinism)", 1)
+	}
+
+	var programPath string
+	if len(cmdArgs) > 0 {
+		programPath = cmdArgs[0]
+	}
+
+	if OLR.Command == "" && programPath == "" {
+		Fatal(cmd, "Please specify an inline command or a path to a python file.", 1)
+	}
+
+	language := "python"
+	version := "3.10"
+
+	// TODO: #450 These two code paths make me nervous - the fact that we
+	// have ConstructLanguageJob and ConstructDockerJob as separate means
+	// manually keeping them in sync.
+	j, err := job.ConstructLanguageJob(
+		ctx,
+		OLR.Inputs.Values(),
+		OLR.OutputVolumes,
+		OLR.Concurrency,
+		OLR.Confidence,
+		OLR.MinBids,
+		OLR.Timeout,
+		language,
+		version,
+		OLR.Command,
+		programPath,
+		OLR.RequirementsPath,
+		OLR.Deterministic,
+		OLR.Labels,
+	)
+	if err != nil {
+		return err
+	}
+
+	if OLR.ContextPath == "." && OLR.RequirementsPath == "" && programPath == "" {
+		cmd.Println("no program or requirements specified, not uploading context - set --context-path to full path to force context upload")
+		OLR.ContextPath = ""
+	}
+
+	if OLR.ContextPath != "" {
+		// construct a tar file from the contextPath directory
+		// tar + gzip
+		cmd.Printf("Uploading %q to server to execute command in context, press Ctrl+C to cancel\n", OLR.ContextPath)
+		time.Sleep(1 * time.Second)
+		inlineStorage := inline.NewStorage()
+		context, cerr := inlineStorage.Upload(ctx, OLR.ContextPath)
+		if cerr != nil {
+			Fatal(cmd, cerr.Error(), 1)
+			return nil
+		}
+		context.Path = "/job"
+		j.Spec.Inputs = append(j.Spec.Inputs, context)
+	}
+
+	err = ExecuteJob(ctx, cm, cmd, j, OLR.RuntimeSettings, OLR.DownloadSettings)
+	if err != nil {
+		Fatal(cmd, fmt.Sprintf("Error executing job: %s", err), 1)
+		return nil
+	}
+
+	return nil
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -796,6 +796,8 @@ const docTemplate = `{
                 4
             ],
             "x-enum-comments": {
+                "EngineLanguage": "wraps python_wasm",
+                "EnginePythonWasm": "wraps docker",
                 "engineDone": "must be last",
                 "engineUnknown": "must be first"
             },
@@ -804,6 +806,8 @@ const docTemplate = `{
                 "EngineNoop",
                 "EngineDocker",
                 "EngineWasm",
+                "EngineLanguage",
+                "EnginePythonWasm",
                 "engineDone"
             ]
         },
@@ -1057,6 +1061,43 @@ const docTemplate = `{
                 },
                 "WorkingDirectory": {
                     "description": "working directory inside the container",
+                    "type": "string"
+                }
+            }
+        },
+        "model.JobSpecLanguage": {
+            "type": "object",
+            "properties": {
+                "Command": {
+                    "description": "optional program specified on commandline, like python -c \"print(1+1)\"",
+                    "type": "string"
+                },
+                "DeterministicExecution": {
+                    "description": "must this job be run in a deterministic context?",
+                    "type": "boolean"
+                },
+                "JobContext": {
+                    "description": "context is a tar file stored in ipfs, containing e.g. source code and requirements",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.StorageSpec"
+                        }
+                    ]
+                },
+                "Language": {
+                    "description": "e.g. python",
+                    "type": "string"
+                },
+                "LanguageVersion": {
+                    "description": "e.g. 3.8",
+                    "type": "string"
+                },
+                "ProgramPath": {
+                    "description": "optional program path relative to the context dir. one of Command or ProgramPath must be specified",
+                    "type": "string"
+                },
+                "RequirementsPath": {
+                    "description": "optional requirements.txt (or equivalent) path relative to the context dir",
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -792,6 +792,8 @@
                 4
             ],
             "x-enum-comments": {
+                "EngineLanguage": "wraps python_wasm",
+                "EnginePythonWasm": "wraps docker",
                 "engineDone": "must be last",
                 "engineUnknown": "must be first"
             },
@@ -800,6 +802,8 @@
                 "EngineNoop",
                 "EngineDocker",
                 "EngineWasm",
+                "EngineLanguage",
+                "EnginePythonWasm",
                 "engineDone"
             ]
         },
@@ -1053,6 +1057,43 @@
                 },
                 "WorkingDirectory": {
                     "description": "working directory inside the container",
+                    "type": "string"
+                }
+            }
+        },
+        "model.JobSpecLanguage": {
+            "type": "object",
+            "properties": {
+                "Command": {
+                    "description": "optional program specified on commandline, like python -c \"print(1+1)\"",
+                    "type": "string"
+                },
+                "DeterministicExecution": {
+                    "description": "must this job be run in a deterministic context?",
+                    "type": "boolean"
+                },
+                "JobContext": {
+                    "description": "context is a tar file stored in ipfs, containing e.g. source code and requirements",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.StorageSpec"
+                        }
+                    ]
+                },
+                "Language": {
+                    "description": "e.g. python",
+                    "type": "string"
+                },
+                "LanguageVersion": {
+                    "description": "e.g. 3.8",
+                    "type": "string"
+                },
+                "ProgramPath": {
+                    "description": "optional program path relative to the context dir. one of Command or ProgramPath must be specified",
+                    "type": "string"
+                },
+                "RequirementsPath": {
+                    "description": "optional requirements.txt (or equivalent) path relative to the context dir",
                     "type": "string"
                 }
             }
@@ -1506,6 +1547,9 @@
                             "$ref": "#/definitions/model.Engine"
                         }
                     ]
+                },
+                "Language": {
+                    "$ref": "#/definitions/model.JobSpecLanguage"
                 },
                 "Network": {
                     "description": "The type of networking access that the job needs",

--- a/pkg/executor/language/executor.go
+++ b/pkg/executor/language/executor.go
@@ -1,0 +1,122 @@
+package language
+
+/*
+The language executor wraps either the python_wasm executor or the generic
+docker executor, depending on whether determinism is required.
+*/
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/resource"
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
+	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+)
+
+type Executor struct {
+	Jobs               map[string]*model.Job
+	executors          executor.ExecutorProvider
+	delegatedExecutors generic.SyncMap[string, executor.Executor]
+}
+
+type LanguageSpec struct {
+	Language, Version string
+}
+
+var supportedVersions = map[LanguageSpec]model.Engine{
+	{"python", "3.10"}: model.EnginePythonWasm,
+	{"wasm", "2.0"}:    model.EngineWasm,
+}
+
+func NewExecutor(
+	ctx context.Context,
+	cm *system.CleanupManager,
+	executors executor.ExecutorProvider,
+) (*Executor, error) {
+	e := &Executor{
+		executors: executors,
+	}
+	return e, nil
+}
+
+func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (e *Executor) HasStorageLocally(ctx context.Context, volume model.StorageSpec) (bool, error) {
+	return true, nil
+}
+
+func (e *Executor) GetVolumeSize(ctx context.Context, volumes model.StorageSpec) (uint64, error) {
+	return 0, nil
+}
+
+func (e *Executor) GetSemanticBidStrategy(ctx context.Context) (bidstrategy.SemanticBidStrategy, error) {
+	return semantic.NewChainedSemanticBidStrategy(), nil
+}
+
+func (e *Executor) GetResourceBidStrategy(ctx context.Context) (bidstrategy.ResourceBidStrategy, error) {
+	return resource.NewChainedResourceBidStrategy(), nil
+}
+
+func (e *Executor) Run(
+	ctx context.Context,
+	executionID string,
+	job model.Job,
+	jobResultsDir string,
+) (*model.RunCommandResult, error) {
+	executor, err := e.getDelegateExecutor(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+	e.delegatedExecutors.Put(executionID, executor)
+	return executor.Run(ctx, executionID, job, jobResultsDir)
+}
+
+func (e *Executor) GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error) {
+	executor, exists := e.delegatedExecutors.Get(executionID)
+	if !exists {
+		return nil, fmt.Errorf("execution %v not found", executionID)
+	}
+	return executor.GetOutputStream(ctx, executionID, withHistory, follow)
+}
+
+func (e *Executor) getDelegateExecutor(ctx context.Context, job model.Job) (executor.Executor, error) {
+	requiredLang := LanguageSpec{
+		Language: job.Spec.Language.Language,
+		Version:  job.Spec.Language.LanguageVersion,
+	}
+
+	engineKey, exists := supportedVersions[requiredLang]
+	if !exists {
+		err := fmt.Errorf("%v is not supported", requiredLang)
+		return nil, err
+	}
+
+	if job.Spec.Language.Deterministic {
+		log.Ctx(ctx).Debug().Msgf("Running deterministic %v", requiredLang)
+		// Instantiate a python_wasm
+		// TODO: mutate job as needed?
+		executor, err := e.executors.Get(ctx, engineKey)
+		if err != nil {
+			return nil, err
+		}
+		return executor, nil
+	} else {
+		err := fmt.Errorf("non-deterministic %v not supported yet", requiredLang)
+		// TODO: Instantiate a docker with python:3.10 image
+		return nil, err
+	}
+}
+
+// Compile-time check that Executor implements the Executor interface.
+var _ executor.Executor = (*Executor)(nil)

--- a/pkg/executor/python_wasm/executor.go
+++ b/pkg/executor/python_wasm/executor.go
@@ -1,0 +1,109 @@
+package pythonwasm
+
+/*
+The python_wasm executor wraps the docker executor. The Requester will have
+automatically uploaded the execution context (python files, requirements.txt) to
+ipfs so that it can be mounted into the wasm runtime container.
+*/
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+)
+
+type Executor struct {
+	Jobs map[string]*model.Job
+
+	executors executor.ExecutorProvider
+}
+
+func NewExecutor(
+	executors executor.ExecutorProvider,
+) (*Executor, error) {
+	e := &Executor{
+		executors: executors,
+	}
+	return e, nil
+}
+
+func (e *Executor) IsInstalled(ctx context.Context) (bool, error) {
+	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
+	if err != nil {
+		return false, err
+	}
+	return dockerExecutor.IsInstalled(ctx)
+}
+
+func (e *Executor) HasStorageLocally(context.Context, model.StorageSpec) (bool, error) {
+	return true, nil
+}
+
+func (e *Executor) GetVolumeSize(context.Context, model.StorageSpec) (uint64, error) {
+	return 0, nil
+}
+
+func (e *Executor) GetSemanticBidStrategy(ctx context.Context) (bidstrategy.SemanticBidStrategy, error) {
+	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
+	if err != nil {
+		return nil, err
+	}
+	return dockerExecutor.GetSemanticBidStrategy(ctx)
+}
+
+func (e *Executor) GetResourceBidStrategy(ctx context.Context) (bidstrategy.ResourceBidStrategy, error) {
+	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
+	if err != nil {
+		return nil, err
+	}
+	return dockerExecutor.GetResourceBidStrategy(ctx)
+}
+
+func (e *Executor) Run(ctx context.Context, executionID string, job model.Job, resultsDir string) (
+	*model.RunCommandResult, error) {
+	log.Ctx(ctx).Debug().Msgf("in python_wasm executor!")
+	// translate language jobspec into a docker run command
+	job.Spec.Docker.Image = "ghcr.io/bacalhau-project/pyodide:v0.0.2"
+	if job.Spec.Language.Command != "" {
+		// pass command through to node wasm wrapper
+		job.Spec.Docker.Entrypoint = []string{"node", "n.js", "-c", job.Spec.Language.Command}
+	} else if job.Spec.Language.ProgramPath != "" {
+		// pass command through to node wasm wrapper
+		job.Spec.Docker.Entrypoint = []string{"node", "n.js", fmt.Sprintf("/pyodide_inputs/job/%s", job.Spec.Language.ProgramPath)}
+	}
+	job.Spec.Engine = model.EngineDocker
+
+	// prepend a path on each of the user supplied volumes to prevent an accidental
+	// collision with the internal pyodide filesystem
+	for idx, v := range job.Spec.Inputs {
+		job.Spec.Inputs[idx].Path = fmt.Sprintf("/pyodide_inputs%s", v.Path)
+	}
+
+	for idx, v := range job.Spec.Outputs {
+		job.Spec.Outputs[idx].Path = fmt.Sprintf("/pyodide_outputs%s", v.Path)
+	}
+
+	// TODO: pass in command, and have n.js interpret it and pass it on to pyodide
+	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
+	if err != nil {
+		return nil, err
+	}
+	return dockerExecutor.Run(ctx, executionID, job, resultsDir)
+}
+
+func (e *Executor) GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error) {
+	dockerExecutor, err := e.executors.Get(ctx, model.EngineDocker)
+	if err != nil {
+		return nil, err
+	}
+	return dockerExecutor.GetOutputStream(ctx, executionID, withHistory, follow)
+}
+
+// Compile-time check that Executor implements the Executor interface.
+var _ executor.Executor = (*Executor)(nil)

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -8,7 +8,9 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/docker"
+	"github.com/bacalhau-project/bacalhau/pkg/executor/language"
 	noop_executor "github.com/bacalhau-project/bacalhau/pkg/executor/noop"
+	pythonwasm "github.com/bacalhau-project/bacalhau/pkg/executor/python_wasm"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/wasm"
 	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -183,6 +185,20 @@ func NewStandardExecutorProvider(
 		model.EngineDocker: dockerExecutor,
 		model.EngineWasm:   wasmExecutor,
 	})
+
+	// language executors wrap other executors, so pass them a reference to all
+	// the executors so they can look up the ones they need
+	exLang, err := language.NewExecutor(ctx, cm, executors)
+	if err != nil {
+		return nil, err
+	}
+	executors.Add(model.EngineLanguage, exLang)
+
+	exPythonWasm, err := pythonwasm.NewExecutor(executors)
+	if err != nil {
+		return nil, err
+	}
+	executors.Add(model.EnginePythonWasm, exPythonWasm)
 
 	return executors, nil
 }

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/rs/zerolog/log"
-
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/rs/zerolog/log"
 )
 
 // these are util methods for the CLI
@@ -113,4 +112,73 @@ func ConstructDockerJob( //nolint:funlen
 	}
 
 	return j, nil
+}
+
+func ConstructLanguageJob(
+	ctx context.Context,
+	inputs []model.StorageSpec,
+	outputVolumes []string,
+	concurrency int,
+	confidence int,
+	minBids int,
+	timeout float64,
+	// See JobSpecLanguage
+	language string,
+	languageVersion string,
+	command string,
+	programPath string,
+	requirementsPath string,
+	deterministic bool,
+	annotations []string,
+) (*model.Job, error) {
+	// TODO refactor this wrt ConstructDockerJob
+
+	jobOutputs, err := buildJobOutputs(ctx, outputVolumes)
+	if err != nil {
+		return &model.Job{}, err
+	}
+
+	var jobAnnotations []string
+	var unSafeAnnotations []string
+	for _, a := range annotations {
+		if IsSafeAnnotation(a) && a != "" {
+			jobAnnotations = append(jobAnnotations, a)
+		} else {
+			unSafeAnnotations = append(unSafeAnnotations, a)
+		}
+	}
+
+	if len(unSafeAnnotations) > 0 {
+		log.Ctx(ctx).Error().Msgf("The following labels are unsafe. Labels must fit the regex '/%s/' (and all emjois): %+v",
+			RegexString,
+			strings.Join(unSafeAnnotations, ", "))
+	}
+
+	j, err := model.NewJobWithSaneProductionDefaults()
+	if err != nil {
+		return &model.Job{}, err
+	}
+
+	j.Spec.Engine = model.EngineLanguage
+	j.Spec.Language = model.JobSpecLanguage{
+		Language:         language,
+		LanguageVersion:  languageVersion,
+		Deterministic:    deterministic,
+		Context:          model.StorageSpec{},
+		Command:          command,
+		ProgramPath:      programPath,
+		RequirementsPath: requirementsPath,
+	}
+	j.Spec.Timeout = timeout
+	j.Spec.Inputs = inputs
+	j.Spec.Outputs = jobOutputs
+	j.Spec.Annotations = jobAnnotations
+
+	j.Spec.Deal = model.Deal{
+		Concurrency: concurrency,
+		Confidence:  confidence,
+		MinBids:     minBids,
+	}
+
+	return j, err
 }

--- a/pkg/model/engine.go
+++ b/pkg/model/engine.go
@@ -13,7 +13,9 @@ const (
 	EngineNoop
 	EngineDocker
 	EngineWasm
-	engineDone // must be last
+	EngineLanguage   // wraps python_wasm
+	EnginePythonWasm // wraps docker
+	engineDone       // must be last
 )
 
 func IsValidEngine(e Engine) bool {

--- a/pkg/model/engine_string.go
+++ b/pkg/model/engine_string.go
@@ -12,12 +12,14 @@ func _() {
 	_ = x[EngineNoop-1]
 	_ = x[EngineDocker-2]
 	_ = x[EngineWasm-3]
-	_ = x[engineDone-4]
+	_ = x[EngineLanguage-4]
+	_ = x[EnginePythonWasm-5]
+	_ = x[engineDone-6]
 }
 
-const _Engine_name = "engineUnknownNoopDockerWasmengineDone"
+const _Engine_name = "engineUnknownNoopDockerWasmLanguagePythonWasmengineDone"
 
-var _Engine_index = [...]uint8{0, 13, 17, 23, 27, 37}
+var _Engine_index = [...]uint8{0, 13, 17, 23, 27, 35, 45, 55}
 
 func (i Engine) String() string {
 	if i < 0 || i >= Engine(len(_Engine_index)-1) {

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -158,8 +158,9 @@ type Spec struct {
 	PublisherSpec PublisherSpec `json:"PublisherSpec,omitempty"`
 
 	// executor specific data
-	Docker JobSpecDocker `json:"Docker,omitempty"`
-	Wasm   JobSpecWasm   `json:"Wasm,omitempty"`
+	Docker   JobSpecDocker   `json:"Docker,omitempty"`
+	Language JobSpecLanguage `json:"Language,omitempty"`
+	Wasm     JobSpecWasm     `json:"Wasm,omitempty"`
 
 	// the compute (cpu, ram) resources this job requires
 	Resources ResourceUsageConfig `json:"Resources,omitempty"`
@@ -201,6 +202,7 @@ func (s *Spec) GetTimeout() time.Duration {
 // Return pointers to all the storage specs in the spec.
 func (s *Spec) AllStorageSpecs() []*StorageSpec {
 	storages := []*StorageSpec{
+		&s.Language.Context,
 		&s.Wasm.EntryModule,
 	}
 
@@ -226,6 +228,22 @@ type JobSpecDocker struct {
 	EnvironmentVariables []string `json:"EnvironmentVariables,omitempty"`
 	// working directory inside the container
 	WorkingDirectory string `json:"WorkingDirectory,omitempty"`
+}
+
+// for language style executors (can target docker or wasm)
+type JobSpecLanguage struct {
+	Language        string `json:"Language,omitempty"`        // e.g. python
+	LanguageVersion string `json:"LanguageVersion,omitempty"` // e.g. 3.8
+	// must this job be run in a deterministic context?
+	Deterministic bool `json:"DeterministicExecution,omitempty"`
+	// context is a tar file stored in ipfs, containing e.g. source code and requirements
+	Context StorageSpec `json:"JobContext,omitempty"`
+	// optional program specified on commandline, like python -c "print(1+1)"
+	Command string `json:"Command,omitempty"`
+	// optional program path relative to the context dir. one of Command or ProgramPath must be specified
+	ProgramPath string `json:"ProgramPath,omitempty"`
+	// optional requirements.txt (or equivalent) path relative to the context dir
+	RequirementsPath string `json:"RequirementsPath,omitempty"`
 }
 
 // Describes a raw WASM job

--- a/pkg/test/devstack/pythonwasm_test.go
+++ b/pkg/test/devstack/pythonwasm_test.go
@@ -1,0 +1,268 @@
+//go:build integration || !unit
+
+package devstack
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/devstack"
+	"github.com/bacalhau-project/bacalhau/pkg/docker"
+	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/node"
+	testutils "github.com/bacalhau-project/bacalhau/pkg/test/utils"
+
+	cmd "github.com/bacalhau-project/bacalhau/cmd/bacalhau"
+	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/requester/publicapi"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/rs/zerolog/log"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DevstackPythonWASMSuite struct {
+	suite.Suite
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestDevstackPythonWASMSuite(t *testing.T) {
+	suite.Run(t, new(DevstackPythonWASMSuite))
+}
+
+// Before each test
+func (s *DevstackPythonWASMSuite) SetupTest() {
+	docker.MustHaveDocker(s.T())
+
+	logger.ConfigureTestLogging(s.T())
+	system.InitConfigForTesting(s.T())
+}
+
+// full end-to-end test of python/wasm:
+//
+// * use CLI to submit a python job with --deterministic set
+// * context (python file and requirements.txt) should be pinned to ipfs by
+//   requester node
+// * docker executor downloads context and starts wasm container image with the
+//   context mounted in
+
+func (s *DevstackPythonWASMSuite) TestPythonWasmVolumes() {
+	testutils.SkipIfArm(s.T(), "https://github.com/bacalhau-project/bacalhau/issues/1268")
+	cmd.Fatal = cmd.FakeFatalErrorHandler
+
+	nodeCount := 1
+	inputPath := "/input"
+	outputPath := "/output"
+	fileContents := "pineapples"
+
+	ctx := context.Background()
+	stack, _ := testutils.SetupTest(ctx, s.T(), nodeCount, 0, false,
+		node.NewComputeConfigWithDefaults(),
+		node.NewRequesterConfigWithDefaults())
+
+	tmpDir := s.T().TempDir()
+
+	oldDir, err := os.Getwd()
+	require.NoError(s.T(), err)
+	err = os.Chdir(tmpDir)
+	require.NoError(s.T(), err)
+	defer func() {
+		err := os.Chdir(oldDir)
+		require.NoError(s.T(), err)
+	}()
+
+	fileCid, err := ipfs.AddTextToNodes(ctx, []byte(fileContents), devstack.ToIPFSClients(stack.Nodes[:nodeCount])...)
+	require.NoError(s.T(), err)
+
+	// write bytes to main.py
+	mainPy := []byte(fmt.Sprintf(`
+	import os
+	print("LIST /")
+	print(os.listdir("/"))
+	print("LIST %s")
+	print(os.listdir("%s"))
+	open("%s/test.txt", "w").write(open("%s").read())
+`, outputPath, outputPath, outputPath, inputPath))
+
+	err = os.WriteFile("main.py", mainPy, 0644)
+	require.NoError(s.T(), err)
+
+	_, out, err := cmd.ExecuteTestCobraCommand(
+		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
+		"--api-host=localhost",
+		"run",
+		"-i", fmt.Sprintf("ipfs://%s,dst=%s", fileCid, inputPath),
+		"-o", fmt.Sprintf("%s:%s", "output", outputPath),
+		"python",
+		"--deterministic",
+		"main.py",
+	)
+	jobID := system.FindJobIDInTestOutput(out)
+	require.NoError(s.T(), err)
+	log.Debug().Msgf("jobId=%s", jobID)
+	time.Sleep(time.Second * 5)
+
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
+	resolver := apiClient.GetJobStateResolver()
+	require.NoError(s.T(), err)
+	err = resolver.WaitUntilComplete(ctx, jobID)
+	require.NoError(s.T(), err)
+
+	executions, err := resolver.GetExecutions(ctx, jobID)
+	require.NoError(s.T(), err)
+	require.True(s.T(), len(executions) > 0)
+
+	executionState := executions[0]
+
+	outputDir := s.T().TempDir()
+	require.NotEmpty(s.T(), executionState.PublishedResult.CID)
+
+	finalOutputPath := filepath.Join(outputDir, executionState.PublishedResult.CID)
+	err = stack.Nodes[0].IPFSClient.Get(ctx, executionState.PublishedResult.CID, finalOutputPath)
+	require.NoError(s.T(), err)
+
+	err = filepath.Walk(finalOutputPath,
+		func(path string, info os.FileInfo, err error) error {
+			require.NoError(s.T(), err)
+			log.Debug().Msgf("%s - %d", path, info.Size())
+			return err
+		})
+	require.NoError(s.T(), err)
+
+	stdoutContents, err := os.ReadFile(filepath.Join(finalOutputPath, "stdout"))
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), stdoutContents)
+
+	log.Debug().Msgf("stdoutContents=> %s", stdoutContents)
+
+	// stderrContents, err := ioutil.ReadFile(filepath.Join(finalOutputPath, "stderr"))
+	// require.NoError(s.T(), err)
+	// require.Empty(s.T(), stderrContents, "stderr should be empty: %s", stderrContents)
+
+	filePath := fmt.Sprintf("%s/output/test.txt", finalOutputPath)
+	outputData, err := os.ReadFile(filePath)
+	require.NoError(s.T(), err)
+
+	require.Equal(s.T(), fileContents, strings.TrimSpace(string(outputData)))
+}
+func (s *DevstackPythonWASMSuite) TestSimplestPythonWasmDashC() {
+	testutils.SkipIfArm(s.T(), "https://github.com/bacalhau-project/bacalhau/issues/1268")
+	cmd.Fatal = cmd.FakeFatalErrorHandler
+
+	ctx := context.Background()
+	stack, _ := testutils.SetupTest(ctx, s.T(), 1, 0, false,
+		node.NewComputeConfigWithDefaults(),
+		node.NewRequesterConfigWithDefaults())
+
+	// TODO: see also list_test.go, maybe factor out a common way to do this cli
+	// setup
+	_, out, err := cmd.ExecuteTestCobraCommand(
+		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
+		"--api-host=localhost",
+		"run",
+		"python",
+		"--deterministic",
+		"-c",
+		"print(1+1)",
+	)
+	require.NoError(s.T(), err)
+
+	jobId := system.FindJobIDInTestOutput(out)
+	require.NoError(s.T(), err)
+	log.Debug().Msgf("jobId=%s", jobId)
+	time.Sleep(time.Second * 5)
+
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
+	resolver := apiClient.GetJobStateResolver()
+	require.NoError(s.T(), err)
+	err = resolver.WaitUntilComplete(ctx, jobId)
+	require.NoError(s.T(), err)
+
+}
+
+// TODO: test that > 10MB context is rejected
+
+func (s *DevstackPythonWASMSuite) TestSimplePythonWasm() {
+	testutils.SkipIfArm(s.T(), "https://github.com/bacalhau-project/bacalhau/issues/1268")
+	cmd.Fatal = cmd.FakeFatalErrorHandler
+
+	ctx := context.Background()
+	stack, _ := testutils.SetupTest(ctx, s.T(), 1, 0, false,
+		node.NewComputeConfigWithDefaults(),
+		node.NewRequesterConfigWithDefaults())
+
+	tmpDir := s.T().TempDir()
+
+	oldDir, err := os.Getwd()
+	require.NoError(s.T(), err)
+	err = os.Chdir(tmpDir)
+	require.NoError(s.T(), err)
+	defer func() {
+		err := os.Chdir(oldDir)
+		require.NoError(s.T(), err)
+	}()
+
+	// write bytes to main.py
+	mainPy := []byte("print(1+1)\n")
+	err = os.WriteFile("main.py", mainPy, 0644)
+	require.NoError(s.T(), err)
+
+	_, out, err := cmd.ExecuteTestCobraCommand(
+		fmt.Sprintf("--api-port=%d", stack.Nodes[0].APIServer.Port),
+		"--api-host=localhost",
+		"run",
+		"python",
+		"--deterministic",
+		"main.py",
+	)
+	require.NoError(s.T(), err)
+
+	jobId := system.FindJobIDInTestOutput(out)
+	require.NotEmpty(s.T(), jobId, "Unable to find Job ID in", out)
+	log.Debug().Msgf("jobId=%s", jobId)
+	time.Sleep(time.Second * 5)
+
+	apiServer := stack.Nodes[0].APIServer
+	apiClient := publicapi.NewRequesterAPIClient(apiServer.Address, apiServer.Port)
+	resolver := apiClient.GetJobStateResolver()
+	require.NoError(s.T(), err)
+	err = resolver.WaitUntilComplete(ctx, jobId)
+	require.NoError(s.T(), err)
+}
+
+// func TestPythonWasmWithRequirements(t *testing.T) {
+// 	tmpDir, err := ioutil.TempDir("", "devstack_test")
+// 	require.NoError(t, err)
+// 	defer func() {
+// 		err := os.RemoveAll(tmpDir)
+// 		require.NoError(t, err)
+// 	}()
+
+// 	oldDir, err := os.Getwd()
+// 	require.NoError(t, err)
+// 	err = os.Chdir(tmpDir)
+// 	require.NoError(t, err)
+// 	defer func() {
+// 		err := os.Chdir(oldDir)
+// 		require.NoError(t, err)
+// 	}()
+
+// 	_, out, err := ExecuteTestCobraCommand(t, RootCmd,
+// 		"run",
+// 		"python",
+// 		"--deterministic",
+// 		"main.py",
+// 	)
+// 	require.NoError(t, err)
+
+// }

--- a/testdata/sample_commands/good_python.sh
+++ b/testdata/sample_commands/good_python.sh
@@ -1,0 +1,1 @@
+python3 -c "import time; print('inside python'); time.sleep(1);"


### PR DESCRIPTION
One option to fix: https://github.com/bacalhau-project/bacalhau/issues/2512

This reverts the following commits:
- 37efaae6ee8c9d257ffafcb586dbb00a53ae3cb0.
- db8dbc34d3dc40ff37c88345f245e5e88a2eb1b0.
- 1df041d363cbe48b22846dcadd4de7be9d8b4e93.