### PR TITLE
Transport log cmd errors to the client in main message struct

### DIFF
--- a/cmd/cli/logs/logs.go
+++ b/cmd/cli/logs/logs.go
@@ -49,10 +49,5 @@ func NewCmd() *cobra.Command {
 		`Follow the logs in real-time after retrieving the current logs.`,
 	)
 
-	logsCmd.PersistentFlags().BoolVarP(
-		&options.Follow, "history", "h", false,
-		`Show all logs with history. TODO better definition`,
-	)
-
 	return logsCmd
 }

--- a/cmd/util/fatal.go
+++ b/cmd/util/fatal.go
@@ -14,7 +14,7 @@ func fatalError(cmd *cobra.Command, err error, code int) {
 		if !strings.HasSuffix(msg, "\n") {
 			msg += "\n"
 		}
-		cmd.Print(msg)
+		cmd.PrintErr(msg)
 	}
 	os.Exit(code)
 }


### PR DESCRIPTION
Currently messages are sent via the control channel, and this runs up against an unclearly documented limit of 125 bytes for the control channel message.  This means that all errors end up as abnormal errors at the client end, something we should never send ourselves.

Now errors are included in the message structure, if present it is printed to STDERR and the process is cancelled.

No changes to access policy have been made yet.

Resolves  #2669 