### PR TITLE
Use a temporary folder for the devstack repo

### DIFF
--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/spf13/viper"
 	"k8s.io/kubectl/pkg/util/i18n"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
@@ -144,8 +143,18 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 
 	cm := util.GetCleanupManager(ctx)
 
-	fsRepo, err := repo.NewFS(viper.GetString("repo"))
+	repoPath, _ := os.MkdirTemp("", "")
+	cm.RegisterCallback(func() error {
+		// We need to clean up the repo when the node shuts down, but we can ONLY
+		// do this because we know it is a temporary directory.
+		return os.RemoveAll(repoPath)
+	})
+
+	fsRepo, err := repo.NewFS(repoPath)
 	if err != nil {
+		return err
+	}
+	if err = fsRepo.Init(); err != nil {
 		return err
 	}
 	if err := fsRepo.Open(); err != nil {

--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -143,12 +143,10 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 
 	cm := util.GetCleanupManager(ctx)
 
+	// We need to clean up the repo when the node shuts down, but we can ONLY
+	// do this because we know it is a temporary directory.
 	repoPath, _ := os.MkdirTemp("", "")
-	cm.RegisterCallback(func() error {
-		// We need to clean up the repo when the node shuts down, but we can ONLY
-		// do this because we know it is a temporary directory.
-		return os.RemoveAll(repoPath)
-	})
+	defer os.RemoveAll(repoPath)
 
 	fsRepo, err := repo.NewFS(repoPath)
 	if err != nil {

--- a/pkg/config/configenv/dev.go
+++ b/pkg/config/configenv/dev.go
@@ -88,7 +88,7 @@ var DevelopmentComputeConfig = types.ComputeConfig{
 		},
 	},
 	ExecutionStore: types.StorageConfig{
-		Type: types.InMemory,
+		Type: types.BoltDB,
 		Path: "",
 	},
 	JobTimeouts: types.JobTimeoutConfig{
@@ -123,7 +123,7 @@ var DevelopmentRequesterConfig = types.RequesterConfig{
 		ProbeExec:           "",
 	},
 	JobStore: types.StorageConfig{
-		Type: types.InMemory,
+		Type: types.BoltDB,
 		Path: "",
 	},
 	HousekeepingBackgroundTaskInterval: types.Duration(30 * time.Second),


### PR DESCRIPTION
Whenever we create a devstack, the result is lots of files stored in the repo for each compute and requester node started that never get cleaned up. This PR changes the devstack to use a temporary directory for its repository.  This means we can auto cleanup the entire repository when the devstack is torn down.

TODO:

It would still be useful to force a specific location for the repo but without the burden of a default setting. e.g. if --repo is specified, we should use it, but we don't want the default value at all.