### PR TITLE
Fix jobs targeting all nodes being unable to retry

### DIFF
--- a/pkg/requester/scheduler_state.go
+++ b/pkg/requester/scheduler_state.go
@@ -53,6 +53,8 @@ func (s *BaseScheduler) checkForFailedExecutions(ctx context.Context, job model.
 	nodesToRetry, err := s.nodeSelector.SelectNodesForRetry(ctx, &job, &jobState)
 	if err != nil || (len(nodesToRetry) > 0 && !s.retryStrategy.ShouldRetry(ctx, RetryRequest{JobID: job.ID()})) {
 		// There was an error selecting nodes, or we need to retry some but retry strategy says no.
+		log.Ctx(ctx).Debug().Err(err).Int("NodesToRetry", len(nodesToRetry)).Msg("Failing job")
+
 		var finalErr error
 		var errMsg string
 

--- a/pkg/requester/selection/all.go
+++ b/pkg/requester/selection/all.go
@@ -103,7 +103,7 @@ func (s *allNodeSelector) SelectNodesForRetry(ctx context.Context, job *model.Jo
 
 	retryNodes := make([]model.NodeInfo, 0, len(failedNodes))
 	for _, foundNode := range foundNodes {
-		id := string(foundNode.PeerInfo.ID)
+		id := foundNode.PeerInfo.ID.String()
 		if slices.Contains(failedNodes, id) && failureCounts[id] < maxRetriesPerNode {
 			retryNodes = append(retryNodes, foundNode)
 		}

--- a/pkg/requester/selection/all_test.go
+++ b/pkg/requester/selection/all_test.go
@@ -15,9 +15,17 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+func MustDecode(s string) peer.ID {
+	v, err := peer.Decode(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 var (
-	test1 peer.ID = peer.ID("test1")
-	test2 peer.ID = peer.ID("test2")
+	test1 peer.ID = MustDecode("Qme4YAdSLd9RSJdd8wF6vRXP1inDwvjTfLCCDubuzC64FR")
+	test2 peer.ID = MustDecode("QmUPB6nPQf5tZ11h9sGsL5ukhVtgFaiJabKvP43ps2ymsM")
 )
 
 type nodeSelectorTestCase struct {
@@ -179,7 +187,7 @@ func TestSelectNodesForRetry(t *testing.T) {
 			job := model.NewJob()
 			executions := lo.Flatten(lo.MapToSlice(testCase.states, func(key peer.ID, value []model.ExecutionStateType) []model.ExecutionState {
 				return lo.Map(value, func(state model.ExecutionStateType, _ int) model.ExecutionState {
-					return model.ExecutionState{JobID: job.ID(), NodeID: string(key), State: state}
+					return model.ExecutionState{JobID: job.ID(), NodeID: key.String(), State: state}
 				})
 			}))
 

--- a/pkg/test/devstack/target_all_test.go
+++ b/pkg/test/devstack/target_all_test.go
@@ -1,0 +1,106 @@
+//go:build integration || !unit
+
+package devstack
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/devstack"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/executor/noop"
+	"github.com/bacalhau-project/bacalhau/pkg/job"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/test/scenario"
+	"github.com/stretchr/testify/suite"
+)
+
+type TargetAllSuite struct {
+	scenario.ScenarioRunner
+}
+
+func TestTargetAllSuite(t *testing.T) {
+	suite.Run(t, new(TargetAllSuite))
+}
+
+func (suite *TargetAllSuite) TestCanTargetZeroNodes() {
+	testCase := scenario.Scenario{
+		Stack: &scenario.StackConfig{DevStackOptions: &devstack.DevStackOptions{
+			NumberOfHybridNodes:        0,
+			NumberOfRequesterOnlyNodes: 1,
+			NumberOfComputeOnlyNodes:   0,
+		}},
+		Spec:          model.Spec{Engine: model.EngineNoop},
+		Deal:          model.Deal{TargetAll: true},
+		SubmitChecker: scenario.SubmitJobSuccess(),
+		JobCheckers:   scenario.WaitUntilSuccessful(0),
+	}
+
+	suite.RunScenario(testCase)
+}
+
+func (suite *TargetAllSuite) TestCanTargetSingleNode() {
+	testCase := scenario.Scenario{
+		Stack: &scenario.StackConfig{DevStackOptions: &devstack.DevStackOptions{
+			NumberOfHybridNodes:        0,
+			NumberOfRequesterOnlyNodes: 1,
+			NumberOfComputeOnlyNodes:   1,
+		}},
+		Spec:          model.Spec{Engine: model.EngineNoop},
+		Deal:          model.Deal{TargetAll: true},
+		SubmitChecker: scenario.SubmitJobSuccess(),
+		JobCheckers:   scenario.WaitUntilSuccessful(1),
+	}
+
+	suite.RunScenario(testCase)
+}
+
+func (suite *TargetAllSuite) TestCanTargetMultipleNodes() {
+	testCase := scenario.Scenario{
+		Stack: &scenario.StackConfig{DevStackOptions: &devstack.DevStackOptions{
+			NumberOfHybridNodes:        0,
+			NumberOfRequesterOnlyNodes: 1,
+			NumberOfComputeOnlyNodes:   5,
+		}},
+		Spec:          model.Spec{Engine: model.EngineNoop},
+		Deal:          model.Deal{TargetAll: true},
+		SubmitChecker: scenario.SubmitJobSuccess(),
+		JobCheckers:   scenario.WaitUntilSuccessful(5),
+	}
+
+	suite.RunScenario(testCase)
+}
+
+func (suite *TargetAllSuite) TestCanRetryOnNodes() {
+	var hasFailed atomic.Bool
+
+	testCase := scenario.Scenario{
+		Stack: &scenario.StackConfig{
+			DevStackOptions: &devstack.DevStackOptions{NumberOfHybridNodes: 0, NumberOfRequesterOnlyNodes: 1, NumberOfComputeOnlyNodes: 2},
+			ExecutorConfig: noop.ExecutorConfig{
+				ExternalHooks: noop.ExecutorConfigExternalHooks{
+					JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
+						if !hasFailed.Swap(true) {
+							return executor.FailResult(fmt.Errorf("oh no"))
+						} else {
+							return executor.WriteJobResults(resultsDir, nil, nil, 0, nil)
+						}
+					},
+				},
+			},
+		},
+		Spec:          model.Spec{Engine: model.EngineNoop},
+		Deal:          model.Deal{TargetAll: true},
+		SubmitChecker: scenario.SubmitJobSuccess(),
+		JobCheckers: []job.CheckStatesFunction{
+			job.WaitForExecutionStates(map[model.ExecutionStateType]int{
+				model.ExecutionStateCompleted: 2,
+				model.ExecutionStateFailed:    1,
+			}),
+		},
+	}
+
+	suite.RunScenario(testCase)
+}


### PR DESCRIPTION
We have only tested this code in the CLI (where it's hard to generate jobs that should retry) and in unit tests where we using faked peer IDs. It turns out that with real peer IDs we were not comparing them correctly.

We now compare them correctly. This includes some end-to-end tests for jobs targeting all nodes.