### PR TITLE
flaky: Improve live execution test for Windows

### DIFF
--- a/pkg/compute/store/boltdb/store_test.go
+++ b/pkg/compute/store/boltdb/store_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -187,10 +186,10 @@ func (s *Suite) TestGetMultipleLiveExecutions() {
 	s.Require().NoError(err)
 	s.Require().Equal(3, len(execs))
 
-	ids := lo.Map(execs, func(item store.LocalExecutionState, _ int) string {
-		return item.Execution.ID
-	})
-	s.Require().Equal(ids, []string{"1", "2", "3"})
+	// We want to make sure the executions are returned with increasing update times
+	// that is, oldest first.
+	s.Require().Less(execs[0].UpdateTime, execs[1].UpdateTime)
+	s.Require().Less(execs[1].UpdateTime, execs[2].UpdateTime)
 }
 
 func (s *Suite) TestGetExecutions_DoesntExist() {

--- a/pkg/compute/store/boltdb/store_test.go
+++ b/pkg/compute/store/boltdb/store_test.go
@@ -187,9 +187,10 @@ func (s *Suite) TestGetMultipleLiveExecutions() {
 	s.Require().Equal(3, len(execs))
 
 	// We want to make sure the executions are returned with increasing update times
-	// that is, oldest first.
-	s.Require().Less(execs[0].UpdateTime, execs[1].UpdateTime)
-	s.Require().Less(execs[1].UpdateTime, execs[2].UpdateTime)
+	// that is, oldest first. On windows, the Update times are the same and so we
+	// allow them to compare as <=.
+	s.Require().LessOrEqual(execs[0].UpdateTime, execs[1].UpdateTime)
+	s.Require().LessOrEqual(execs[1].UpdateTime, execs[2].UpdateTime)
 }
 
 func (s *Suite) TestGetExecutions_DoesntExist() {

--- a/pkg/compute/store/inmemory/store_test.go
+++ b/pkg/compute/store/inmemory/store_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -129,10 +128,10 @@ func (s *Suite) TestGetMultipleLiveExecutions() {
 	s.Require().NoError(err)
 	s.Require().Equal(3, len(execs))
 
-	ids := lo.Map(execs, func(item store.LocalExecutionState, _ int) string {
-		return item.Execution.ID
-	})
-	s.Require().Equal(ids, []string{"1", "2", "3"})
+	// We want to make sure the executions are returned with increasing update times
+	// that is, oldest first.
+	s.Require().Less(execs[0].UpdateTime, execs[1].UpdateTime)
+	s.Require().Less(execs[1].UpdateTime, execs[2].UpdateTime)
 }
 
 func (s *Suite) TestFullLiveExecutions() {

--- a/pkg/compute/store/inmemory/store_test.go
+++ b/pkg/compute/store/inmemory/store_test.go
@@ -130,8 +130,8 @@ func (s *Suite) TestGetMultipleLiveExecutions() {
 
 	// We want to make sure the executions are returned with increasing update times
 	// that is, oldest first.
-	s.Require().Less(execs[0].UpdateTime, execs[1].UpdateTime)
-	s.Require().Less(execs[1].UpdateTime, execs[2].UpdateTime)
+	s.Require().LessOrEqual(execs[0].UpdateTime, execs[1].UpdateTime)
+	s.Require().LessOrEqual(execs[1].UpdateTime, execs[2].UpdateTime)
 }
 
 func (s *Suite) TestFullLiveExecutions() {


### PR DESCRIPTION
Previously the test used the IDs of the written records to test the order of the returned values.
Unfortunately we can't assume they the update time for each record is in the order we sent them requests, and so we update the test to check what we're really interested in, which is are the results oldest first.