### PR TITLE
Preserve storage path and name when copying

### DIFF
--- a/pkg/storage/copy/copy.go
+++ b/pkg/storage/copy/copy.go
@@ -110,5 +110,8 @@ func Copy(
 	if err != nil {
 		err = errors.Wrapf(err, "failed to save %s spec to %s", spec.StorageSource, destination)
 	}
+
+	newSpec.Name = spec.Name
+	newSpec.Path = spec.Path
 	return newSpec, err
 }


### PR DESCRIPTION
Previously, our copy algorithm did not preserve the name or path of a passed StorageSpec, meaning that the mount point was then no longer available when a spec was copied between drivers.

Our copy algorithm now preserves these. It does not preserve the metadata because this is defined as "driver-specific" and hence it is up to the destination storage driver to supply it.

Resolves #2666.