### PR TITLE
Remove using cancel when restarting long-running jobs

### DIFF
--- a/pkg/compute/startup.go
+++ b/pkg/compute/startup.go
@@ -91,15 +91,9 @@ func (s *Startup) failExecution(ctx context.Context, execution store.LocalExecut
 }
 
 func (s *Startup) runExecution(ctx context.Context, execution store.LocalExecutionState) error {
-	// We want to ensure this execution is running.  If we just call .Run, there's a
-	// chance we'll end up with two copies running if the previous version is alive
-	// for whatever reason.  We'll call Cancel here so that we can be sure that it
-	// is not running before we ask for it to be run.
-	// TODO: Find a better way of either:
-	// * Findout out whether the underlying process (e.g. docker) is still running, or
-	// * Have .Run be idempotent for the execution id without relying on the store.
-	_ = s.execBuffer.Cancel(ctx, execution)
-
+	// We want to ensure this 'live' execution is running and rather than go through
+	// multiple steps trying to determine whether the executor or underlying process
+	// is still running, we will just call Run() and expect it to do the correct thing.
 	log.Ctx(ctx).Info().Msgf("Re-running execution %s after restart", execution.Execution.ID)
 	return s.execBuffer.Run(ctx, execution)
 }

--- a/pkg/compute/startup_test.go
+++ b/pkg/compute/startup_test.go
@@ -72,13 +72,12 @@ func (s *StartupTestSuite) TestLongRunning() {
 			NewState:    store.ExecutionStateRunning,
 		})
 		s.Require().NoError(err)
-
 	}
 
 	ctrl := gomock.NewController(s.T())
 	mockExecutor := compute.NewMockExecutor(ctrl)
 
-	mockExecutor.EXPECT().Cancel(any, any).Return(nil).MaxTimes(2)
+	mockExecutor.EXPECT().Cancel(any, any).Return(nil)
 	mockExecutor.EXPECT().Run(any, any).Return(nil)
 
 	execs, err := database.GetLiveExecutions(s.ctx)


### PR DESCRIPTION
When trying to restart a long-running job, we previously attempted to Cancel it, and then call Run.

Once async executors are implemented, we will be able to call just Run() and it will do the correct thing if the underlying process is still running from before the compute node shutdown.
