### PR TITLE
Detect system GPUs using `nvidia-smi` binary

### DIFF
--- a/pkg/compute/capacity/system/provider.go
+++ b/pkg/compute/capacity/system/provider.go
@@ -1,11 +1,14 @@
 package system
 
 import (
+	"bytes"
 	"context"
+	"encoding/csv"
 	"fmt"
+	"io"
 	"os/exec"
 	"runtime"
-	"strings"
+	"strconv"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute/capacity"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
@@ -14,8 +17,14 @@ import (
 	"github.com/ricochet2200/go-disk-usage/du"
 )
 
-// NvidiaCLI is the path to the Nvidia helper binary
-const NvidiaCLI = "nvidia-container-cli"
+type GPU struct {
+	// Self-reported index of the device in the system
+	Index uint64
+	// Model name of the GPU e.g. Tesla T4
+	Name string
+	// Total GPU memory in mebibytes (MiB)
+	Memory uint64
+}
 
 type PhysicalCapacityProvider struct {
 }
@@ -53,45 +62,60 @@ func getFreeDiskSpace(path string) (uint64, error) {
 	return usage.Free(), nil
 }
 
-// numSystemGPUs wraps nvidia-container-cli to get the number of GPUs
 func numSystemGPUs() (uint64, error) {
-	nvidiaPath, err := exec.LookPath(NvidiaCLI)
+	gpus, err := GetSystemGPUs()
+	return uint64(len(gpus)), err
+}
+
+// nvidiaCLI is the path to the Nvidia helper binary
+const nvidiaCLI = "nvidia-smi"
+
+// nvidiaCLIArgs is the args we pass the nvidiaCLI
+var nvidiaCLIArgs = []string{
+	"--query-gpu=index,gpu_name,memory.total",
+	"--format=csv,noheader,nounits",
+}
+
+func GetSystemGPUs() ([]GPU, error) {
+	nvidiaPath, err := exec.LookPath(nvidiaCLI)
 	if err != nil {
-		// If the NVIDIA CLI is not installed, we can't know the number of GPUs, assume zero
-		if (err.(*exec.Error)).Unwrap() == exec.ErrNotFound {
-			return 0, nil
-		}
-		return 0, err
+		// If the NVIDIA CLI is not installed, we can't know the number of GPUs.
+		// It is not an error to assume zero.
+		return []GPU{}, nil
 	}
-	args := []string{
-		"info",
-		"--csv",
-	}
-	cmd := exec.Command(nvidiaPath, args...)
+	cmd := exec.Command(nvidiaPath, nvidiaCLIArgs...)
 	resp, err := cmd.Output()
 	if err != nil {
-		return 0, err
+		return []GPU{}, err
 	}
 
-	// Parse output of nvidia-container-cli command
-	lines := strings.Split(string(resp), "\n")
-	deviceInfoFlag := false
-	numDevices := uint64(0)
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
+	return parseNvidiaCliOutput(bytes.NewReader(resp))
+}
+
+func parseNvidiaCliOutput(resp io.Reader) ([]GPU, error) {
+	reader := csv.NewReader(resp)
+	reader.TrimLeadingSpace = true
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return []GPU{}, err
+	}
+
+	gpus := make([]GPU, len(records))
+	for index, record := range records {
+		gpus[index].Index, err = strconv.ParseUint(record[0], 10, 64)
+		if err != nil {
+			return gpus, err
 		}
-		if strings.HasPrefix(line, "Device Index") {
-			deviceInfoFlag = true
-			continue
-		}
-		if deviceInfoFlag {
-			numDevices += 1
+
+		gpus[index].Name = record[1]
+		gpus[index].Memory, err = strconv.ParseUint(record[2], 10, 64)
+		if err != nil {
+			return gpus, err
 		}
 	}
 
-	fmt.Println(numDevices)
-	return numDevices, nil
+	return gpus, nil
 }
 
 // compile-time check that the provider implements the interface

--- a/pkg/compute/capacity/system/provider_test.go
+++ b/pkg/compute/capacity/system/provider_test.go
@@ -1,0 +1,48 @@
+//go:build unit || !integration
+
+package system
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsingGPUsWithMany(t *testing.T) {
+	output := strings.Join([]string{
+		"0, Tesla T4, 15360",
+		"1, Tesla T1, 12345",
+	}, "\n")
+
+	gpus, err := parseNvidiaCliOutput(strings.NewReader(output))
+	require.NoError(t, err)
+	require.Len(t, gpus, 2)
+	require.Equal(t, uint64(0), gpus[0].Index)
+	require.Equal(t, "Tesla T4", gpus[0].Name)
+	require.Equal(t, uint64(15360), gpus[0].Memory)
+	require.Equal(t, uint64(1), gpus[1].Index)
+	require.Equal(t, "Tesla T1", gpus[1].Name)
+	require.Equal(t, uint64(12345), gpus[1].Memory)
+}
+
+func TestParsingGPUsWithOne(t *testing.T) {
+	output := strings.Join([]string{
+		"0, Tesla T4, 15360",
+	}, "\n")
+
+	gpus, err := parseNvidiaCliOutput(strings.NewReader(output))
+	require.NoError(t, err)
+	require.Len(t, gpus, 1)
+	require.Equal(t, uint64(0), gpus[0].Index)
+	require.Equal(t, "Tesla T4", gpus[0].Name)
+	require.Equal(t, uint64(15360), gpus[0].Memory)
+}
+
+func TestParsingGPUsWithNone(t *testing.T) {
+	output := strings.Join([]string{}, "\n")
+
+	gpus, err := parseNvidiaCliOutput(strings.NewReader(output))
+	require.NoError(t, err)
+	require.Len(t, gpus, 0)
+}


### PR DESCRIPTION
Previously we used to use the `nvidia-container-cli` binary but this is not present within Docker containers that have GPU access, whereas this new binary is. This allows Bacalhau running in a container to still query for system GPUs.