### PR TITLE
Add option to specify location of devstack config

### DIFF
--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/node"
-	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/setup"
 
 	"github.com/bacalhau-project/bacalhau/cmd/cli/serve"
 	"github.com/bacalhau-project/bacalhau/cmd/util"
@@ -160,7 +160,7 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 		defer os.RemoveAll(repoPath)
 	}
 
-	fsRepo, err := getRepo(repoPath)
+	fsRepo, err := setup.SetupBacalhauRepo(repoPath)
 	if err != nil {
 		return err
 	}
@@ -256,31 +256,4 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 
 	cmd.Println("\nShutting down devstack")
 	return nil
-}
-
-// getRepo will return a config repo that given a directory, will
-// create, init (if necessary) and open the repository before
-// returning it.
-func getRepo(repoPath string) (*repo.FsRepo, error) {
-	fsRepo, err := repo.NewFS(repoPath)
-	if err != nil {
-		return nil, err
-	}
-
-	exists, err := fsRepo.Exists()
-	if err != nil {
-		return nil, err
-	}
-
-	if !exists {
-		if err = fsRepo.Init(); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := fsRepo.Open(); err != nil {
-		return nil, err
-	}
-
-	return fsRepo, nil
 }

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -43,7 +43,8 @@ type DevStackOptions struct {
 	DisabledFeatures           node.FeatureConfig
 	AllowListedLocalPaths      []string // Local paths that are allowed to be mounted into jobs
 	NodeInfoPublisherInterval  routing.NodeInfoPublisherIntervalConfig
-	ExecutorPlugins            bool // when true pluggable executors will be used.
+	ExecutorPlugins            bool   // when true pluggable executors will be used.
+	ConfigurationRepo          string // A custom config repo
 }
 
 func (o *DevStackOptions) Options() []ConfigOption {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -50,20 +50,20 @@ func getBacalhauRepoPath() (string, error) {
 }
 
 // SetupBacalhauRepo ensures that a bacalhau repo and config exist and are initialized.
-func SetupBacalhauRepo(repoDir string) (string, error) {
+func SetupBacalhauRepo(repoDir string) (*repo.FsRepo, error) {
 	if repoDir == "" {
 		var err error
 		repoDir, err = getBacalhauRepoPath()
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
 	fsRepo, err := setupRepo(repoDir)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return fsRepo.Path()
+	return fsRepo, nil
 }
 
 func setupRepo(path string) (*repo.FsRepo, error) {


### PR DESCRIPTION
By default, the devstack config is now stored in a temporary folder, which is removed when the devstack is shut down.

There are cases, however, where it is useful for the devstack config to persist beyond the live of the devstack, allowing for inspection of the values in the repo, or access to the databases.

By specifying `--stack-repo PATH` it is now possible for the devstack to create a config repo in a specific location that is not removed when the devstack closes.