### PR TITLE
Add flag for job submitters to control node targeting 

### DIFF
--- a/cmd/bacalhau/flags.go
+++ b/cmd/bacalhau/flags.go
@@ -269,6 +269,15 @@ func NetworkFlag(value *model.Network) *ValueFlag[model.Network] {
 	}
 }
 
+func TargetingFlag(value *model.TargetingMode) *ValueFlag[model.TargetingMode] {
+	return &ValueFlag[model.TargetingMode]{
+		value:    value,
+		parser:   model.ParseTargetingMode,
+		stringer: func(tm *model.TargetingMode) string { return tm.String() },
+		typeStr:  "all|any",
+	}
+}
+
 func DataLocalityFlag(value *model.JobSelectionDataLocality) *ValueFlag[model.JobSelectionDataLocality] {
 	return &ValueFlag[model.JobSelectionDataLocality]{
 		value:    value,
@@ -383,6 +392,21 @@ func DisabledFeatureCLIFlags(config *node.FeatureConfig) *pflag.FlagSet {
 	flags.Var(PublishersFlag(&config.Publishers), "disable-publisher", "A publisher type to disable.")
 	flags.Var(VerifiersFlag(&config.Verifiers), "disable-verifier", "A verifier to disable.")
 	flags.Var(StorageSourcesFlag(&config.Storages), "disable-storage", "A storage type to disable.")
+
+	return flags
+}
+
+func DealCLIFlags(deal *model.Deal) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("Deal", pflag.ContinueOnError)
+
+	flags.Var(TargetingFlag(&deal.TargetingMode), "target",
+		`Whether to target the minimum number of matching nodes ("any") (default) or all matching nodes ("all")`)
+	flags.IntVarP(&deal.Concurrency, "concurrency", "c", deal.Concurrency,
+		`How many nodes should run the job when using --target=any`)
+	flags.IntVar(&deal.Confidence, "confidence", deal.Confidence,
+		`The minimum number of nodes that must agree on a verification result`)
+	flags.IntVar(&deal.MinBids, "min-bids", deal.MinBids,
+		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`)
 
 	return flags
 }

--- a/cmd/bacalhau/wasm_run.go
+++ b/cmd/bacalhau/wasm_run.go
@@ -111,6 +111,7 @@ func newRunWasmCmd() *cobra.Command {
 
 	wasmRunCmd.PersistentFlags().AddFlagSet(NewRunTimeSettingsFlags(&ODR.RunTimeSettings))
 	wasmRunCmd.PersistentFlags().AddFlagSet(NewIPFSDownloadFlags(&ODR.DownloadFlags))
+	wasmRunCmd.PersistentFlags().AddFlagSet(DealCLIFlags(&ODR.Job.Spec.Deal))
 
 	wasmRunCmd.PersistentFlags().StringVarP(
 		&ODR.NodeSelector, "selector", "s", ODR.NodeSelector,
@@ -123,18 +124,6 @@ func newRunWasmCmd() *cobra.Command {
 	)
 	wasmRunCmd.PersistentFlags().VarP(&ODR.Publisher, "publisher", "p",
 		`Where to publish the result of the job`,
-	)
-	wasmRunCmd.PersistentFlags().IntVarP(
-		&ODR.Job.Spec.Deal.Concurrency, "concurrency", "c", ODR.Job.Spec.Deal.Concurrency,
-		`How many nodes should run the job`,
-	)
-	wasmRunCmd.PersistentFlags().IntVar(
-		&ODR.Job.Spec.Deal.Confidence, "confidence", ODR.Job.Spec.Deal.Confidence,
-		`The minimum number of nodes that must agree on a verification result`,
-	)
-	wasmRunCmd.PersistentFlags().IntVar(
-		&ODR.Job.Spec.Deal.MinBids, "min-bids", ODR.Job.Spec.Deal.MinBids,
-		`Minimum number of bids that must be received before concurrency-many bids will be accepted (at random)`,
 	)
 	wasmRunCmd.PersistentFlags().Float64Var(
 		&ODR.Job.Spec.Timeout, "timeout", ODR.Job.Spec.Timeout,

--- a/pkg/bidstrategy/semantic/distance_delay.go
+++ b/pkg/bidstrategy/semantic/distance_delay.go
@@ -3,12 +3,12 @@ package semantic
 import (
 	"context"
 	"hash/fnv"
-	"math"
 	"time"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 // Decide whether we should even consider bidding on the job, early exit if
@@ -70,7 +70,7 @@ func (s DistanceDelayStrategy) calculateJobNodeDistanceDelay(ctx context.Context
 	// If concurrency=3 and network size=3, there'll only be one piece and
 	// everyone will bid. If concurrency=1 and network size=1 million, there
 	// will be a million slices of the hash space.
-	concurrency := max(1, request.Job.Spec.Deal.Concurrency, request.Job.Spec.Deal.MinBids)
+	concurrency := system.Max(1, request.Job.Spec.Deal.Concurrency, request.Job.Spec.Deal.MinBids)
 	chunk := int((float32(concurrency) / float32(s.networkSize)) * 4294967295) //nolint:gomnd
 	// wait 1 second per chunk distance. So, if we land in exactly the same
 	// chunk, bid immediately. If we're one chunk away, wait a bit before
@@ -104,15 +104,4 @@ func diff(a, b int) int {
 		return b - a
 	}
 	return a - b
-}
-
-func max(vars ...int) int {
-	res := math.MinInt
-
-	for _, i := range vars {
-		if res < i {
-			res = i
-		}
-	}
-	return res
 }

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -26,9 +26,7 @@ func ConstructDockerJob( //nolint:funlen
 	env []string,
 	entrypoint []string,
 	image string,
-	concurrency int,
-	confidence int,
-	minBids int,
+	deal model.Deal,
 	timeout float64,
 	annotations []string,
 	nodeSelector string,
@@ -105,11 +103,7 @@ func ConstructDockerJob( //nolint:funlen
 		j.Spec.Docker.WorkingDirectory = workingDir
 	}
 
-	j.Spec.Deal = model.Deal{
-		Concurrency: concurrency,
-		Confidence:  confidence,
-		MinBids:     minBids,
-	}
+	j.Spec.Deal = deal
 
 	return j, nil
 }

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -84,9 +84,12 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 					[]string{}, // env
 					[]string{}, // entrypoint
 					"",         // image
-					1,          // concurrency
-					0,          // confidence
-					0,          // min bids
+					model.Deal{
+						TargetingMode: model.TargetAny,
+						Concurrency:   1,
+						Confidence:    0,
+						MinBids:       0,
+					},
 					300,        // timeout
 					[]string{}, // annotations
 					"",         // node selector

--- a/pkg/job/util.go
+++ b/pkg/job/util.go
@@ -131,7 +131,7 @@ func ComputeVerifiedSummary(j *model.JobWithInfo) string {
 	if j.Job.Spec.Verifier == model.VerifierNoop {
 		verifiedSummary = ""
 	} else {
-		desiredExecutionCount := GetJobConcurrency(j.Job)
+		desiredExecutionCount := len(j.State.Executions)
 		verifiedExecutionCount := CountVerifiedExecutionStates(j.State)
 		verifiedSummary = fmt.Sprintf("%d/%d", verifiedExecutionCount, desiredExecutionCount)
 	}
@@ -145,12 +145,4 @@ func GetIPFSPublishedStorageSpec(executionID string, job model.Job, storageType 
 		CID:           cid,
 		Metadata:      map[string]string{},
 	}
-}
-
-func GetJobConcurrency(j model.Job) int {
-	concurrency := j.Spec.Deal.Concurrency
-	if concurrency < 1 {
-		concurrency = 1
-	}
-	return concurrency
 }

--- a/pkg/job/validate.go
+++ b/pkg/job/validate.go
@@ -30,16 +30,8 @@ func VerifyJob(ctx context.Context, j *model.Job) error {
 		return fmt.Errorf("job spec is empty")
 	}
 
-	if reflect.DeepEqual(model.Deal{}, j.Spec.Deal) {
-		return fmt.Errorf("job deal is empty")
-	}
-
-	if j.Spec.Deal.Concurrency <= 0 {
-		return fmt.Errorf("concurrency must be >= 1")
-	}
-
-	if j.Spec.Deal.Confidence < 0 {
-		return fmt.Errorf("confidence must be >= 0")
+	if err := j.Spec.Deal.IsValid(); err != nil {
+		return err
 	}
 
 	if !model.IsValidEngine(j.Spec.Engine) {
@@ -56,10 +48,6 @@ func VerifyJob(ctx context.Context, j *model.Job) error {
 
 	if err := j.Spec.Network.IsValid(); err != nil {
 		return err
-	}
-
-	if j.Spec.Deal.Confidence > j.Spec.Deal.Concurrency {
-		return fmt.Errorf("the deal confidence cannot be higher than the concurrency")
 	}
 
 	for _, inputVolume := range j.Spec.Inputs {

--- a/pkg/model/job_test.go
+++ b/pkg/model/job_test.go
@@ -1,0 +1,50 @@
+//go:build unit || !integration
+
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var validDeals = []Deal{
+	{TargetingMode: TargetAny, Concurrency: 1, Confidence: 0, MinBids: 0},
+	{TargetingMode: TargetAny, Concurrency: 1, Confidence: 0, MinBids: 3},
+	{TargetingMode: TargetAny, Concurrency: 1, Confidence: 1, MinBids: 0},
+	{TargetingMode: TargetAny, Concurrency: 5, Confidence: 0, MinBids: 0},
+	{TargetingMode: TargetAll, Concurrency: 0, Confidence: 0, MinBids: 0},
+	{TargetingMode: TargetAll, Concurrency: 1, Confidence: 0, MinBids: 0},
+}
+
+var invalidDeals = []Deal{
+	{},
+	{TargetingMode: TargetAll, Concurrency: 2, Confidence: 0, MinBids: 0},
+	{TargetingMode: TargetAll, Concurrency: 0, Confidence: 1, MinBids: 0},
+	{TargetingMode: TargetAll, Concurrency: 0, Confidence: 0, MinBids: 1},
+	{TargetingMode: TargetAny, Concurrency: -1, Confidence: 0, MinBids: 0},
+	{TargetingMode: TargetAny, Concurrency: 1, Confidence: -1, MinBids: 0},
+	{TargetingMode: TargetAny, Concurrency: 1, Confidence: 0, MinBids: -1},
+	{TargetingMode: TargetAny, Concurrency: 1, Confidence: 2, MinBids: 0},
+}
+
+func TestDealValidity(t *testing.T) {
+	for _, deal := range validDeals {
+		t.Run(
+			fmt.Sprintf("%v is valid", deal),
+			func(t *testing.T) {
+				require.NoError(t, deal.IsValid())
+			},
+		)
+	}
+
+	for _, deal := range invalidDeals {
+		t.Run(
+			fmt.Sprintf("%v is invalid", deal),
+			func(t *testing.T) {
+				require.Error(t, deal.IsValid())
+			},
+		)
+	}
+}

--- a/pkg/requester/selection/switch.go
+++ b/pkg/requester/selection/switch.go
@@ -8,22 +8,22 @@ import (
 )
 
 type switcher struct {
-	selectors map[bool]requester.NodeSelector
+	selectors map[model.TargetingMode]requester.NodeSelector
 }
 
 // Returns a node selector that switches between node selectors dependent on the
 // targeting type defined in the job.
 func NewNodeSelectorSwitch(forAny, forAll requester.NodeSelector) requester.NodeSelector {
 	return &switcher{
-		selectors: map[bool]requester.NodeSelector{
-			false: forAny,
-			true:  forAll,
+		selectors: map[model.TargetingMode]requester.NodeSelector{
+			model.TargetAny: forAny,
+			model.TargetAll: forAll,
 		},
 	}
 }
 
 func (s *switcher) SelectorForJob(job *model.Job) requester.NodeSelector {
-	return s.selectors[job.Spec.Deal.TargetAll]
+	return s.selectors[job.Spec.Deal.TargetingMode]
 }
 
 // CanCompleteJob implements requester.NodeSelector.

--- a/pkg/system/utils.go
+++ b/pkg/system/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/c2h5oh/datasize"
+	"github.com/samber/lo"
 	"golang.org/x/exp/constraints"
 )
 
@@ -48,18 +49,12 @@ func PathExists(path string) (bool, error) {
 	return false, err
 }
 
-func Min[T constraints.Ordered](a, b T) T {
-	if a < b {
-		return a
-	}
-	return b
+func Min[T constraints.Ordered](item T, items ...T) T {
+	return lo.Min(append(items, item))
 }
 
-func Max[T constraints.Ordered](a, b T) T {
-	if a > b {
-		return a
-	}
-	return b
+func Max[T constraints.Ordered](item T, items ...T) T {
+	return lo.Max(append(items, item))
 }
 
 func ReverseList(s []string) []string {

--- a/pkg/test/devstack/target_all_test.go
+++ b/pkg/test/devstack/target_all_test.go
@@ -33,7 +33,7 @@ func (suite *TargetAllSuite) TestCanTargetZeroNodes() {
 			NumberOfComputeOnlyNodes:   0,
 		}},
 		Spec:          model.Spec{Engine: model.EngineNoop},
-		Deal:          model.Deal{TargetAll: true},
+		Deal:          model.Deal{TargetingMode: model.TargetAll},
 		SubmitChecker: scenario.SubmitJobSuccess(),
 		JobCheckers:   scenario.WaitUntilSuccessful(0),
 	}
@@ -49,7 +49,7 @@ func (suite *TargetAllSuite) TestCanTargetSingleNode() {
 			NumberOfComputeOnlyNodes:   1,
 		}},
 		Spec:          model.Spec{Engine: model.EngineNoop},
-		Deal:          model.Deal{TargetAll: true},
+		Deal:          model.Deal{TargetingMode: model.TargetAll},
 		SubmitChecker: scenario.SubmitJobSuccess(),
 		JobCheckers:   scenario.WaitUntilSuccessful(1),
 	}
@@ -65,7 +65,7 @@ func (suite *TargetAllSuite) TestCanTargetMultipleNodes() {
 			NumberOfComputeOnlyNodes:   5,
 		}},
 		Spec:          model.Spec{Engine: model.EngineNoop},
-		Deal:          model.Deal{TargetAll: true},
+		Deal:          model.Deal{TargetingMode: model.TargetAll},
 		SubmitChecker: scenario.SubmitJobSuccess(),
 		JobCheckers:   scenario.WaitUntilSuccessful(5),
 	}
@@ -92,7 +92,7 @@ func (suite *TargetAllSuite) TestCanRetryOnNodes() {
 			},
 		},
 		Spec:          model.Spec{Engine: model.EngineNoop},
-		Deal:          model.Deal{TargetAll: true},
+		Deal:          model.Deal{TargetingMode: model.TargetAll},
 		SubmitChecker: scenario.SubmitJobSuccess(),
 		JobCheckers: []job.CheckStatesFunction{
 			job.WaitForExecutionStates(map[model.ExecutionStateType]int{

--- a/pkg/verifier/utils.go
+++ b/pkg/verifier/utils.go
@@ -2,12 +2,11 @@ package verifier
 
 import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 func ValidateExecutions(request VerifierRequest) error {
 	// minimum number of executions that should be present
-	minCount := system.Min(request.Deal.GetConfidence(), request.Deal.GetConcurrency())
+	minCount := request.Deal.GetConfidence()
 	if len(request.Executions) < minCount {
 		return NewErrInsufficientExecutions(request.JobID, minCount, len(request.Executions))
 	}


### PR DESCRIPTION
Now by passing the `--target=all` flag, users of the CLI can request a job that will target all nodes.

Also some generic cleanup around the deal structure and friends.