### PR TITLE
WIP: Delete old/expired jobs from jobstore

### DIFF
--- a/pkg/jobstore/boltdb/bucketpath.go
+++ b/pkg/jobstore/boltdb/bucketpath.go
@@ -1,0 +1,71 @@
+package boltjobstore
+
+import (
+	"fmt"
+	"strings"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+type BucketPath struct {
+	path string
+}
+
+// NewBucketPath creates a bucket path which can be used to describe the
+// nested relationship between buckets, rather than calling b.Bucket() on
+// each b found.  BucketPaths are typically described using strings like
+// "root.bucket.here".
+func NewBucketPath(sections ...string) *BucketPath {
+	return &BucketPath{
+		path: strings.Join(sections, BucketPathDelimiter),
+	}
+}
+
+// Get retrieves the Bucket, or an error, for the bucket found at this path
+func (bp *BucketPath) Get(tx *bolt.Tx, create bool) (*bolt.Bucket, error) {
+	path := strings.Split(bp.path, BucketPathDelimiter)
+
+	type BucketMaker interface {
+		Bucket([]byte) *bolt.Bucket
+		CreateBucketIfNotExists([]byte) (*bolt.Bucket, error)
+	}
+
+	getBucket := func(root BucketMaker, name string) (*bolt.Bucket, error) {
+		bucket := root.Bucket([]byte(name))
+		return bucket, nil
+	}
+	if create {
+		getBucket = func(root BucketMaker, name string) (*bolt.Bucket, error) {
+			bucket, err := root.CreateBucketIfNotExists([]byte(name))
+			if err != nil {
+				return nil, err
+			}
+			return bucket, nil
+		}
+	}
+
+	var bucket *bolt.Bucket
+	var bucketMaker BucketMaker = tx
+
+	for _, name := range path {
+		sub, err := getBucket(bucketMaker, name)
+		if err != nil {
+			return nil, err
+		}
+		if sub == nil {
+			return nil, bolt.ErrBucketNotFound
+		}
+		bucket = sub
+		bucketMaker = sub
+	}
+
+	return bucket, nil
+}
+
+func (bp *BucketPath) Sub(names ...[]byte) *BucketPath {
+	path := bp.path
+	for _, s := range names {
+		path = fmt.Sprintf("%s%s%s", path, BucketPathDelimiter, s)
+	}
+	return NewBucketPath(path)
+}

--- a/pkg/jobstore/boltdb/bucketpath_test.go
+++ b/pkg/jobstore/boltdb/bucketpath_test.go
@@ -1,0 +1,100 @@
+//go:build unit || !integration
+
+package boltjobstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	bolt "go.etcd.io/bbolt"
+)
+
+type BucketPathTestSuite struct {
+	suite.Suite
+	store  *BoltJobStore
+	dbFile string
+	ctx    context.Context
+}
+
+func TestBucketPathTestSuite(t *testing.T) {
+	suite.Run(t, new(BucketPathTestSuite))
+}
+
+func (s *BucketPathTestSuite) SetupTest() {
+	s.ctx = context.Background()
+
+	dir, _ := os.MkdirTemp("", "bacalhau-jobstore-test")
+	s.dbFile = filepath.Join(dir, "testing.db")
+
+	s.store, _ = NewBoltJobStore(s.dbFile)
+}
+
+func (s *BucketPathTestSuite) TearDownTest() {
+	s.store.Close(s.ctx)
+	os.Remove(s.dbFile)
+}
+
+func (s *BucketPathTestSuite) TestGetDatabaseBad() {
+	_, err := GetDatabase("")
+	s.Error(err)
+}
+
+func (s *BucketPathTestSuite) TestBucketCreation() {
+	err := s.store.database.Update(func(tx *bolt.Tx) error {
+		final, err := NewBucketPath("root/bucket/final").Get(tx, true)
+		s.NoError(err)
+		s.NotNil(final)
+
+		root := tx.Bucket([]byte("root"))
+		s.NotNil(root)
+
+		bucket := root.Bucket([]byte("bucket"))
+		s.NotNil(bucket)
+
+		finalAgain := bucket.Bucket([]byte("final"))
+		s.NotNil(finalAgain)
+
+		s.Equal(final.Root(), finalAgain.Root())
+
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *BucketPathTestSuite) TestBucketCreationOne() {
+	err := s.store.database.Update(func(tx *bolt.Tx) error {
+		final, err := NewBucketPath("root").Get(tx, true)
+		s.NoError(err)
+		s.NotNil(final)
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *BucketPathTestSuite) TestBucketCreationNone() {
+	err := s.store.database.Update(func(tx *bolt.Tx) error {
+		_, _ = tx.CreateBucketIfNotExists([]byte("single"))
+
+		final, err := NewBucketPath("single").Get(tx, false)
+		s.NoError(err)
+		s.NotNil(final)
+
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *BucketPathTestSuite) TestBucketCreationError() {
+	err := s.store.database.Update(func(tx *bolt.Tx) error {
+		_ = tx.Bucket([]byte("root"))
+
+		final, err := NewBucketPath("root/missing/bucket").Get(tx, false)
+		s.Error(err)
+		s.Nil(final)
+		return nil
+	})
+	s.NoError(err)
+}

--- a/pkg/jobstore/boltdb/database.go
+++ b/pkg/jobstore/boltdb/database.go
@@ -2,10 +2,12 @@ package boltjobstore
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/model"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -13,6 +15,8 @@ const (
 	DefaultDatabasePermissions   = 0600
 	DefaultBucketSearchSliceSize = 16
 	BucketPathDelimiter          = "/"
+	DefaultJobIDListSize         = 32
+	DeadJobBucket                = "deadjobs"
 )
 
 func GetDatabase(path string) (*bolt.DB, error) {
@@ -52,69 +56,6 @@ func GetBucketData(tx *bolt.Tx, bucketPath *BucketPath, key []byte) []byte {
 	return bkt.Get(key)
 }
 
-type BucketPath struct {
-	path string
-}
-
-// NewBucketPath creates a bucket path which can be used to describe the
-// nested relationship between buckets, rather than calling b.Bucket() on
-// each b found.  BucketPaths are typically described using strings like
-// "root.bucket.here".
-func NewBucketPath(sections ...string) *BucketPath {
-	return &BucketPath{
-		path: strings.Join(sections, BucketPathDelimiter),
-	}
-}
-
-// Get retrieves the Bucket, or an error, for the bucket found at this path
-func (bp *BucketPath) Get(tx *bolt.Tx, create bool) (*bolt.Bucket, error) {
-	path := strings.Split(bp.path, BucketPathDelimiter)
-
-	type BucketMaker interface {
-		Bucket([]byte) *bolt.Bucket
-		CreateBucketIfNotExists([]byte) (*bolt.Bucket, error)
-	}
-
-	getBucket := func(root BucketMaker, name string) (*bolt.Bucket, error) {
-		bucket := root.Bucket([]byte(name))
-		return bucket, nil
-	}
-	if create {
-		getBucket = func(root BucketMaker, name string) (*bolt.Bucket, error) {
-			bucket, err := root.CreateBucketIfNotExists([]byte(name))
-			if err != nil {
-				return nil, err
-			}
-			return bucket, nil
-		}
-	}
-
-	var bucket *bolt.Bucket
-	var bucketMaker BucketMaker = tx
-
-	for _, name := range path {
-		sub, err := getBucket(bucketMaker, name)
-		if err != nil {
-			return nil, err
-		}
-		if sub == nil {
-			return nil, bolt.ErrBucketNotFound
-		}
-		bucket = sub
-		bucketMaker = sub
-	}
-
-	return bucket, nil
-}
-
-func (bp *BucketPath) Sub(names ...[]byte) *BucketPath {
-	path := bp.path
-	for _, s := range names {
-		path = fmt.Sprintf("%s%s%s", path, BucketPathDelimiter, s)
-	}
-	return NewBucketPath(path)
-}
-
 // BucketSequenceString returns the next sequence in the provided
 // bucket, formatted as a 16 character padded string to ensure that
 // bolt's lexicographic ordering will return them in the correct
@@ -125,4 +66,87 @@ func BucketSequenceString(_ *bolt.Tx, bucket *bolt.Bucket) string {
 		return ""
 	}
 	return fmt.Sprintf("%016d", seqNum)
+}
+
+// MarkDeadJobs identifies dead jobs and returns their job id
+//
+// Once a job has reached a terminal state it should have a limited
+// lifetime, after which it should be deleted. Each jobtype will have
+// a different duration, and if not present in the lifetimes map then
+// it will never be deleted.
+func FindDeadJobs(readTx *bolt.Tx, now time.Time, lifetimes map[string]time.Duration) ([]string, error) {
+	jobs, err := NewBucketPath(BucketJobs).Get(readTx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	jobids := make([]string, 0, DefaultJobIDListSize)
+
+	err = jobs.ForEachBucket(func(k []byte) (err error) {
+		jobBkt := jobs.Bucket(k)
+		if jobBkt == nil {
+			return fmt.Errorf("failed to load bucket while iterating")
+		}
+
+		var job model.Job
+		var state model.JobState
+
+		if specBytes := jobBkt.Get(SpecKey); specBytes == nil {
+			return fmt.Errorf("failed to load job while iterating jobs")
+		} else {
+			err = json.Unmarshal(specBytes, &job)
+			if err != nil {
+				return err
+			}
+		}
+
+		lifetime, ok := lifetimes[job.Type()]
+		if !ok {
+			// No duration available for this job type, so we can safely
+			// just move onto the next
+			return nil
+		}
+
+		if stateBytes := jobBkt.Get(StateKey); stateBytes == nil {
+			return fmt.Errorf("failed to load job state while iterating jobs")
+		} else {
+			err = json.Unmarshal(stateBytes, &state)
+			if err != nil {
+				return err
+			}
+		}
+
+		if state.State.IsTerminal() {
+			if now.Unix() > state.UpdateTime.Add(lifetime).Unix() {
+				jobids = append(jobids, state.JobID)
+			}
+		}
+
+		return nil
+	})
+
+	return jobids, err
+}
+
+// DeleteDeadJobs deletes all of the specified jobIDs by deleting the bucket
+// with a name matching each jobid within the jobs bucket
+func DeleteDeadJobs(writeTX *bolt.Tx, jobIDs []string) error {
+	errList := make([]error, 0, len(jobIDs))
+
+	if bkt, err := NewBucketPath(BucketJobs).Get(writeTX, false); err != nil {
+		return err
+	} else {
+		for _, jobID := range jobIDs {
+			e := bkt.DeleteBucket([]byte(jobID))
+			if e != nil {
+				errList = append(errList, e)
+			}
+		}
+	}
+
+	if len(errList) > 0 {
+		return fmt.Errorf("failed to delete the following jobs: %s", errors.Join(errList...))
+	}
+
+	return nil
 }

--- a/pkg/jobstore/boltdb/store.go
+++ b/pkg/jobstore/boltdb/store.go
@@ -555,6 +555,10 @@ func (b *BoltJobStore) getJobHistory(tx *bolt.Tx, jobID string,
 
 // CreateJob creates a new record of a job in the data store
 func (b *BoltJobStore) CreateJob(ctx context.Context, job model.Job) error {
+	if job.ID() == "" {
+		return fmt.Errorf("cannot create a job with no id")
+	}
+
 	return b.database.Update(func(tx *bolt.Tx) (err error) {
 		return b.createJob(tx, job)
 	})

--- a/pkg/jobstore/envelope.go
+++ b/pkg/jobstore/envelope.go
@@ -3,7 +3,7 @@ package jobstore
 import "encoding/json"
 
 // Envelope provides a wrapper around types that can be stored in a jobstore.
-// It takes responsibility for ser/de for the wrapped type, ensuring that
+// It takes responsibility for ser/de for the wrapped type.
 type Envelope[T any] struct {
 	Body      T
 	marshal   MarshalFunc


### PR DESCRIPTION
When jobs enter a terminal state, they should have a limited lifetime after which they are removed from the jobstore. 

This PR implements the necessary logic to clean up those expired jobs when the jobstore is created, as the first step in providing hooks to a general housekeeping task that will be necessary in the requester node (for other cleanup tasks, like managing jobs in invalid states etc).  This PR does not add the housekeeping.

## Blocked by

* [ ] Need to configure the lifetimes per job type. Will add a config struct for jobstore until new configv2 is ready