### PR TITLE
Ensure tools required for go generate are installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,9 +426,15 @@ coverage/:
 	mkdir -p $@
 
 .PHONY: generate
-generate:
+generate: generate-tools
 	${GO} generate -gcflags '-N -l' -ldflags "-X main.VERSION=$(TAG)" ./...
-	echo "[OK] Files added to pipeline template directory!"
+	@echo "[OK] Files added to pipeline template directory!"
+
+.PHONY: generate-tools
+generate-tools:
+	@which mockgen > /dev/null || echo "Installing 'mockgen'" && ${GO} install go.uber.org/mock/mockgen@latest
+	@which stringer > /dev/null  || echo "Installing 'stringer'" && ${GO} install golang.org/x/tools/cmd/stringer
+
 
 .PHONY: security
 security:


### PR DESCRIPTION
When running `make generate` to run `go generate` over the source code, some of the required tools (mockgen and stringer) may be missing.

Adds a new target, upon which `make generate` depends to install the tools if they are not currently available (as determined by `which`).

The google maintained version of gomock is now archived and so https://github.com/bacalhau-project/bacalhau/pull/2656 (merged) switches to a new maintained fork 


Closes #2651
