### PR TITLE
ensure the repo config value is always set to a usable value

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/cmd/cli/agent"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/job"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/node"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/bacalhau-project/bacalhau/cmd/cli/agent"
+	"github.com/bacalhau-project/bacalhau/cmd/cli/job"
+	"github.com/bacalhau-project/bacalhau/cmd/cli/node"
 
 	"github.com/bacalhau-project/bacalhau/cmd/cli/cancel"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/create"
@@ -83,9 +84,10 @@ func NewRootCmd() *cobra.Command {
 			ctx.Value(util.SystemManagerKey).(*system.CleanupManager).Cleanup(ctx)
 		},
 	}
+	// ensure the `repo` key always gets a usable default value.
 	defaultRepo, err := defaultRepo()
 	if err != nil {
-		panic(err)
+		util.Fatal(RootCmd, err, 1)
 	}
 	RootCmd.PersistentFlags().String("repo", defaultRepo, "path to bacalhau repo")
 	if err := viper.BindPFlag("repo", RootCmd.PersistentFlags().Lookup("repo")); err != nil {

--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/multiformats/go-multiaddr"
-	"github.com/spf13/viper"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
@@ -155,7 +154,11 @@ func serve(cmd *cobra.Command) error {
 	cm := util.GetCleanupManager(ctx)
 
 	// load the repo and its config file, reading in the values, flags and env vars will override values in config.
-	fsRepo, err := repo.NewFS(viper.GetString("repo"))
+	repoDir, err := config.Get[string]("repo")
+	if err != nil {
+		return err
+	}
+	fsRepo, err := repo.NewFS(repoDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/multiformats/go-multiaddr"
+	"github.com/spf13/viper"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
@@ -19,7 +20,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/node"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
-	"github.com/bacalhau-project/bacalhau/pkg/setup"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
 
@@ -155,11 +155,7 @@ func serve(cmd *cobra.Command) error {
 	cm := util.GetCleanupManager(ctx)
 
 	// load the repo and its config file, reading in the values, flags and env vars will override values in config.
-	repoPath, err := setup.GetBacalhauRepoPath()
-	if err != nil {
-		return err
-	}
-	fsRepo, err := repo.NewFS(repoPath)
+	fsRepo, err := repo.NewFS(viper.GetString("repo"))
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const defaultBacalhauDir = ".bacalhau"
+
+func defaultRepo() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home dir: %w", err)
+	}
+	return filepath.Join(home, defaultBacalhauDir), nil
+}

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -4,14 +4,82 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/rs/zerolog/log"
 )
 
 const defaultBacalhauDir = ".bacalhau"
 
+// defaultRepo determines an appropriate directory for storing repository data.
+// Priority order:
+// 1. If the environment variable BACALHAU_DIR is set, use it.
+// 2. If the environment variable FIL_WALLET_ADDRESS is set, it tries to use ROOT_DIR.
+// 3. The user's home directory.
+// 4. User-specific configuration directory.
+// 5. User-specific cache directory.
+// 6. System's temporary directory.
+// Each step logs a warning on failure and proceeds to the next.
+// The function returns the chosen directory path or an error if no suitable directory is found.
 func defaultRepo() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user home dir: %w", err)
+	// Check known locations for a valid path; error if none found.
+
+	if _, set := os.LookupEnv("BACALHAU_DIR"); set {
+		repoDir := os.Getenv("BACALHAU_DIR")
+		if repoDir != "" {
+			return repoDir, nil
+		}
 	}
-	return filepath.Join(home, defaultBacalhauDir), nil
+
+	//If FIL_WALLET_ADDRESS is set, assumes that ROOT_DIR is the config dir for Station
+	//and not a generic environment variable set by the user
+	if _, set := os.LookupEnv("FIL_WALLET_ADDRESS"); set {
+		repoDir := os.Getenv("ROOT_DIR")
+		if repoDir != "" {
+			log.Debug().Str("repo", repoDir).Msg("using station ROOT_DIR as bacalhau repo")
+			return repoDir, nil
+		}
+	}
+
+	// UserHomeDir gets the user's home directory.
+	// On Unix/macOS: $HOME, Windows: %USERPROFILE%, Plan 9: $home.
+	userHome, err := os.UserHomeDir()
+	if err == nil {
+		return filepath.Join(userHome, defaultBacalhauDir), nil
+	} else {
+		log.Warn().Err(err).Msg("Failed to find user home dir. Trying user config directory next.")
+	}
+
+	// UserConfigDir provides the root directory for user-specific configuration data.
+	// Unix: $XDG_CONFIG_HOME or $HOME/.config, Darwin: $HOME/Library/Application Support,
+	// Windows: %AppData%, Plan 9: $home/lib.
+	userDir, err := os.UserConfigDir()
+	if err == nil {
+		return filepath.Join(userDir, defaultBacalhauDir), nil
+	} else {
+		log.Warn().Err(err).Msg("Failed to find user config dir. Trying user cache directory next.")
+	}
+
+	// UserCacheDir provides the root directory for user-specific cached data.
+	// Unix: $XDG_CACHE_HOME or $HOME/.cache, Darwin: $HOME/Library/Caches,
+	// Windows: %LocalAppData%, Plan 9: $home/lib/cache.
+	userCache, err := os.UserCacheDir()
+	if err == nil {
+		return filepath.Join(userCache, defaultBacalhauDir), nil
+	} else {
+		log.Warn().Err(err).Msg("Failed to find user cache dir. Defaulting to temp directory.")
+	}
+
+	// TempDir returns the default temp directory.
+	// Unix: $TMPDIR or /tmp, Windows: %TMP%, %TEMP%, %USERPROFILE% or Windows directory, Plan 9: /tmp.
+	tempDir := os.TempDir()
+
+	// Check if the directory exists.
+	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		return "", fmt.Errorf("temp directory (%s) does not exist", tempDir)
+	} else if err != nil {
+		return "", err
+	}
+
+	// else we use the temp dir
+	return tempDir, nil
 }

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -10,19 +10,15 @@ import (
 
 const defaultBacalhauDir = ".bacalhau"
 
-// defaultRepo determines an appropriate directory for storing repository data.
+// defaultRepo determines the appropriate default directory for storing repository data.
+// If a user provides the `--repo` flag the value returned from this function will be overridden.
 // Priority order:
 // 1. If the environment variable BACALHAU_DIR is set, use it.
 // 2. If the environment variable FIL_WALLET_ADDRESS is set, it tries to use ROOT_DIR.
-// 3. The user's home directory.
-// 4. User-specific configuration directory.
-// 5. User-specific cache directory.
-// 6. System's temporary directory.
-// Each step logs a warning on failure and proceeds to the next.
-// The function returns the chosen directory path or an error if no suitable directory is found.
+// 2. User-specific configuration directory.
+// 4. The user's home directory.
+// The function returns the chosen directory path or an error if no suitable directory can be determined.
 func defaultRepo() (string, error) {
-	// Check known locations for a valid path; error if none found.
-
 	if _, set := os.LookupEnv("BACALHAU_DIR"); set {
 		repoDir := os.Getenv("BACALHAU_DIR")
 		if repoDir != "" {
@@ -30,8 +26,8 @@ func defaultRepo() (string, error) {
 		}
 	}
 
-	//If FIL_WALLET_ADDRESS is set, assumes that ROOT_DIR is the config dir for Station
-	//and not a generic environment variable set by the user
+	// If FIL_WALLET_ADDRESS is set, assumes that ROOT_DIR is the config dir for Station
+	// and not a generic environment variable set by the user
 	if _, set := os.LookupEnv("FIL_WALLET_ADDRESS"); set {
 		repoDir := os.Getenv("ROOT_DIR")
 		if repoDir != "" {
@@ -46,7 +42,7 @@ func defaultRepo() (string, error) {
 	if err == nil {
 		return filepath.Join(userHome, defaultBacalhauDir), nil
 	} else {
-		log.Warn().Err(err).Msg("Failed to find user home dir. Trying user config directory next.")
+		log.Debug().Err(err).Msg("Failed to find user home dir. Trying user config directory next.")
 	}
 
 	// UserConfigDir provides the root directory for user-specific configuration data.
@@ -56,30 +52,8 @@ func defaultRepo() (string, error) {
 	if err == nil {
 		return filepath.Join(userDir, defaultBacalhauDir), nil
 	} else {
-		log.Warn().Err(err).Msg("Failed to find user config dir. Trying user cache directory next.")
+		log.Debug().Err(err).Msg("Failed to find user config dir.")
 	}
 
-	// UserCacheDir provides the root directory for user-specific cached data.
-	// Unix: $XDG_CACHE_HOME or $HOME/.cache, Darwin: $HOME/Library/Caches,
-	// Windows: %LocalAppData%, Plan 9: $home/lib/cache.
-	userCache, err := os.UserCacheDir()
-	if err == nil {
-		return filepath.Join(userCache, defaultBacalhauDir), nil
-	} else {
-		log.Warn().Err(err).Msg("Failed to find user cache dir. Defaulting to temp directory.")
-	}
-
-	// TempDir returns the default temp directory.
-	// Unix: $TMPDIR or /tmp, Windows: %TMP%, %TEMP%, %USERPROFILE% or Windows directory, Plan 9: /tmp.
-	tempDir := os.TempDir()
-
-	// Check if the directory exists.
-	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		return "", fmt.Errorf("temp directory (%s) does not exist", tempDir)
-	} else if err != nil {
-		return "", err
-	}
-
-	// else we use the temp dir
-	return tempDir, nil
+	return "", fmt.Errorf("failed to determine default repo path from '$BACALHAU_DIR', '$HOME', or '$XDG_CONFIG_HOME'")
 }

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -7,58 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
 )
 
-func getBacalhauRepoPath() (string, error) {
-	// BACALHAU_DIR has the highest precedence, if its set, we return it
-	repoDir := os.Getenv("BACALHAU_DIR")
-	if repoDir != "" {
-		log.Debug().Str("repo", repoDir).Msg("using BACALHAU_DIR as bacalhau repo")
-		return repoDir, nil
-	}
-	// next precedence is station configuration
-
-	//If FIL_WALLET_ADDRESS is set, assumes that ROOT_DIR is the config dir for Station
-	//and not a generic environment variable set by the user
-	if _, set := os.LookupEnv("FIL_WALLET_ADDRESS"); set {
-		repoDir = os.Getenv("ROOT_DIR")
-		if repoDir != "" {
-			log.Debug().Str("repo", repoDir).Msg("using station ROOT_DIR as bacalhau repo")
-			return repoDir, nil
-		}
-	}
-
-	// next is the repo flag
-
-	if repoDir = viper.GetString("repo"); repoDir != "" {
-		log.Debug().Str("repo", repoDir).Msg("using --repo flag value as bacalhau repo")
-		return repoDir, nil
-	}
-
-	// last is the default, the home directory
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user home dir for bacalhau repo: %w", err)
-	}
-	repoDir = filepath.Join(home, ".bacalhau")
-	log.Info().Str("repo", repoDir).Msg("using $HOME for bacalhau repo")
-	return repoDir, nil
-}
-
 // SetupBacalhauRepo ensures that a bacalhau repo and config exist and are initialized.
 func SetupBacalhauRepo(repoDir string) (*repo.FsRepo, error) {
-	if repoDir == "" {
-		var err error
-		repoDir, err = getBacalhauRepoPath()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	fsRepo, err := setupRepo(repoDir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Modifies the behavior of the `defaultRepo` method which determines an appropriate directory for storing the repository.

Priority order:
1. If the environment variable BACALHAU_DIR is set, use it.
2. If the environment variable FIL_WALLET_ADDRESS is set, it tries to use ROOT_DIR.
3. The user's home directory.
4. User-specific configuration directory.

Each step logs a debug message on failure and proceeds to the next. The function returns the chosen directory path or an error if no suitable directory is found.