### PR TITLE
Show node ranking failures in the CLI

### DIFF
--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/imdario/mergo"
@@ -207,6 +208,10 @@ type LabelSelectorRequirement struct {
 	// the values array must be non-empty. If the operator is Exists or DoesNotExist,
 	// the values array must be empty. This array is replaced during a strategic
 	Values []string `json:"Values,omitempty"`
+}
+
+func (r LabelSelectorRequirement) String() string {
+	return fmt.Sprintf("%s %s %s", r.Key, r.Operator, strings.Join(r.Values, "|"))
 }
 
 type PublisherSpec struct {

--- a/pkg/model/resource_usage.go
+++ b/pkg/model/resource_usage.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/rs/zerolog/log"
 )
 
@@ -125,7 +126,10 @@ func (r ResourceUsageData) IsZero() bool {
 
 // return string representation of ResourceUsageData
 func (r ResourceUsageData) String() string {
-	return fmt.Sprintf("{CPU: %f, Memory: %d, Disk: %d, GPU: %d}", r.CPU, r.Memory, r.Disk, r.GPU)
+	cpu := Millicores(r.CPU * float64(Core))
+	mem := datasize.ByteSize(r.Memory)
+	disk := datasize.ByteSize(r.Disk)
+	return fmt.Sprintf("{CPU: %s, Memory: %s, Disk: %s, GPU: %d}", cpu, mem.HR(), disk.HR(), r.GPU)
 }
 
 type ResourceUsageProfile struct {

--- a/pkg/requester/errors.go
+++ b/pkg/requester/errors.go
@@ -3,16 +3,17 @@ package requester
 import (
 	"fmt"
 
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // ErrNotEnoughNodes is returned when not enough nodes in the network to run a job
 type ErrNotEnoughNodes struct {
 	RequestedNodes int
-	AvailableNodes int
+	AvailableNodes []NodeRank
 }
 
-func NewErrNotEnoughNodes(requestedNodes, availableNodes int) ErrNotEnoughNodes {
+func NewErrNotEnoughNodes(requestedNodes int, availableNodes []NodeRank) ErrNotEnoughNodes {
 	return ErrNotEnoughNodes{
 		RequestedNodes: requestedNodes,
 		AvailableNodes: availableNodes,
@@ -20,7 +21,31 @@ func NewErrNotEnoughNodes(requestedNodes, availableNodes int) ErrNotEnoughNodes 
 }
 
 func (e ErrNotEnoughNodes) Error() string {
-	return fmt.Sprintf("not enough nodes to run job. requested: %d, available: %d", e.RequestedNodes, e.AvailableNodes)
+	nodeErrors := ""
+	available := 0
+	for _, rank := range e.AvailableNodes {
+		if rank.MeetsRequirement() {
+			available += 1
+		} else {
+			nodeErrors += fmt.Sprintf("\n\tNode %s: %s", system.GetShortID(rank.NodeInfo.PeerInfo.ID.String()), rank.Reason)
+		}
+	}
+	return fmt.Sprintf("not enough nodes to run job. requested: %d, available: %d. %s", e.RequestedNodes, available, nodeErrors)
+}
+
+// ErrTooManyRetries is returned when an execution has been retried too many times
+type ErrTooManyRetries struct {
+	Attempts int
+}
+
+func NewErrTooManyRetries(attempts int) ErrTooManyRetries {
+	return ErrTooManyRetries{
+		Attempts: attempts,
+	}
+}
+
+func (e ErrTooManyRetries) Error() string {
+	return fmt.Sprintf("too many retries (attempted %d)", e.Attempts)
 }
 
 // ErrNodeNotFound is returned when nodeInfo was not found for a requested peer id

--- a/pkg/requester/ranking/chain.go
+++ b/pkg/requester/ranking/chain.go
@@ -39,9 +39,10 @@ func (c *Chain) RankNodes(ctx context.Context, job model.Job, nodes []model.Node
 			return nil, err
 		}
 		for _, nodeRank := range nodeRanks {
-			if !ranksMap[nodeRank.NodeInfo.PeerInfo.ID].MeetsRequirement() || !nodeRank.MeetsRequirement() {
+			if !nodeRank.MeetsRequirement() {
 				ranksMap[nodeRank.NodeInfo.PeerInfo.ID].Rank = requester.RankUnsuitable
-			} else {
+				ranksMap[nodeRank.NodeInfo.PeerInfo.ID].Reason = nodeRank.Reason
+			} else if ranksMap[nodeRank.NodeInfo.PeerInfo.ID].MeetsRequirement() {
 				ranksMap[nodeRank.NodeInfo.PeerInfo.ID].Rank += nodeRank.Rank
 			}
 		}

--- a/pkg/requester/ranking/labels.go
+++ b/pkg/requester/ranking/labels.go
@@ -2,6 +2,7 @@ package ranking
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -51,26 +52,30 @@ func (s *LabelsNodeRanker) RankNodes(ctx context.Context, job model.Job, nodes [
 		}
 	}
 	for i, node := range nodes {
-		rank := 0
+		rank := requester.RankPossible
+		reason := "selectors not set or unknown"
 		if !mustSelector.Empty() {
 			if mustSelector.Matches(labels.Set(node.Labels)) {
-				rank = 10
+				rank = requester.RankPreferred
+				reason = "match for required selector"
 			} else {
-				log.Ctx(ctx).Trace().Msgf("filtering node %s with labels %s doesn't match selectors %+v",
-					node.PeerInfo.ID, node.Labels, job.Spec.NodeSelectors)
-				rank = -1
+				rank = requester.RankUnsuitable
+				reason = fmt.Sprintf("labels %s don't match required selectors %s", node.Labels, job.Spec.NodeSelectors)
 			}
 		}
 		ranks[i] = requester.NodeRank{
 			NodeInfo: node,
 			Rank:     rank,
+			Reason:   reason,
 		}
+		log.Ctx(ctx).Trace().Object("Rank", ranks[i]).Msg("Ranked node")
 	}
 
 	if !favourSelector.Empty() {
 		for i, rank := range ranks {
 			if rank.MeetsRequirement() && favourSelector.Matches(labels.Set(rank.NodeInfo.Labels)) {
 				ranks[i].Rank += requester.RankPreferred
+				ranks[i].Reason = "match for preferred selector"
 			}
 		}
 	}

--- a/pkg/requester/ranking/previous_executions.go
+++ b/pkg/requester/ranking/previous_executions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/requester"
+	"github.com/rs/zerolog/log"
 )
 
 type PreviousExecutionsNodeRankerParams struct {
@@ -47,19 +48,25 @@ func (s *PreviousExecutionsNodeRanker) RankNodes(ctx context.Context, job model.
 	}
 	for i, node := range nodes {
 		rank := 3 * requester.RankPreferred
+		reason := "job not executed yet"
 		if previousExecutions, ok := previousExecutors[node.PeerInfo.ID.String()]; ok {
 			if previousExecutions > 1 {
 				rank = requester.RankUnsuitable
+				reason = "job already executed on this node more than once"
 			} else if _, filterOut := toFilterOut[node.PeerInfo.ID.String()]; filterOut {
 				rank = requester.RankUnsuitable
+				reason = "job rejected or produced invalid result"
 			} else {
 				rank = requester.RankPossible
+				reason = "job already executed on this node"
 			}
 		}
 		ranks[i] = requester.NodeRank{
 			NodeInfo: node,
 			Rank:     rank,
+			Reason:   reason,
 		}
+		log.Ctx(ctx).Trace().Object("Rank", ranks[i]).Msg("Ranked node")
 	}
 	return ranks, nil
 }

--- a/pkg/requester/selection/any.go
+++ b/pkg/requester/selection/any.go
@@ -56,19 +56,18 @@ func (s *anyNodeSelector) Select(ctx context.Context, job *model.Job, minCount, 
 			filteredNodes = append(filteredNodes, nodeRank)
 		}
 	}
-	rankedNodes = filteredNodes
-	log.Ctx(ctx).Debug().Int("Ranked", len(rankedNodes)).Msg("Ranked nodes for job")
+	log.Ctx(ctx).Debug().Int("Ranked", len(filteredNodes)).Msg("Ranked nodes for job")
 
-	if len(rankedNodes) < minCount {
-		err = requester.NewErrNotEnoughNodes(minCount, len(rankedNodes))
+	if len(filteredNodes) < minCount {
+		err = requester.NewErrNotEnoughNodes(minCount, rankedNodes)
 		return nil, err
 	}
 
-	sort.Slice(rankedNodes, func(i, j int) bool {
-		return rankedNodes[i].Rank > rankedNodes[j].Rank
+	sort.Slice(filteredNodes, func(i, j int) bool {
+		return filteredNodes[i].Rank > filteredNodes[j].Rank
 	})
 
-	selectedNodes := rankedNodes[:system.Min(len(rankedNodes), desiredCount)]
+	selectedNodes := filteredNodes[:system.Min(len(filteredNodes), desiredCount)]
 	selectedInfos := generic.Map(selectedNodes, func(nr requester.NodeRank) model.NodeInfo { return nr.NodeInfo })
 	return selectedInfos, nil
 }

--- a/pkg/requester/types.go
+++ b/pkg/requester/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/verifier"
 	"github.com/bacalhau-project/bacalhau/pkg/verifier/external"
+	"github.com/rs/zerolog"
 )
 
 // Endpoint is the frontend and entry point to the requester node for the end users to submit, update and cancel jobs.
@@ -72,6 +73,7 @@ type NodeSelector interface {
 type NodeRank struct {
 	NodeInfo model.NodeInfo
 	Rank     int
+	Reason   string
 }
 
 const (
@@ -88,6 +90,12 @@ const (
 // Returns whether the node meets the requirements to run the job.
 func (r NodeRank) MeetsRequirement() bool {
 	return r.Rank > RankUnsuitable
+}
+
+func (r NodeRank) MarshalZerologObject(e *zerolog.Event) {
+	e.Stringer("Node", r.NodeInfo.PeerInfo.ID).
+		Bool("MeetsRequirement", r.MeetsRequirement()).
+		Str("Reason", r.Reason)
 }
 
 // StartJobRequest triggers the scheduling of a job.


### PR DESCRIPTION
Previously when so many nodes fail ranking that not enough are available to run the job, the CLI would just print an unhelpful "not enough nodes to run job" message. This makes it hard to diagnose why the job isn't suitable.

This commit adds a reason to the node rankings, and in the event of total job failure displays the reasons for each node in the CLI.

E.g.
```
% go run . create job-local.yaml
Error executing job: failed to submit job: not enough nodes to run job. requested: 1, available: 0. 
        Node QmW7rsRr: job requires more resources {CPU: 0, Memory: 0 B, Disk: 0 B, GPU: 2} than are available per job {CPU: 6400m, Memory: 12.8 GB, Disk: 97.5 GB, GPU: 0}
```

```
% go run . create job-local.yaml
Error executing job: failed to submit job: not enough nodes to run job. requested: 1, available: 0. 
        Node QmZdjfNa: does not support model.StorageSourceType LocalDirectory, only [IPFS URLDownload FilecoinUnsealed Inline]
```

Resolves #2398.