### PR TITLE
Fix assignment of reference in nodeinfo lookup

### DIFF
--- a/pkg/orchestrator/scheduler/batch_job.go
+++ b/pkg/orchestrator/scheduler/batch_job.go
@@ -143,8 +143,8 @@ func (b *BatchJobScheduler) existingNodeInfos(ctx context.Context, existingExecu
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
-	for _, node := range discoveredNodes {
-		nodesMap[string(node.PeerInfo.ID)] = &node
+	for i, node := range discoveredNodes {
+		nodesMap[string(node.PeerInfo.ID)] = &discoveredNodes[i]
 	}
 
 	for _, execution := range existingExecutions {


### PR DESCRIPTION
Currently the code is assigning a reference to something extracted from a range, ensuring that once the loop is complete all values will point to the last item.  Fixed to reference the full array instead