### PR TITLE
Fix all outstanding/broken lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,7 @@ linters-settings:
     locale: US
     ignore-words:
     - favour
+    - cancelled
   nolintlint:
     allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: true # report any unused nolint directives
@@ -164,4 +165,3 @@ issues:
   exclude:
   # Naming of `error` variables as `err` is standard practise for Go
   - 'shadow: declaration of "err" shadows declaration at'
-  - '`cancelled` is a misspelling of `canceled`'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,9 +2,9 @@ linters-settings:
   depguard:
     list-type: denylist
     packages:
-      - github.com/sirupsen/logrus
+    - github.com/sirupsen/logrus
     packages-with-error-message:
-      - github.com/sirupsen/logrus: "logging is allowed only by zerolog"
+    - github.com/sirupsen/logrus: "logging is allowed only by zerolog"
   dupl:
     threshold: 100
   funlen:
@@ -15,19 +15,19 @@ linters-settings:
     min-occurrences: 3
   gocritic:
     enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
+    - diagnostic
+    - experimental
+    - opinionated
+    - performance
+    - style
     disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-      - hugeParam
-      - importShadow
+    - dupImport # https://github.com/go-critic/go-critic/issues/845
+    - ifElseChain
+    - octalLiteral
+    - whyNoLint
+    - wrapperFunc
+    - hugeParam
+    - importShadow
   gocyclo:
     min-complexity: 18
   goimports:
@@ -35,17 +35,17 @@ linters-settings:
   gomnd:
     # don't include the "operation" and "assign"
     checks:
-      - argument
-      - case
-      - condition
-      - return
+    - argument
+    - case
+    - condition
+    - return
     ignored-numbers:
-      - "0"
-      - "1"
-      - "2"
-      - "3"
+    - "0"
+    - "1"
+    - "2"
+    - "3"
     ignored-functions:
-      - strings.SplitN
+    - strings.SplitN
 
   govet:
     check-shadowing: true
@@ -61,7 +61,7 @@ linters-settings:
   misspell:
     locale: US
     ignore-words:
-      - favour
+    - favour
   nolintlint:
     allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: true # report any unused nolint directives
@@ -72,36 +72,36 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - bodyclose
-    - unused
-    - depguard
-    - dogsled
-    - errcheck
-    - exportloopref
-    - funlen
-    - gochecknoinits
-    - goconst
-    # - gocritic
-    - gocyclo
-    - gofmt
-    - goimports
-    - gomnd
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - lll
-    - misspell
-    - nakedret
-    - noctx
-    - nolintlint
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unconvert
-    - unused
-    - whitespace
+  - bodyclose
+  - unused
+  - depguard
+  - dogsled
+  - errcheck
+  - exportloopref
+  - funlen
+  - gochecknoinits
+  - goconst
+  # - gocritic
+  - gocyclo
+  - gofmt
+  - goimports
+  - gomnd
+  - goprintffuncname
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - lll
+  - misspell
+  - nakedret
+  - noctx
+  - nolintlint
+  - staticcheck
+  - stylecheck
+  - typecheck
+  - unconvert
+  - unused
+  - whitespace
 
 # Options for analysis running.
 run:
@@ -126,11 +126,11 @@ run:
   # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
   # "/" will be replaced by current OS file path separator to properly work on Windows.
   skip-dirs:
-    - experimental$
-    - vendor$
-    - viz$
-    - ops$
-    - testdata$
+  - experimental$
+  - vendor$
+  - viz$
+  - ops$
+  - testdata$
   # Enables skipping of directories:
   # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   # Default: true
@@ -162,5 +162,6 @@ run:
 
 issues:
   exclude:
-    # Naming of `error` variables as `err` is standard practise for Go
-    - 'shadow: declaration of "err" shadows declaration at'
+  # Naming of `error` variables as `err` is standard practise for Go
+  - 'shadow: declaration of "err" shadows declaration at'
+  - '`cancelled` is a misspelling of `canceled`'

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/registry"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -465,7 +466,7 @@ func getAuthToken(ctx context.Context, image string, dockerCreds config.DockerCr
 		// pulls for `image` or `user/image` should be okay, anything trying
 		// to pull `repo/user/image` should not.
 		if strings.Count(image, "/") < 2 {
-			authConfig := types.AuthConfig{
+			authConfig := registry.AuthConfig{
 				Username: dockerCreds.Username,
 				Password: dockerCreds.Password,
 			}

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -60,6 +60,7 @@ var (
 	gatewayCapabilities = []string{"NET_ADMIN"}
 )
 
+//nolint:nakedret
 func (e *Executor) setupNetworkForJob(
 	ctx context.Context,
 	job string,

--- a/pkg/job/parser.go
+++ b/pkg/job/parser.go
@@ -14,6 +14,7 @@ import (
 
 const defaultStoragePath = "/inputs"
 
+//nolint:gocyclo
 func ParseStorageString(sourceURI, destinationPath string, options map[string]string) (model.StorageSpec, error) {
 	sourceURI = strings.Trim(sourceURI, " '\"")
 	destinationPath = strings.Trim(destinationPath, " '\"")

--- a/pkg/node/config_defaults.go
+++ b/pkg/node/config_defaults.go
@@ -85,7 +85,7 @@ var DefaultNodeInfoPublishConfig = routing.NodeInfoPublisherIntervalConfig{
 	EagerPublishDuration: 30 * time.Second,
 }
 
-// speed up node announcements for tests
+// TestNodeInfoPublishConfig speeds up node announcements for tests
 var TestNodeInfoPublishConfig = routing.NodeInfoPublisherIntervalConfig{
 	Interval:             30 * time.Second,
 	EagerPublishInterval: 10 * time.Millisecond,

--- a/pkg/orchestrator/planner/compute_forwarder.go
+++ b/pkg/orchestrator/planner/compute_forwarder.go
@@ -15,7 +15,7 @@ type ComputeForwarder struct {
 	id             string
 	computeService compute.Endpoint
 	jobStore       jobstore.Store
-	evalBroker     orchestrator.EvaluationBroker
+	evalBroker     orchestrator.EvaluationBroker //nolint:unused
 }
 
 type ComputeForwarderParams struct {

--- a/pkg/orchestrator/scheduler/batch_job.go
+++ b/pkg/orchestrator/scheduler/batch_job.go
@@ -102,7 +102,7 @@ func (b *BatchJobScheduler) Process(ctx context.Context, evaluation *models.Eval
 	}
 
 	// stop executions if we over-subscribed and exceeded the desired number of executions
-	running, overSubscriptions := b.filterOverSubscribedExecs(running, desiredRemainingCount)
+	_, overSubscriptions := b.filterOverSubscribedExecs(running, desiredRemainingCount)
 	b.markStopped(overSubscriptions, execNotNeeded, plan)
 
 	// mark job as completed

--- a/pkg/orchestrator/scheduler/types.go
+++ b/pkg/orchestrator/scheduler/types.go
@@ -12,6 +12,7 @@ import (
 // that help reconcile state.
 type execSet map[string]*model.ExecutionState
 
+//nolint:unused
 func execSetFromSlice(executions []*model.ExecutionState) execSet {
 	set := execSet{}
 	for _, exec := range executions {
@@ -49,6 +50,8 @@ func (set execSet) has(key string) bool {
 }
 
 // keys returns the keys of the set as a slice
+//
+//nolint:unused
 func (set execSet) keys() []string {
 	keys := make([]string, 0, len(set))
 	for k := range set {

--- a/pkg/orchestrator/selection/ranking/previous_executions.go
+++ b/pkg/orchestrator/selection/ranking/previous_executions.go
@@ -27,7 +27,8 @@ func NewPreviousExecutionsNodeRanker(params PreviousExecutionsNodeRankerParams) 
 // - Rank 30: Node has never executed the job.
 // - Rank 0: Node has already executed the job.
 // - Rank -1: Node has executed the job more than once, has rejected a bid, or produced a invalid result
-func (s *PreviousExecutionsNodeRanker) RankNodes(ctx context.Context, job model.Job, nodes []model.NodeInfo) ([]orchestrator.NodeRank, error) {
+func (s *PreviousExecutionsNodeRanker) RankNodes(ctx context.Context,
+	job model.Job, nodes []model.NodeInfo) ([]orchestrator.NodeRank, error) {
 	ranks := make([]orchestrator.NodeRank, len(nodes))
 	previousExecutors := make(map[string]int)
 	toFilterOut := make(map[string]bool)

--- a/pkg/routing/inmemory/inmemory.go
+++ b/pkg/routing/inmemory/inmemory.go
@@ -56,9 +56,7 @@ func (r *NodeInfoStore) Add(ctx context.Context, nodeInfo model.NodeInfo) error 
 	} else {
 		var engines []model.Engine
 		if nodeInfo.ComputeNodeInfo != nil {
-			for _, engine := range nodeInfo.ComputeNodeInfo.ExecutionEngines {
-				engines = append(engines, engine)
-			}
+			engines = append(engines, nodeInfo.ComputeNodeInfo.ExecutionEngines...)
 		}
 		log.Ctx(ctx).Debug().Msgf("Adding new node %s to in-memory nodeInfo store with engines %v", nodeInfo.PeerInfo.ID, engines)
 	}

--- a/pkg/test/utils/stack.go
+++ b/pkg/test/utils/stack.go
@@ -123,6 +123,7 @@ func SetupTestWithNoopExecutor(
 	require.NoError(t, err)
 
 	// Wait for nodes to have announced their presence.
+	//nolint:gomnd
 	assert.Eventually(t, func() bool {
 		return allNodesDiscovered(t, stack)
 	}, 10*time.Second, 100*time.Millisecond, "failed to discover all nodes")


### PR DESCRIPTION
`make lint` failing on main with quite a few complaints.  This PR fixes those that are obvious, and nolints those that are not.

Also removes the complaint about the spelling of cancelled/canceled by way of the lint config.