### PR TITLE
Disappeared or maximally retried nodes should be job failures

### DIFF
--- a/pkg/requester/selection/all_test.go
+++ b/pkg/requester/selection/all_test.go
@@ -91,7 +91,7 @@ var retryTestCases = []nodeSelectorTestCase{
 		expectedNodes: []peer.ID{},
 	},
 	{
-		name:  "does not retry job after many failed retries",
+		name:  "many failed retries is a job failure",
 		nodes: []peer.ID{test1},
 		ranks: []int{1},
 		states: map[peer.ID][]model.ExecutionStateType{
@@ -101,8 +101,7 @@ var retryTestCases = []nodeSelectorTestCase{
 				model.ExecutionStateFailed,
 			},
 		},
-		checkError:    require.NoError,
-		expectedNodes: []peer.ID{},
+		checkError: require.Error,
 	},
 	{
 		name:  "does not retry job on a different node",
@@ -118,11 +117,11 @@ var retryTestCases = []nodeSelectorTestCase{
 				model.ExecutionStateCompleted,
 			},
 		},
-		checkError:    require.NoError,
+		checkError:    require.Error,
 		expectedNodes: []peer.ID{},
 	},
 	{
-		name:  "throws error if node disappeared",
+		name:  "disappeared node is a job failure",
 		nodes: []peer.ID{},
 		ranks: []int{},
 		states: map[peer.ID][]model.ExecutionStateType{
@@ -130,8 +129,7 @@ var retryTestCases = []nodeSelectorTestCase{
 				model.ExecutionStateFailed,
 			},
 		},
-		checkError:    require.Error,
-		expectedNodes: []peer.ID{},
+		checkError: require.Error,
 	},
 }
 


### PR DESCRIPTION
As discussed: https://github.com/bacalhau-project/bacalhau/pull/2518#issuecomment-1576911394

It is a job failure if the `any` strategy cannot schedule the job onto enough nodes. This makes sense because we have not been able to fulfil the user's Deal.

This commit modifies the `all` strategy to have the same behaviour. If the job cannot be successfully run on "all" nodes, the job now fails.