### PR TITLE
refactor: executor interface and storage dependency

### DIFF
--- a/cmd/cli/wasm/wasm_run.go
+++ b/cmd/cli/wasm/wasm_run.go
@@ -21,9 +21,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/executor/wasm"
 	"github.com/bacalhau-project/bacalhau/pkg/job"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/inline"
-	"github.com/bacalhau-project/bacalhau/pkg/storage/noop"
 	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
 )
@@ -304,8 +302,7 @@ func validateWasm(cmd *cobra.Command, args []string, opts *WasmRunOptions) error
 	defer closer.ContextCloserWithLogOnError(ctx, "engine", engine)
 
 	config := wazero.NewModuleConfig()
-	storage := model.NewNoopProvider[model.StorageSourceType, storage.Storage](noop.NewNoopStorage())
-	loader := wasm.NewModuleLoader(engine, config, storage)
+	loader := wasm.NewModuleLoader(engine, config)
 	module, err := loader.Load(ctx, programPath)
 	if err != nil {
 		return err

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -55,7 +55,13 @@ func NewBaseExecutor(params BaseExecutorParams) *BaseExecutor {
 	}
 }
 
-func PrepareRunArguments(ctx context.Context, strgprovider storage.StorageProvider, execution store.Execution, resultsDir string, cleanup *system.CleanupManager) (*executor.RunCommandRequest, error) {
+func PrepareRunArguments(
+	ctx context.Context,
+	strgprovider storage.StorageProvider,
+	execution store.Execution,
+	resultsDir string,
+	cleanup *system.CleanupManager,
+) (*executor.RunCommandRequest, error) {
 	inputVolumes, err := storage.ParallelPrepareStorage(ctx, strgprovider, execution.Job.Spec.Inputs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepate storage for execution: %w", err)
@@ -159,7 +165,7 @@ func (e *BaseExecutor) Run(ctx context.Context, execution store.Execution) (err 
 	}
 
 	if e.failureInjection.IsBadActor {
-		return fmt.Errorf("I am a baaad node. I failed execution %s", execution.ID)
+		return fmt.Errorf("i am a baaad node. i failed execution %s", execution.ID)
 	}
 
 	runCommandCleanup := system.NewCleanupManager()

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -2,10 +2,12 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
 )
 
 // Returns a executor for the given engine type
@@ -16,30 +18,40 @@ type ExecutorProvider = model.Provider[model.Engine, Executor]
 type Executor interface {
 	model.Providable
 
-	// used to filter and select jobs
-	//    tells us if the storage resource is "close" i.e. cheap to access
-	HasStorageLocally(context.Context, model.StorageSpec) (bool, error)
-
 	// A BidStrategy that should return a positive response if the executor
 	// could run the job or a negative response otherwise.
 	GetSemanticBidStrategy(context.Context) (bidstrategy.SemanticBidStrategy, error)
 
 	GetResourceBidStrategy(ctx context.Context) (bidstrategy.ResourceBidStrategy, error)
 
-	//    tells us how much storage the given volume would consume
-	//    which we then use to calculate if there is capacity
-	//    alongside cpu & memory usage
-	GetVolumeSize(context.Context, model.StorageSpec) (uint64, error)
-
 	// GetOutputStream retrieves a muxed stream from the executor
 	GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error)
 
 	// run the given job - it's expected that we have already prepared the job
 	// this will return a local filesystem path to the jobs results
-	Run(
-		ctx context.Context,
-		executionID string,
-		job model.Job,
-		resultsDir string,
-	) (*model.RunCommandResult, error)
+	Run(ctx context.Context, Args *RunCommandRequest) (*model.RunCommandResult, error)
+}
+
+type RunCommandRequest struct {
+	JobID        string
+	ExecutionID  string
+	Resources    model.ResourceUsageConfig
+	Network      model.NetworkConfig
+	Outputs      []model.StorageSpec
+	Inputs       []storage.PreparedStorage
+	ResultsDir   string
+	EngineParams *Arguments
+}
+
+// ExecutorParams is a stub for pluggable engines
+type Arguments struct {
+	Params []byte
+}
+
+func EncodeArguments(in interface{}) (*Arguments, error) {
+	b, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	return &Arguments{Params: b}, nil
 }

--- a/pkg/executor/util/utils.go
+++ b/pkg/executor/util/utils.go
@@ -125,7 +125,7 @@ func NewStandardExecutorProvider(
 	storageProvider storage.StorageProvider,
 	executorOptions StandardExecutorOptions,
 ) (executor.ExecutorProvider, error) {
-	dockerExecutor, err := docker.NewExecutor(ctx, cm, executorOptions.DockerID, storageProvider)
+	dockerExecutor, err := docker.NewExecutor(ctx, cm, executorOptions.DockerID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/wasm/loader.go
+++ b/pkg/executor/wasm/loader.go
@@ -54,9 +54,9 @@ func (loader *ModuleLoader) Load(ctx context.Context, path string) (wazero.Compi
 	return module, nil
 }
 
-// LoadRemoteModules loads and compiles all of the modules located by the passed storage specs.
-func (loader *ModuleLoader) LoadRemoteModules(ctx context.Context, m storage.PreparedStorage) (wazero.CompiledModule, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.ModuleLoader.LoadRemoteModules")
+// loadModule loads and compiles all of the modules located by the passed storage specs.
+func (loader *ModuleLoader) loadModule(ctx context.Context, m storage.PreparedStorage) (wazero.CompiledModule, error) {
+	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.ModuleLoader.loadModule")
 	defer span.End()
 
 	programPath := m.Volume.Source
@@ -114,7 +114,7 @@ func (loader *ModuleLoader) InstantiateRemoteModule(ctx context.Context, m stora
 	}
 
 	// Get the remote module.
-	module, err := loader.LoadRemoteModules(ctx, m)
+	module, err := loader.loadModule(ctx, m)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -38,6 +38,7 @@ type Compute struct {
 	Capacity            capacity.Tracker
 	ExecutionStore      store.ExecutionStore
 	Executors           executor.ExecutorProvider
+	Storages            storage.StorageProvider
 	LogServer           *logstream.LogStreamServer
 	Bidder              compute.Bidder
 	computeCallback     *bprotocol.CallbackProxy
@@ -88,6 +89,7 @@ func NewComputeNode(
 		ID:                     host.ID().String(),
 		Callback:               computeCallback,
 		Store:                  executionStore,
+		Storages:               storages,
 		Executors:              executors,
 		Publishers:             publishers,
 		FailureInjectionConfig: config.FailureInjectionConfig,
@@ -127,7 +129,7 @@ func NewComputeNode(
 				Defaults: config.DefaultJobResourceLimits,
 			}),
 			disk.NewDiskUsageCalculator(disk.DiskUsageCalculatorParams{
-				Executors: executors,
+				Storages: storages,
 			}),
 		},
 	})
@@ -138,8 +140,8 @@ func NewComputeNode(
 			executor_util.NewExecutorSpecificBidStrategy(executors),
 			semantic.FromJobSelectionPolicy(config.JobSelectionPolicy),
 			semantic.NewInputLocalityStrategy(semantic.InputLocalityStrategyParams{
-				Locality:  config.JobSelectionPolicy.Locality,
-				Executors: executors,
+				Locality: config.JobSelectionPolicy.Locality,
+				Storages: storages,
 			}),
 			semantic.NewProviderInstalledStrategy(
 				publishers,
@@ -252,6 +254,7 @@ func NewComputeNode(
 		Capacity:            runningCapacityTracker,
 		ExecutionStore:      executionStore,
 		Executors:           executors,
+		Storages:            storages,
 		Bidder:              bidder,
 		LogServer:           logserver,
 		computeCallback:     computeCallback,

--- a/pkg/storage/parallel_test.go
+++ b/pkg/storage/parallel_test.go
@@ -10,16 +10,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	executor_util "github.com/bacalhau-project/bacalhau/pkg/executor/util"
 	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
 	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/maps"
 )
 
 type ParallelStorageSuite struct {
@@ -71,15 +71,15 @@ func (s *ParallelStorageSuite) TestIPFSCleanup() {
 			CID:           s.cid,
 			Path:          "/inputs/test.txt",
 		},
-	})
+	}...)
 	require.NoError(s.T(), err)
 
 	// Make a list of which files we expect to find written to local disk and check they are
 	// there.
-	files := lo.Map(maps.Values(volumes), func(item storage.StorageVolume, index int) string {
-		return item.Source
-	})
-
+	var files []string
+	for _, v := range volumes {
+		files = append(files, v.Volume.Source)
+	}
 	// IPFS cleanup doesn't actually return an error as it deletes a folder
 	_ = storage.ParallelCleanStorage(s.ctx, s.provider, volumes)
 
@@ -106,14 +106,15 @@ func (s *ParallelStorageSuite) TestURLCleanup() {
 			URL:           fmt.Sprintf("%s/test.txt", ts.URL),
 			Path:          "/inputs/test.txt",
 		},
-	})
+	}...)
 	require.NoError(s.T(), err)
 
 	// Make a list of which files we expect to find written to local disk and check they are
 	// there.
-	files := lo.Map(maps.Values(volumes), func(item storage.StorageVolume, index int) string {
-		return item.Source
-	})
+	var files []string
+	for _, v := range volumes {
+		files = append(files, v.Volume.Source)
+	}
 
 	// URL cleanup doesn't actually return an error as it deletes a folder
 	_ = storage.ParallelCleanStorage(s.ctx, s.provider, volumes)

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/docker"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/noop"
@@ -14,7 +16,6 @@ import (
 	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/test/scenario"
-	"github.com/stretchr/testify/suite"
 )
 
 type DevstackErrorLogsSuite struct {
@@ -48,7 +49,7 @@ var errorLogsTestCase = scenario.Scenario{
 	Stack: &scenario.StackConfig{
 		ExecutorConfig: noop.ExecutorConfig{
 			ExternalHooks: noop.ExecutorConfigExternalHooks{
-				JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
+				JobHandler: func(ctx context.Context, _ string, resultsDir string) (*model.RunCommandResult, error) {
 					return executor.WriteJobResults(resultsDir, strings.NewReader("apples"), strings.NewReader("oranges"), 19, nil)
 				},
 			},

--- a/pkg/test/devstack/target_all_test.go
+++ b/pkg/test/devstack/target_all_test.go
@@ -8,13 +8,14 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/noop"
 	"github.com/bacalhau-project/bacalhau/pkg/job"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/test/scenario"
-	"github.com/stretchr/testify/suite"
 )
 
 type TargetAllSuite struct {
@@ -81,7 +82,7 @@ func (suite *TargetAllSuite) TestCanRetryOnNodes() {
 			DevStackOptions: &devstack.DevStackOptions{NumberOfHybridNodes: 0, NumberOfRequesterOnlyNodes: 1, NumberOfComputeOnlyNodes: 2},
 			ExecutorConfig: noop.ExecutorConfig{
 				ExternalHooks: noop.ExecutorConfigExternalHooks{
-					JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
+					JobHandler: func(ctx context.Context, _ string, resultsDir string) (*model.RunCommandResult, error) {
 						if !hasFailed.Swap(true) {
 							return executor.FailResult(fmt.Errorf("oh no"))
 						} else {

--- a/pkg/test/devstack/timeout_test.go
+++ b/pkg/test/devstack/timeout_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/noop"
@@ -18,7 +20,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/requester/retry"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/test/scenario"
-	"github.com/stretchr/testify/suite"
 )
 
 type DevstackTimeoutSuite struct {
@@ -65,7 +66,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 				}),
 				ExecutorConfig: noop.ExecutorConfig{
 					ExternalHooks: noop.ExecutorConfigExternalHooks{
-						JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
+						JobHandler: func(ctx context.Context, _ string, resultsDir string) (*model.RunCommandResult, error) {
 							time.Sleep(testCase.sleepTime)
 							return executor.WriteJobResults(resultsDir, strings.NewReader(""), strings.NewReader(""), 0, nil)
 						},

--- a/pkg/test/scenario/example_noop_test.go
+++ b/pkg/test/scenario/example_noop_test.go
@@ -5,17 +5,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/executor/noop"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
-	"github.com/stretchr/testify/suite"
 )
 
 var noopScenario Scenario = Scenario{
 	Stack: &StackConfig{
 		ExecutorConfig: noop.ExecutorConfig{
 			ExternalHooks: noop.ExecutorConfigExternalHooks{
-				JobHandler: func(ctx context.Context, job model.Job, resultsDir string) (*model.RunCommandResult, error) {
+				JobHandler: func(ctx context.Context, jobID string, resultsDir string) (*model.RunCommandResult, error) {
 					return executor.WriteJobResults(resultsDir, strings.NewReader("hello, world!\n"), nil, 0, nil)
 				},
 			},

--- a/pkg/test/scenario/storage.go
+++ b/pkg/test/scenario/storage.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
-	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/rs/zerolog/log"
 	"github.com/vincent-petithory/dataurl"
+
+	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
 )
 
 // A SetupStorage is a function that return a model.StorageSpec representing
@@ -56,6 +57,7 @@ func StoredFile(
 		}
 		inputStorageSpecs := []model.StorageSpec{
 			{
+				Name:          fileCid,
 				StorageSource: driverName,
 				CID:           fileCid,
 				Path:          mountPath,


### PR DESCRIPTION
### What
The goal of this PR is to simplify the implementation #2637 by removing the requirement of configuring storage providers for executors. It includes several refactors to the bid strategies, executors interface, and corresponding implementation.
- Executors no longer contain storage providers. Instead the compute node responsible for orchestrating executors maintains the set of available storage providers. The compute node makes storage available to executors as local volumes. 
- ParallelPrepareStorage now returns a slice of prepared storage (instead of a map). This allows the returned `PreparedStorage` type to be serialized and passes across RPC boundaries.
- `NewModuleLoader` will not fetch remote wasm modules, and instead operates over a slice of `PreparedStorage`.
  - This change was required to remove the Storage Provider type from the wasm executor which previously fetched remote content from `Job.Input` during execution.
- Modifies the `Executor` interface by removing methods related to providing storage and reducing the complexity of parameters passes to the `Run` method.