### PR TITLE
Promotes EnvironmentVariables into the spec.

### DIFF
--- a/cmd/cli/docker/docker_run.go
+++ b/cmd/cli/docker/docker_run.go
@@ -189,8 +189,13 @@ func CreateJob(ctx context.Context, cmdArgs []string, opts *DockerRunOptions) (*
 		return nil, err
 	}
 
+	env, err := util.ParseArrayAsMap(opts.SpecSettings.EnvVar, "=")
+	if err != nil {
+		return nil, err
+	}
+
 	spec, err := jobutils.MakeDockerSpec(
-		image, opts.WorkingDirectory, opts.Entrypoint, opts.SpecSettings.EnvVar, parameters,
+		image, opts.WorkingDirectory, opts.Entrypoint, parameters,
 		jobutils.WithPublisher(opts.SpecSettings.Publisher.Value()),
 		jobutils.WithResources(
 			opts.ResourceSettings.CPU,
@@ -211,6 +216,7 @@ func CreateJob(ctx context.Context, cmdArgs []string, opts *DockerRunOptions) (*
 			opts.DealSettings.TargetingMode,
 			opts.DealSettings.Concurrency,
 		),
+		jobutils.WithEnvironmentVariables(env),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/util/types.go
+++ b/cmd/util/types.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+const null rune = 0
+
+// ParseArrayAsMap processes a string array where each string looks like "k=v" and
+// converts it into a map of string to string (in this case `m[k] = v`). In the
+// process it makes sure that none of the values are ""
+func ParseArrayAsMap(inputArray []string, fieldSep string) (map[string]string, error) {
+	resultMap := make(map[string]string)
+
+	for _, v := range inputArray {
+		parts := strings.Split(v, fieldSep)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("expected field to be separate by an '=' character: %s", v)
+		}
+
+		key, value := parts[0], parts[1]
+
+		// See wazero.ModuleConfig.WithEnv
+		if value == "" || strings.ContainsRune(value, null) {
+			return nil, fmt.Errorf("invalid environment variable %s=%s", key, value)
+		}
+
+		resultMap[key] = value
+	}
+
+	return resultMap, nil
+}

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -99,11 +99,10 @@ func PrepareRunArguments(
 			return nil
 		})
 		engineArgs = &wasm.Arguments{
-			EntryPoint:           execution.Job.Spec.Wasm.EntryPoint,
-			Parameters:           execution.Job.Spec.Wasm.Parameters,
-			EnvironmentVariables: execution.Job.Spec.Wasm.EnvironmentVariables,
-			EntryModule:          entryModuleVolumes[0],
-			ImportModules:        importModuleVolumes,
+			EntryPoint:    execution.Job.Spec.Wasm.EntryPoint,
+			Parameters:    execution.Job.Spec.Wasm.Parameters,
+			EntryModule:   entryModuleVolumes[0],
+			ImportModules: importModuleVolumes,
 		}
 	}
 	args, err := executor.EncodeArguments(engineArgs)
@@ -111,14 +110,15 @@ func PrepareRunArguments(
 		return nil, err
 	}
 	return &executor.RunCommandRequest{
-		JobID:        execution.Job.ID(),
-		ExecutionID:  execution.ID,
-		Resources:    execution.Job.Spec.Resources,
-		Network:      execution.Job.Spec.Network,
-		Outputs:      execution.Job.Spec.Outputs,
-		Inputs:       inputVolumes,
-		ResultsDir:   resultsDir,
-		EngineParams: args,
+		JobID:                execution.Job.ID(),
+		ExecutionID:          execution.ID,
+		Resources:            execution.Job.Spec.Resources,
+		Network:              execution.Job.Spec.Network,
+		Outputs:              execution.Job.Spec.Outputs,
+		EnvironmentVariables: execution.Job.Spec.EnvironmentVariables,
+		Inputs:               inputVolumes,
+		ResultsDir:           resultsDir,
+		EngineParams:         args,
 	}, nil
 }
 

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -176,7 +176,7 @@ func (e *Executor) Run(
 	containerConfig := &container.Config{
 		Image:      dockerArgs.Image,
 		Tty:        false,
-		Env:        dockerArgs.EnvironmentVariables,
+		Env:        pkgUtil.FlattenMap(request.EnvironmentVariables),
 		Entrypoint: dockerArgs.Entrypoint,
 		Cmd:        dockerArgs.Parameters,
 		Labels:     e.containerLabels(request.ExecutionID, request.JobID),

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -120,14 +120,15 @@ func (s *ExecutorTestSuite) runJobWithContext(ctx context.Context, spec model.Sp
 	return s.executor.Run(
 		ctx,
 		&executor.RunCommandRequest{
-			JobID:        j.ID(),
-			ExecutionID:  name,
-			Resources:    spec.Resources,
-			Network:      spec.Network,
-			Outputs:      spec.Outputs,
-			Inputs:       nil,
-			ResultsDir:   result,
-			EngineParams: args,
+			JobID:                j.ID(),
+			ExecutionID:          name,
+			Resources:            spec.Resources,
+			Network:              spec.Network,
+			Outputs:              spec.Outputs,
+			EnvironmentVariables: spec.EnvironmentVariables,
+			Inputs:               nil,
+			ResultsDir:           result,
+			EngineParams:         args,
 		},
 	)
 }

--- a/pkg/executor/types.go
+++ b/pkg/executor/types.go
@@ -33,14 +33,15 @@ type Executor interface {
 }
 
 type RunCommandRequest struct {
-	JobID        string
-	ExecutionID  string
-	Resources    model.ResourceUsageConfig
-	Network      model.NetworkConfig
-	Outputs      []model.StorageSpec
-	Inputs       []storage.PreparedStorage
-	ResultsDir   string
-	EngineParams *Arguments
+	JobID                string
+	ExecutionID          string
+	Resources            model.ResourceUsageConfig
+	Network              model.NetworkConfig
+	Outputs              []model.StorageSpec
+	Inputs               []storage.PreparedStorage
+	EnvironmentVariables map[string]string
+	ResultsDir           string
+	EngineParams         *Arguments
 }
 
 // ExecutorParams is a stub for pluggable engines

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -127,11 +127,10 @@ func (e *Executor) makeFsFromStorage(
 }
 
 type Arguments struct {
-	EntryPoint           string
-	Parameters           []string
-	EnvironmentVariables map[string]string
-	EntryModule          storage.PreparedStorage
-	ImportModules        []storage.PreparedStorage
+	EntryPoint    string
+	Parameters    []string
+	EntryModule   storage.PreparedStorage
+	ImportModules []storage.PreparedStorage
 }
 
 func DecodeArguments(args *executor.Arguments) (*Arguments, error) {
@@ -211,11 +210,11 @@ func (e *Executor) Run(
 		WithSysWalltime().
 		WithFS(rootFs)
 
-	keys := maps.Keys(engineParams.EnvironmentVariables)
+	keys := maps.Keys(request.EnvironmentVariables)
 	sort.Strings(keys)
 	for _, key := range keys {
 		// Make sure we add the environment variables in a consistent order
-		config = config.WithEnv(key, engineParams.EnvironmentVariables[key])
+		config = config.WithEnv(key, request.EnvironmentVariables[key])
 	}
 
 	// Load and instantiate imported modules

--- a/pkg/job/factory_test.go
+++ b/pkg/job/factory_test.go
@@ -52,7 +52,7 @@ func (suite *JobFactorySuite) TestRun_DockerJobOutputs() {
 		for _, tcids := range testCids {
 			func() {
 				spec, err := MakeSpec(
-					WithDockerEngine("", "", []string{}, []string{}, []string{}),
+					WithDockerEngine("", "", []string{}, []string{}),
 					WithResources("1", "1", "0", "0"),
 					WithOutputs(tcids.outputVolumes...),
 					WithTimeout(300),

--- a/pkg/model/docker_task.go
+++ b/pkg/model/docker_task.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
+	"golang.org/x/exp/maps"
 )
 
 type DockerInputs struct {
@@ -24,10 +25,8 @@ func (docker DockerInputs) UnmarshalInto(with string, spec *Spec) error {
 		WorkingDirectory: docker.Workdir,
 	}
 
-	spec.Docker.EnvironmentVariables = []string{}
-	for key, val := range docker.Env.Values {
-		spec.Docker.EnvironmentVariables = append(spec.Docker.EnvironmentVariables, key, val)
-	}
+	spec.EnvironmentVariables = make(map[string]string)
+	maps.Copy(spec.EnvironmentVariables, docker.Env.Values)
 
 	inputData, err := parseInputs(docker.Mounts)
 	if err != nil {

--- a/pkg/model/docker_task_test.go
+++ b/pkg/model/docker_task_test.go
@@ -22,7 +22,7 @@ func TestUnmarshalDocker(t *testing.T) {
 	require.Equal(t, "ubuntu", spec.Docker.Image)
 	require.Equal(t, []string{"date"}, spec.Docker.Entrypoint)
 	require.Equal(t, "/", spec.Docker.WorkingDirectory)
-	require.Equal(t, []string{"HELLO", "world"}, spec.Docker.EnvironmentVariables)
+	require.Equal(t, map[string]string{"HELLO": "world"}, spec.EnvironmentVariables)
 	require.Equal(t, []StorageSpec{}, spec.Inputs)
 	require.Equal(t, []StorageSpec{
 		{Path: "/outputs", Name: "outputs"},

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -210,6 +210,10 @@ type Spec struct {
 	// for example "write the results to ipfs"
 	Outputs []StorageSpec `json:"Outputs,omitempty"`
 
+	// the environment variables that the compute will have available at
+	// runtime.
+	EnvironmentVariables map[string]string `json:"EnvironmentVariables,omitempty"`
+
 	// Annotations on the job - could be user or machine assigned
 	Annotations []string `json:"Annotations,omitempty"`
 
@@ -254,8 +258,6 @@ type JobSpecDocker struct {
 	Entrypoint []string `json:"Entrypoint,omitempty"`
 	// Parameters holds additional commandline arguments
 	Parameters []string `json:"Parameters,omitempty"`
-	// a map of env to run the container with
-	EnvironmentVariables []string `json:"EnvironmentVariables,omitempty"`
 	// working directory inside the container
 	WorkingDirectory string `json:"WorkingDirectory,omitempty"`
 }
@@ -273,9 +275,6 @@ type JobSpecWasm struct {
 
 	// The arguments supplied to the program (i.e. as ARGV).
 	Parameters []string `json:"Parameters,omitempty"`
-
-	// The variables available in the environment of the running program.
-	EnvironmentVariables map[string]string `json:"EnvironmentVariables,omitempty"`
 
 	// TODO #880: Other WASM modules whose exports will be available as imports
 	// to the EntryModule.

--- a/pkg/model/wasm_task.go
+++ b/pkg/model/wasm_task.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
+	"golang.org/x/exp/maps"
 )
 
 type WasmInputs struct {
@@ -21,10 +22,9 @@ var _ JobType = (*WasmInputs)(nil)
 func (wasm *WasmInputs) UnmarshalInto(with string, spec *Spec) error {
 	spec.Engine = EngineWasm
 	spec.Wasm = JobSpecWasm{
-		EntryPoint:           wasm.Entrypoint,
-		Parameters:           wasm.Parameters,
-		EnvironmentVariables: wasm.Env.Values,
-		ImportModules:        []StorageSpec{},
+		EntryPoint:    wasm.Entrypoint,
+		Parameters:    wasm.Parameters,
+		ImportModules: []StorageSpec{},
 	}
 
 	entryModule, err := parseResource(with)
@@ -37,6 +37,9 @@ func (wasm *WasmInputs) UnmarshalInto(with string, spec *Spec) error {
 		resource := resource
 		spec.Wasm.ImportModules = append(spec.Wasm.ImportModules, parseStorageSource("", &resource))
 	}
+
+	spec.EnvironmentVariables = make(map[string]string)
+	maps.Copy(spec.EnvironmentVariables, wasm.Env.Values)
 
 	inputData, err := parseInputs(wasm.Mounts)
 	if err != nil {

--- a/pkg/model/wasm_task_test.go
+++ b/pkg/model/wasm_task_test.go
@@ -21,7 +21,7 @@ func TestUnmarshalWasm(t *testing.T) {
 	require.Equal(t, EngineWasm, spec.Engine)
 	require.Equal(t, "_start", spec.Wasm.EntryPoint)
 	require.Equal(t, []string{"/inputs/data.tar.gz"}, spec.Wasm.Parameters)
-	require.Equal(t, map[string]string{"HELLO": "world"}, spec.Wasm.EnvironmentVariables)
+	require.Equal(t, map[string]string{"HELLO": "world"}, spec.EnvironmentVariables)
 	require.Equal(t, []StorageSpec{
 		{Path: "/job", StorageSource: StorageSourceIPFS, CID: "bafybeig7mdkzcgpacpozamv7yhhaelztfrnb6ozsupqqh7e5uyqdkijegi"},
 		{Path: "/inputs", StorageSource: StorageSourceURLDownload, URL: "https://www.example.com/data.tar.gz"},

--- a/pkg/test/logstream/stream_address_test.go
+++ b/pkg/test/logstream/stream_address_test.go
@@ -48,14 +48,15 @@ func (s *LogStreamTestSuite) TestStreamAddress() {
 		exec.Run(
 			s.ctx,
 			&executor.RunCommandRequest{
-				JobID:        job.ID(),
-				ExecutionID:  execution.ID,
-				Resources:    job.Spec.Resources,
-				Network:      job.Spec.Network,
-				Outputs:      job.Spec.Outputs,
-				Inputs:       nil,
-				ResultsDir:   "/tmp",
-				EngineParams: args,
+				JobID:                job.ID(),
+				ExecutionID:          execution.ID,
+				Resources:            job.Spec.Resources,
+				Network:              job.Spec.Network,
+				Outputs:              job.Spec.Outputs,
+				EnvironmentVariables: job.Spec.EnvironmentVariables,
+				Inputs:               nil,
+				ResultsDir:           "/tmp",
+				EngineParams:         args,
 			},
 		)
 	}()

--- a/pkg/test/logstream/stream_docker_test.go
+++ b/pkg/test/logstream/stream_docker_test.go
@@ -56,14 +56,15 @@ func (s *LogStreamTestSuite) TestDockerOutputStream() {
 		exec.Run(
 			ctx,
 			&executor.RunCommandRequest{
-				JobID:        job.ID(),
-				ExecutionID:  executionID,
-				Resources:    job.Spec.Resources,
-				Network:      job.Spec.Network,
-				Outputs:      job.Spec.Outputs,
-				Inputs:       nil,
-				ResultsDir:   "/tmp",
-				EngineParams: args,
+				JobID:                job.ID(),
+				ExecutionID:          executionID,
+				Resources:            job.Spec.Resources,
+				Network:              job.Spec.Network,
+				Outputs:              job.Spec.Outputs,
+				EnvironmentVariables: job.Spec.EnvironmentVariables,
+				Inputs:               nil,
+				ResultsDir:           "/tmp",
+				EngineParams:         args,
 			},
 		)
 		fail <- true

--- a/pkg/test/scenario/test_scenarios.go
+++ b/pkg/test/scenario/test_scenarios.go
@@ -158,11 +158,11 @@ var WasmExitCode = Scenario{
 	Spec: model.Spec{
 		Engine: model.EngineWasm,
 		Wasm: model.JobSpecWasm{
-			EntryPoint:           "_start",
-			EntryModule:          InlineData(exit_code.Program()),
-			Parameters:           []string{},
-			EnvironmentVariables: map[string]string{"EXIT_CODE": "5"},
+			EntryPoint:  "_start",
+			EntryModule: InlineData(exit_code.Program()),
+			Parameters:  []string{},
 		},
+		EnvironmentVariables: map[string]string{"EXIT_CODE": "5"},
 	},
 }
 
@@ -177,10 +177,10 @@ var WasmEnvVars = Scenario{
 		Wasm: model.JobSpecWasm{
 			EntryPoint:  "_start",
 			EntryModule: InlineData(env.Program()),
-			EnvironmentVariables: map[string]string{
-				"TEST":    "yes",
-				"AWESOME": "definitely",
-			},
+		},
+		EnvironmentVariables: map[string]string{
+			"TEST":    "yes",
+			"AWESOME": "definitely",
 		},
 	},
 }

--- a/pkg/util/env_var.go
+++ b/pkg/util/env_var.go
@@ -1,6 +1,9 @@
 package util
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 type EnvParserFunc[T any] func(string) (T, error)
 
@@ -23,4 +26,16 @@ func GetEnv(envVar string, deflt string) string {
 	}
 
 	return deflt
+}
+
+// FlattenMap is used for flattening an env var map
+// for use with docker runtime
+func FlattenMap(m map[string]string) []string {
+	s := make([]string, 0, len(m))
+
+	for k, v := range m {
+		s = append(s, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return s
 }

--- a/testdata/job.json
+++ b/testdata/job.json
@@ -9,17 +9,16 @@
                 "/bin/bash",
                 "-c",
                 "echo 15"
-            ],
-            "EnvironmentVariables": []
+            ]
         },
+        "EnvironmentVariables": {},
         "Resources": {
             "CPU": "",
             "GPU": "",
             "Memory": "",
             "Disk": ""
         },
-        "Inputs": [
-        ],
+        "Inputs": [],
         "Outputs": [
             {
                 "StorageSource": "ipfs",

--- a/testdata/job_cancel.json
+++ b/testdata/job_cancel.json
@@ -9,9 +9,9 @@
                 "/bin/bash",
                 "-c",
                 "sleep 1000"
-            ],
-            "EnvironmentVariables": []
+            ]
         },
+        "EnvironmentVariables": {},
         "Resources": {
             "CPU": "",
             "GPU": "",


### PR DESCRIPTION
Currently the environment variables are held (differently) within the engine specs, but they're really a property of the environment where the executor will be run - and so it feels like it might make more sense for them to be part of the JobSpec. They're also held there as a map[string]string rather than []string.