### PR TITLE
Allow maximum job execution time to be configured

### DIFF
--- a/cmd/cli/serve/serve_test.go
+++ b/cmd/cli/serve/serve_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 )
 
-const maxServeTime = 5 * time.Second
+const maxServeTime = 15 * time.Second
 const maxTestTime = 10 * time.Second
 const RETURN_ERROR_FLAG = "RETURN_ERROR"
 

--- a/cmd/cli/serve/timeout_test.go
+++ b/cmd/cli/serve/timeout_test.go
@@ -1,0 +1,74 @@
+//go:build unit || !integration
+
+package serve_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/docker"
+	"github.com/bacalhau-project/bacalhau/pkg/job"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/requester/publicapi"
+)
+
+var (
+	noTimeout          = model.NoJobTimeout
+	nonZeroTimeout     = 30 * time.Second
+	halfNonZeroTimeout = nonZeroTimeout / 2
+)
+
+func (s *ServeSuite) TestNoTimeoutSetOrApplied() {
+	docker.MustHaveDocker(s.T())
+
+	cases := []struct {
+		configuredMax    *time.Duration
+		timeoutSpecified *time.Duration
+		timeoutApplied   time.Duration
+		stateExpected    model.JobStateType
+	}{
+		{configuredMax: nil, timeoutSpecified: nil, timeoutApplied: model.NoJobTimeout, stateExpected: model.JobStateCompleted},
+		{configuredMax: nil, timeoutSpecified: &nonZeroTimeout, timeoutApplied: nonZeroTimeout, stateExpected: model.JobStateCompleted},
+		{configuredMax: &nonZeroTimeout, timeoutSpecified: nil, timeoutApplied: nonZeroTimeout, stateExpected: model.JobStateCompleted},
+		{configuredMax: &nonZeroTimeout, timeoutSpecified: &halfNonZeroTimeout, timeoutApplied: halfNonZeroTimeout, stateExpected: model.JobStateCompleted},
+		{configuredMax: &nonZeroTimeout, timeoutSpecified: &noTimeout, timeoutApplied: noTimeout, stateExpected: model.JobStateError},
+	}
+
+	for _, tc := range cases {
+		name := fmt.Sprintf(
+			"job in %s has timeout %s after configuring %s and specifying %s",
+			tc.stateExpected,
+			tc.timeoutApplied,
+			tc.configuredMax,
+			tc.timeoutSpecified,
+		)
+
+		s.Run(name, func() {
+			args := []string{}
+			if tc.configuredMax != nil {
+				args = append(args, "--max-timeout", tc.configuredMax.String())
+			}
+
+			port, err := s.serve(args...)
+			s.Require().NoError(err)
+
+			client := publicapi.NewRequesterAPIClient("localhost", port)
+			s.Require().NoError(publicapi.WaitForHealthy(s.ctx, client))
+
+			testJob := model.NewJob()
+			specOpts := []job.SpecOpt{}
+			if tc.timeoutSpecified != nil {
+				specOpts = append(specOpts, job.WithTimeout(int64(tc.timeoutSpecified.Seconds())))
+			}
+			testJob.Spec, err = job.MakeSpec(specOpts...)
+			s.Require().NoError(err)
+
+			returnedJob, err := client.Submit(s.ctx, testJob)
+			s.Require().NoError(err)
+
+			jobState, err := client.GetJobState(s.ctx, returnedJob.ID())
+			s.Require().NoError(err)
+			s.Require().Equal(jobState.State, model.JobStateError)
+		})
+	}
+}

--- a/cmd/util/flags/spec.go
+++ b/cmd/util/flags/spec.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util/opts"
-	jobutils "github.com/bacalhau-project/bacalhau/pkg/job"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 )
 
@@ -27,7 +26,7 @@ func NewSpecFlagDefaultSettings() *SpecFlagSettings {
 		Inputs:        opts.StorageOpt{},
 		OutputVolumes: []string{"outputs:/outputs"},
 		EnvVar:        []string{},
-		Timeout:       jobutils.DefaultTimeout.Seconds(),
+		Timeout:       int64(model.DefaultJobTimeout.Seconds()),
 		Labels:        []string{},
 		Selector:      "",
 		DoNotTrack:    false,
@@ -39,7 +38,7 @@ type SpecFlagSettings struct {
 	Inputs        opts.StorageOpt   // Array of inputs
 	OutputVolumes []string          // Array of output volumes in 'name:mount point' form
 	EnvVar        []string          // Array of environment variables
-	Timeout       float64           // Job execution timeout in seconds
+	Timeout       int64             // Job execution timeout in seconds
 	Labels        []string          // Labels for the job on the Bacalhau network (for searching)
 	Selector      string            // Selector (label query) to filter nodes on which this job can be executed
 	DoNotTrack    bool
@@ -73,11 +72,11 @@ func SpecFlags(settings *SpecFlagSettings) *pflag.FlagSet {
 		settings.EnvVar,
 		`The environment variables to supply to the job (e.g. --env FOO=bar --env BAR=baz)`,
 	)
-	flags.Float64Var(
+	flags.Int64Var(
 		&settings.Timeout,
 		"timeout",
 		settings.Timeout,
-		`Job execution timeout in seconds (e.g. 300 for 5 minutes and 0.1 for 100ms)`,
+		`Job execution timeout in seconds (e.g. 300 for 5 minutes)`,
 	)
 	flags.StringSliceVarP(
 		&settings.Labels,

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -61,6 +61,7 @@ bacalhau serve \
   --job-selection-accept-networked \
   --job-selection-probe-exec "${BACALHAU_PROBE_EXEC}" \
   --ipfs-connect /ip4/127.0.0.1/tcp/5001 \
+  --max-timeout '60m' \
   --swarm-port "${BACALHAU_PORT}" \
   --api-port 1234 \
   --peer "${CONNECT_PEER}" \

--- a/pkg/bidstrategy/semantic/timeout_strategy_test.go
+++ b/pkg/bidstrategy/semantic/timeout_strategy_test.go
@@ -30,11 +30,11 @@ func TestTimeoutStrategy(t *testing.T) {
 			request: bidstrategy.BidStrategyRequest{
 				Job: model.Job{
 					Metadata: model.Metadata{ClientID: "client"},
-					Spec:     model.Spec{Timeout: 9223372036.1},
+					Spec:     model.Spec{Timeout: int64(model.NoJobTimeout.Seconds()) + 1},
 				},
 			},
 			shouldBid: false,
-			reason:    "job timeout 9223372036.1 exceeds maximum possible value",
+			reason:    "job timeout 9223372037 exceeds maximum possible value 9223372036",
 		},
 		{
 			name: "client-skip-list",

--- a/pkg/compute/executor_buffer.go
+++ b/pkg/compute/executor_buffer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	sync "github.com/bacalhau-project/golang-mutex-tracer"
+	"github.com/rs/zerolog/log"
 )
 
 type bufferTask struct {
@@ -141,13 +142,13 @@ func (s *ExecutorBuffer) doRun(ctx context.Context, task *bufferTask) {
 
 	select {
 	case <-ctx.Done():
-		s.callback.OnComputeFailure(ctx, ComputeError{
+		log.Ctx(ctx).Info().Str("ID", task.execution.ID).Dur("Timeout", timeout).Msg("Execution timed out")
+		s.callback.OnCancelComplete(ctx, CancelResult{
 			ExecutionMetadata: NewExecutionMetadata(task.execution),
 			RoutingMetadata: RoutingMetadata{
 				SourcePeerID: s.ID,
 				TargetPeerID: task.execution.RequesterNodeID,
 			},
-			Err: fmt.Sprintf("execution timed out after %s", timeout),
 		})
 	case <-ch:
 		// no need to check for run errors as they are already handled by the delegate backend.Executor and

--- a/pkg/job/factory.go
+++ b/pkg/job/factory.go
@@ -3,7 +3,6 @@ package job
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
@@ -37,7 +36,7 @@ func WithResources(cpu, memory, disk, gpu string) SpecOpt {
 	}
 }
 
-func WithTimeout(t float64) SpecOpt {
+func WithTimeout(t int64) SpecOpt {
 	return func(s *model.Spec) error {
 		s.Timeout = t
 		return nil
@@ -148,9 +147,6 @@ func MakeWasmSpec(
 	return spec, nil
 }
 
-// TODO(forrest): find a home
-const DefaultTimeout = 30 * time.Minute
-
 func MakeSpec(opts ...SpecOpt) (model.Spec, error) {
 	spec := &model.Spec{
 		Engine:    model.EngineNoop,
@@ -162,7 +158,7 @@ func MakeSpec(opts ...SpecOpt) (model.Spec, error) {
 		Network: model.NetworkConfig{
 			Type: model.NetworkNone,
 		},
-		Timeout: float64(DefaultTimeout),
+		Timeout: int64(model.DefaultJobTimeout.Seconds()),
 		Deal: model.Deal{
 			Concurrency: 1,
 		},

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"math"
+	"time"
+)
+
 const (
 	// DefaultNamespace is the default namespace.
 	DefaultNamespace = "default"
@@ -11,3 +16,13 @@ const (
 	JobTypeOps     = "ops" // TODO: revisit the job naming
 	JobTypeSystem  = "system"
 )
+
+// The user did not specify a timeout or explicitly requested that the job
+// should receive the longest possible timeout. This value will be changed
+// by the node into whatever is configured as max timeout.
+const DefaultJobTimeout time.Duration = time.Duration(0)
+
+// NoJobTimeout specifies that the job should not be subject to timeouts. This
+// value is the largest possible time.Duration that is a whole number of seconds
+// so conversions into an int64 number of seconds and back again are bijective.
+var NoJobTimeout time.Duration = time.Duration(math.MaxInt64).Truncate(time.Second)

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -209,7 +209,7 @@ type Spec struct {
 
 	// How long a job can run in seconds before it is killed.
 	// This includes the time required to run, verify and publish results
-	Timeout float64 `json:"Timeout,omitempty"`
+	Timeout int64 `json:"Timeout,omitempty"`
 
 	// the data volumes we will read in the job
 	// for example "read this ipfs cid"
@@ -234,7 +234,7 @@ type Spec struct {
 
 // Return timeout duration
 func (s *Spec) GetTimeout() time.Duration {
-	return time.Duration(s.Timeout * float64(time.Second))
+	return time.Duration(s.Timeout) * time.Second
 }
 
 // Return pointers to all the storage specs in the spec.

--- a/pkg/model/task.go
+++ b/pkg/model/task.go
@@ -94,7 +94,7 @@ func (task *Task) ToSpec() (*Spec, error) {
 
 			spec.Publisher = config.Publisher
 			spec.Annotations = config.Annotations
-			spec.Timeout = config.Timeout.Seconds()
+			spec.Timeout = int64(config.Timeout.Seconds())
 			spec.Resources = ResourceUsageConfig{
 				CPU:    config.Resources.Cpu.String(),
 				Memory: config.Resources.Memory.String(),

--- a/pkg/model/task_test.go
+++ b/pkg/model/task_test.go
@@ -48,6 +48,6 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "1GB", spec.Resources.Disk)
 	require.Equal(t, "1GB", spec.Resources.Memory)
 	require.Equal(t, "0", spec.Resources.GPU)
-	require.Equal(t, 300.0, spec.Timeout)
+	require.Equal(t, int64(300), spec.Timeout)
 	require.Equal(t, false, spec.DoNotTrack)
 }

--- a/pkg/node/config_defaults.go
+++ b/pkg/node/config_defaults.go
@@ -20,15 +20,15 @@ var DefaultComputeConfig = ComputeConfigParams{
 
 	JobNegotiationTimeout:      3 * time.Minute,
 	MinJobExecutionTimeout:     500 * time.Millisecond,
-	MaxJobExecutionTimeout:     60 * time.Minute,
-	DefaultJobExecutionTimeout: 10 * time.Minute,
+	MaxJobExecutionTimeout:     model.NoJobTimeout,
+	DefaultJobExecutionTimeout: model.NoJobTimeout,
 
 	LogRunningExecutionsInterval: 10 * time.Second,
 }
 
 var DefaultRequesterConfig = RequesterConfigParams{
 	MinJobExecutionTimeout:     0 * time.Second,
-	DefaultJobExecutionTimeout: 30 * time.Minute,
+	DefaultJobExecutionTimeout: model.NoJobTimeout,
 
 	HousekeepingBackgroundTaskInterval: 30 * time.Second,
 	NodeRankRandomnessRange:            5,

--- a/pkg/requester/housekeeping.go
+++ b/pkg/requester/housekeeping.go
@@ -57,7 +57,7 @@ func (h *Housekeeping) housekeepingBackgroundTask() {
 					continue
 				}
 				// cancel jobs that have been in progress beyond the timeout period
-				if now.Sub(jobDescription.State.CreateTime).Seconds() > jobDescription.Job.Spec.Timeout {
+				if now.Sub(jobDescription.State.CreateTime) > jobDescription.Job.Spec.GetTimeout() {
 					log.Ctx(ctx).Info().Msgf("job %s timed out. Canceling", jobDescription.Job.Metadata.ID)
 					go func(jobID string) {
 						_, innerErr := h.endpoint.CancelJob(ctx, CancelJobRequest{

--- a/pkg/requester/jobtransform/default_timeout.go
+++ b/pkg/requester/jobtransform/default_timeout.go
@@ -11,7 +11,7 @@ import (
 func NewTimeoutApplier(minTimeout, defaultTimeout time.Duration) Transformer {
 	return func(ctx context.Context, job *model.Job) (modified bool, err error) {
 		if job.Spec.GetTimeout() <= minTimeout {
-			job.Spec.Timeout = defaultTimeout.Seconds()
+			job.Spec.Timeout = int64(defaultTimeout.Seconds())
 			return true, nil
 		}
 		return

--- a/pkg/test/devstack/timeout_test.go
+++ b/pkg/test/devstack/timeout_test.go
@@ -83,7 +83,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 				PublisherSpec: model.PublisherSpec{
 					Type: model.PublisherIpfs,
 				},
-				Timeout: testCase.jobTimeout.Seconds(),
+				Timeout: int64(testCase.jobTimeout.Seconds()),
 			},
 			Deal: model.Deal{
 				Concurrency: testCase.concurrency,
@@ -91,7 +91,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 			JobCheckers: []job.CheckStatesFunction{
 				job.WaitForExecutionStates(map[model.ExecutionStateType]int{
 					model.ExecutionStateCompleted:         testCase.completedCount,
-					model.ExecutionStateFailed:            testCase.errorCount,
+					model.ExecutionStateCancelled:         testCase.errorCount,
 					model.ExecutionStateAskForBidRejected: testCase.rejectedCount,
 				}),
 			},
@@ -148,7 +148,7 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 			nodeCount:                           1,
 			concurrency:                         1,
 			sleepTime:                           20 * time.Second,
-			jobTimeout:                          1 * time.Millisecond,
+			jobTimeout:                          1 * time.Second,
 			errorCount:                          1,
 		},
 		{


### PR DESCRIPTION
Previously Bacalhau had some hard-coded values for maximum job time. Having a maximum timeout makes sense on a public network where non-paying users should not be able to hog capacity. For private clusters, the behaviour should be configurable – users may wish to run jobs that span many days.

In this commit we provide a new config flag `--max-timeout` respected by `bacalhau serve` that allows these maximum job times to be set by a node operator. It also changes the default when the flag is unused to jobs having no maximum execution time.

The behaviour of the Bacalhau demo network is unchanged.

The timeout value has been changed from a floating point number of seconds to an integer number of seconds. There are no instances of anyone submitting jobs with fractional seconds on the public network, so this is a backwards compatible change.

Resolves #2561.