### PR TITLE
Use priority field for compute node execute buffer

### DIFF
--- a/pkg/compute/executor_buffer.go
+++ b/pkg/compute/executor_buffer.go
@@ -182,8 +182,8 @@ func (s *ExecutorBuffer) deque() {
 	for i := 0; i < max; i++ {
 		task, prio, err := s.queuedTasks.Dequeue()
 		if err != nil {
-			// TODO: Log error
-			continue
+			log.Ctx(ctx).Error().Err(err).Msg("executor_buffer failed to obtain task from queue")
+			break
 		}
 
 		execID := task.localExecutionState.Execution.ID

--- a/pkg/compute/node_info_provider.go
+++ b/pkg/compute/node_info_provider.go
@@ -48,7 +48,7 @@ func (n *NodeInfoProvider) GetComputeInfo(ctx context.Context) models.ComputeNod
 		AvailableCapacity:  n.capacityTracker.GetAvailableCapacity(ctx),
 		MaxJobRequirements: n.maxJobRequirements,
 		RunningExecutions:  len(n.executorBuffer.RunningExecutions()),
-		EnqueuedExecutions: len(n.executorBuffer.EnqueuedExecutions()),
+		EnqueuedExecutions: n.executorBuffer.EnqueuedExecutionsCount(),
 	}
 }
 

--- a/pkg/lib/collections/hashed_priority_queue.go
+++ b/pkg/lib/collections/hashed_priority_queue.go
@@ -1,0 +1,84 @@
+package collections
+
+type HashedPriorityQueue[K comparable, T any] struct {
+	identifiers map[K]struct{}
+	queue       *PriorityQueue[T]
+	indexer     IndexerFunc[K, T]
+}
+
+// IndexerFunc is used to find the key (of type K) from the provided
+// item (T). This will be used for the item lookup in `Contains`
+type IndexerFunc[K comparable, T any] func(item T) K
+
+// NewHashedPriorityQueue creates a new PriorityQueue that allows us to check if specific
+// items (indexed by a key field) are present in the queue. The provided IndexerFunc will
+// be used on Enqueue/Dequeue to keep the index up to date.
+func NewHashedPriorityQueue[K comparable, T any](indexer IndexerFunc[K, T]) *HashedPriorityQueue[K, T] {
+	return &HashedPriorityQueue[K, T]{
+		identifiers: make(map[K]struct{}),
+		queue:       NewPriorityQueue[T](),
+		indexer:     indexer,
+	}
+}
+
+// Contains will return true if the provided identifier (of type K)
+// will be found in this queue, false if it is not present.
+func (q *HashedPriorityQueue[K, T]) Contains(id K) bool {
+	_, ok := q.identifiers[id]
+	return ok
+}
+
+// Enqueue will add the item specified by `data` to the queue with the
+// the priority given by `priority`.
+func (q *HashedPriorityQueue[K, T]) Enqueue(data T, priority int) {
+	k := q.indexer(data)
+
+	q.identifiers[k] = struct{}{}
+	q.queue.Enqueue(data, priority)
+}
+
+// Dequeue returns the next highest priority item, returning both
+// the data Enqueued previously, and the priority with which it was
+// enqueued. An err (ErrEmptyQueue) may be returned if the queue is
+// currently empty.
+func (q *HashedPriorityQueue[K, T]) Dequeue() *QueueItem[T] {
+	item := q.queue.Dequeue()
+	if item == nil {
+		return nil
+	}
+
+	k := q.indexer(item.Value)
+	delete(q.identifiers, k)
+
+	return item
+}
+
+// DequeueWhere allows the caller to iterate through the queue, in priority order, and
+// attempt to match an item using the provided `MatchingFunction`.  This method has a high
+// time cost as dequeued but non-matching items must be held and requeued once the process
+// is complete.  Luckily, we use the same amount of space (bar a few bytes for the
+// extra PriorityQueue) for the dequeued items.
+func (q *HashedPriorityQueue[K, T]) DequeueWhere(matcher MatchingFunction[T]) *QueueItem[T] {
+	item := q.queue.DequeueWhere(matcher)
+	if item == nil {
+		return nil
+	}
+
+	k := q.indexer(item.Value)
+	delete(q.identifiers, k)
+
+	return item
+}
+
+// Len returns the number of items currently in the queue
+func (q *HashedPriorityQueue[K, T]) Len() int {
+	return q.queue.Len()
+}
+
+// IsEmpty returns a boolean denoting whether the queue is
+// currently empty or not.
+func (q *HashedPriorityQueue[K, T]) IsEmpty() bool {
+	return q.queue.Len() == 0
+}
+
+var _ PriorityQueueInterface[struct{}] = (*HashedPriorityQueue[string, struct{}])(nil)

--- a/pkg/lib/collections/hashed_priority_queue_test.go
+++ b/pkg/lib/collections/hashed_priority_queue_test.go
@@ -1,0 +1,37 @@
+//go:build unit || !integration
+
+package collections_test
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/collections"
+	"github.com/stretchr/testify/suite"
+)
+
+type HashedPriorityQueueSuite struct {
+	suite.Suite
+}
+
+func TestHashedPriorityQueueSuite(t *testing.T) {
+	suite.Run(t, new(HashedPriorityQueueSuite))
+}
+
+func (s *HashedPriorityQueueSuite) TestContains() {
+	type TestData struct {
+		id   string
+		data int
+	}
+
+	indexer := func(t TestData) string {
+		return t.id
+	}
+
+	q := collections.NewHashedPriorityQueue[string, TestData](indexer)
+
+	s.Require().False(q.Contains("A"))
+	q.Enqueue(TestData{id: "A", data: 0}, 1)
+	s.Require().True(q.Contains("A"))
+	_ = q.Dequeue()
+	s.Require().False(q.Contains("A"))
+}

--- a/pkg/lib/collections/priority_queue.go
+++ b/pkg/lib/collections/priority_queue.go
@@ -127,21 +127,26 @@ func (pq *PriorityQueue[T]) DequeueWhere(matcher MatchingFunction[T]) (T, error)
 
 	// Re-add the items from newQ back onto the main queue after initializing
 	// the new q so we can dequeue in priority order
-	heap.Init(&newQ.internalQueue)
-	for {
-		x, p, e := newQ.dequeue()
-		if e != nil {
-			break
-		}
-
-		pq.enqueue(x, p)
-	}
+	pq.Merge(newQ)
 
 	if !found {
 		return result, ErrNoMatch
 	}
 
 	return result, nil
+}
+
+func (pq *PriorityQueue[T]) Merge(other *PriorityQueue[T]) {
+	heap.Init(&other.internalQueue)
+
+	for {
+		x, p, e := other.dequeue()
+		if e != nil {
+			break // break when the other queue is empty
+		}
+
+		pq.enqueue(x, p)
+	}
 }
 
 // Len returns the number of items currently in the queue

--- a/pkg/lib/collections/priority_queue.go
+++ b/pkg/lib/collections/priority_queue.go
@@ -1,0 +1,198 @@
+package collections
+
+import (
+	"container/heap"
+	"errors"
+	"sync"
+)
+
+const (
+	InitialQueueCapacity = 64
+)
+
+var (
+	ErrEmptyQueue error = errors.New("queue is empty")
+	ErrNoMatch    error = errors.New("no items matched")
+)
+
+// PriorityQueue contains items of type T, and allows you to enqueue
+// and dequeue items with a specific priority. Items are dequeued in
+// highest priority first order.
+type PriorityQueue[T any] struct {
+	internalQueue queueHeap
+	mu            sync.Mutex
+}
+
+// MatchingFunction can be used when 'iterating' the priority queue to find
+// items with specific properties.
+type MatchingFunction[T any] func(possibleMatch T) bool
+
+// NewPriorityQueue creates a new ptr to a priority queue for type T.
+func NewPriorityQueue[T any]() *PriorityQueue[T] {
+	q := &PriorityQueue[T]{
+		internalQueue: make(queueHeap, 0, InitialQueueCapacity),
+	}
+	heap.Init(&q.internalQueue)
+	return q
+}
+
+// Enqueue will add the item specified by `data` to the queue with the
+// the priority given by `priority`.
+func (pq *PriorityQueue[T]) Enqueue(data T, priority int) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	pq.enqueue(data, priority)
+}
+
+// enqueue is a lock-free version of Enqueue for internal use when a
+// method already has a lock.
+func (pq *PriorityQueue[T]) enqueue(data T, priority int) {
+	heap.Push(
+		&pq.internalQueue,
+		&heapItem{
+			value:    data,
+			priority: priority,
+		},
+	)
+}
+
+// Dequeue returns the next highest priority item, returning both
+// the data Enqueued previously, and the priority with which it was
+// enqueued. An err (ErrEmptyQueue) may be returned if the queue is
+// currently empty.
+func (pq *PriorityQueue[T]) Dequeue() (T, int, error) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	return pq.dequeue()
+}
+
+// dequeue is a lock-free version of Dequeue() for use by internal
+// methods that already have a lock
+func (pq *PriorityQueue[T]) dequeue() (T, int, error) {
+	if pq.IsEmpty() {
+		return *new(T), 0, ErrEmptyQueue
+	}
+
+	internalItem := heap.Pop(&pq.internalQueue)
+	heapItem := internalItem.(*heapItem)
+	item, ok := heapItem.value.(T)
+	if !ok {
+		// Something has gone very, very wrong if the item in the heap
+		// is not a T as our Enqueue method should be the only thing
+		// putting stuff into it.
+		return item, 0, errors.New("priority queue found a bad type in the internal heap")
+	}
+
+	return item, heapItem.priority, nil
+}
+
+// DequeueWhere allows the caller to iterate through the queue, in priority order, and
+// attempt to match an item using the provided `MatchingFunction`.  This method has a high
+// time cost as dequeued but non-matching items must be held and requeued once the process
+// is complete.  Luckily, we use the same amount of space (bar a few bytes for the
+// extra PriorityQueue) for the dequeued items.
+func (pq *PriorityQueue[T]) DequeueWhere(matcher MatchingFunction[T]) (T, error) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	var result T
+	var found bool
+
+	// Create a new Q to hold items that are not matches, this is suboptimal for time
+	// but not really an issue for space as we'll be using the same.
+	newQ := NewPriorityQueue[T]()
+
+	// Keep dequeueing items until one of them matches the function provided.
+	// If any match it will be returned after the other items have been requeued.
+	// If any iteration does not generate a match, the item is requeued in a temporary
+	// queue reading for requeueing on this queue later on.
+	max := pq.internalQueue.Len()
+	for i := 0; i < max; i++ {
+		item, prio, err := pq.dequeue()
+		if err != nil {
+			return *new(T), err
+		}
+
+		if matcher(item) {
+			result = item
+			found = true
+			break
+		}
+
+		// Add to the queue
+		newQ.enqueue(item, prio)
+	}
+
+	// Re-add the items from newQ back onto the main queue after initializing
+	// the new q so we can dequeue in priority order
+	heap.Init(&newQ.internalQueue)
+	for {
+		x, p, e := newQ.dequeue()
+		if e != nil {
+			break
+		}
+
+		pq.enqueue(x, p)
+	}
+
+	if !found {
+		return result, ErrNoMatch
+	}
+
+	return result, nil
+}
+
+// Len returns the number of items currently in the queue
+func (pq *PriorityQueue[T]) Len() int {
+	return pq.internalQueue.Len()
+}
+
+// IsEmpty returns a boolean denoting whether the queue is
+// currently empty or not.
+func (pq *PriorityQueue[T]) IsEmpty() bool {
+	return pq.Len() == 0
+}
+
+// Internal priority queue implementation based on the go docs for
+// `container/heap`. It is internal here to provide a generic and
+// concurrent interface over the top of it.
+type queueHeap []*heapItem
+
+type heapItem struct {
+	value    any
+	priority int
+	index    int // The index for update
+}
+
+func (q *queueHeap) Push(data any) {
+	n := len(*q)
+	item := data.(*heapItem)
+	item.index = n
+	*q = append(*q, item)
+}
+
+// Dequeue returns the highest priority item from the queue
+func (q *queueHeap) Pop() any {
+	old := *q
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*q = old[0 : n-1]
+	return item
+}
+
+func (q queueHeap) Len() int { return len(q) }
+
+func (q queueHeap) Less(i, j int) bool {
+	// Dequeue returns highest priority so uses greater than here.
+	return q[i].priority > q[j].priority
+}
+
+func (q queueHeap) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+	q[i].index = i
+	q[j].index = j
+}

--- a/pkg/lib/collections/priority_queue.go
+++ b/pkg/lib/collections/priority_queue.go
@@ -162,19 +162,6 @@ func (pq *PriorityQueue[T]) DequeueWhere(matcher MatchingFunction[T]) *QueueItem
 	return result
 }
 
-func (pq *PriorityQueue[T]) Merge(other *PriorityQueue[T]) {
-	heap.Init(&other.internalQueue)
-
-	for {
-		qitem := other.dequeue()
-		if qitem == nil {
-			break // break when the other queue is empty
-		}
-
-		pq.enqueue(qitem.Value, qitem.Priority)
-	}
-}
-
 // Len returns the number of items currently in the queue
 func (pq *PriorityQueue[T]) Len() int {
 	return pq.internalQueue.Len()

--- a/pkg/lib/collections/priority_queue_test.go
+++ b/pkg/lib/collections/priority_queue_test.go
@@ -1,0 +1,88 @@
+//go:build unit || !integration
+
+package collections_test
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/collections"
+	"github.com/stretchr/testify/suite"
+)
+
+type PriorityQueueSuite struct {
+	suite.Suite
+}
+
+func TestPriorityQueueSuite(t *testing.T) {
+	suite.Run(t, new(PriorityQueueSuite))
+}
+
+func (s *PriorityQueueSuite) TestSimple() {
+	type testcase struct {
+		v string
+		p int
+	}
+	testcases := []testcase{
+		{"A", 3},
+		{"A", 3},
+		{"B", 2},
+		{"C", 1},
+		{"C", 1},
+	}
+
+	pq := collections.NewPriorityQueue[string]()
+	for _, tc := range testcases {
+		pq.Enqueue(tc.v, tc.p)
+	}
+
+	for _, tc := range testcases {
+		v, p, e := pq.Dequeue()
+		s.Require().NoError(e)
+		s.Require().Equal(tc.v, v)
+		s.Require().Equal(tc.p, p)
+	}
+
+	s.Require().True(pq.IsEmpty())
+}
+
+func (s *PriorityQueueSuite) TestEmpty() {
+	pq := collections.NewPriorityQueue[string]()
+	_, p, e := pq.Dequeue()
+	s.Require().Error(e)
+	s.Require().ErrorIs(e, collections.ErrEmptyQueue)
+	s.Require().Zero(p)
+	s.Require().True(pq.IsEmpty())
+}
+
+func (s *PriorityQueueSuite) TestDequeueWhere() {
+	pq := collections.NewPriorityQueue[string]()
+	pq.Enqueue("A", 4)
+	pq.Enqueue("D", 1)
+	pq.Enqueue("D", 1)
+	pq.Enqueue("D", 1)
+	pq.Enqueue("D", 1)
+	pq.Enqueue("B", 3)
+	pq.Enqueue("C", 2)
+
+	count := pq.Len()
+
+	item, err := pq.DequeueWhere(func(possibleMatch string) bool {
+		return possibleMatch == "B"
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal("B", item)
+	s.Require().Equal(count-1, pq.Len())
+
+}
+
+func (s *PriorityQueueSuite) TestDequeueWhereFail() {
+	pq := collections.NewPriorityQueue[string]()
+	pq.Enqueue("A", 4)
+
+	_, err := pq.DequeueWhere(func(possibleMatch string) bool {
+		return possibleMatch == "Z"
+	})
+
+	s.Require().Error(err)
+}

--- a/pkg/lib/collections/priority_queue_test.go
+++ b/pkg/lib/collections/priority_queue_test.go
@@ -22,20 +22,19 @@ func (s *PriorityQueueSuite) TestSimple() {
 		v string
 		p int
 	}
-	testcases := []testcase{
-		{"A", 3},
-		{"A", 3},
-		{"B", 2},
-		{"C", 1},
-		{"C", 1},
+	inputs := []testcase{
+		{"B", 2}, {"A", 3}, {"C", 1}, {"A", 3}, {"C", 1}, {"B", 2},
+	}
+	expected := []testcase{
+		{"A", 3}, {"A", 3}, {"B", 2}, {"B", 2}, {"C", 1}, {"C", 1},
 	}
 
 	pq := collections.NewPriorityQueue[string]()
-	for _, tc := range testcases {
+	for _, tc := range inputs {
 		pq.Enqueue(tc.v, tc.p)
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range expected {
 		qitem := pq.Dequeue()
 		s.Require().NotNil(qitem)
 		s.Require().Equal(tc.v, qitem.Value)

--- a/pkg/lib/collections/priority_queue_test.go
+++ b/pkg/lib/collections/priority_queue_test.go
@@ -66,12 +66,13 @@ func (s *PriorityQueueSuite) TestDequeueWhere() {
 
 	count := pq.Len()
 
-	item, err := pq.DequeueWhere(func(possibleMatch string) bool {
+	item, prio, err := pq.DequeueWhere(func(possibleMatch string) bool {
 		return possibleMatch == "B"
 	})
 
 	s.Require().NoError(err)
 	s.Require().Equal("B", item)
+	s.Require().Equal(3, prio)
 	s.Require().Equal(count-1, pq.Len())
 
 }
@@ -80,7 +81,7 @@ func (s *PriorityQueueSuite) TestDequeueWhereFail() {
 	pq := collections.NewPriorityQueue[string]()
 	pq.Enqueue("A", 4)
 
-	_, err := pq.DequeueWhere(func(possibleMatch string) bool {
+	_, _, err := pq.DequeueWhere(func(possibleMatch string) bool {
 		return possibleMatch == "Z"
 	})
 

--- a/pkg/lib/collections/priority_queue_test.go
+++ b/pkg/lib/collections/priority_queue_test.go
@@ -36,10 +36,10 @@ func (s *PriorityQueueSuite) TestSimple() {
 	}
 
 	for _, tc := range testcases {
-		v, p, e := pq.Dequeue()
-		s.Require().NoError(e)
-		s.Require().Equal(tc.v, v)
-		s.Require().Equal(tc.p, p)
+		qitem := pq.Dequeue()
+		s.Require().NotNil(qitem)
+		s.Require().Equal(tc.v, qitem.Value)
+		s.Require().Equal(tc.p, qitem.Priority)
 	}
 
 	s.Require().True(pq.IsEmpty())
@@ -47,10 +47,8 @@ func (s *PriorityQueueSuite) TestSimple() {
 
 func (s *PriorityQueueSuite) TestEmpty() {
 	pq := collections.NewPriorityQueue[string]()
-	_, p, e := pq.Dequeue()
-	s.Require().Error(e)
-	s.Require().ErrorIs(e, collections.ErrEmptyQueue)
-	s.Require().Zero(p)
+	qitem := pq.Dequeue()
+	s.Require().Nil(qitem)
 	s.Require().True(pq.IsEmpty())
 }
 
@@ -66,13 +64,13 @@ func (s *PriorityQueueSuite) TestDequeueWhere() {
 
 	count := pq.Len()
 
-	item, prio, err := pq.DequeueWhere(func(possibleMatch string) bool {
+	qitem := pq.DequeueWhere(func(possibleMatch string) bool {
 		return possibleMatch == "B"
 	})
 
-	s.Require().NoError(err)
-	s.Require().Equal("B", item)
-	s.Require().Equal(3, prio)
+	s.Require().NotNil(qitem)
+	s.Require().Equal("B", qitem.Value)
+	s.Require().Equal(3, qitem.Priority)
 	s.Require().Equal(count-1, pq.Len())
 
 }
@@ -81,9 +79,9 @@ func (s *PriorityQueueSuite) TestDequeueWhereFail() {
 	pq := collections.NewPriorityQueue[string]()
 	pq.Enqueue("A", 4)
 
-	_, _, err := pq.DequeueWhere(func(possibleMatch string) bool {
+	qitem := pq.DequeueWhere(func(possibleMatch string) bool {
 		return possibleMatch == "Z"
 	})
 
-	s.Require().Error(err)
+	s.Require().Nil(qitem)
 }


### PR DESCRIPTION
Currently the executor_buffer which maintains the queue for the compute node running tasks where there are available resources to do so. This is currently a FIFO queue where jobs are processed in order, although it is able to skip entries in case a later job has fewer resource requirements which can be satisfied now.  

This PR changes the executor_buffer over to using a priority queue so that jobs are processed in order of priority (currently the job priority field). If dequeued tasks have resource requirements which can't currently be met, they will be requeued once the iteration has completed.
