### PR TITLE
fix: plurality of ipfs-swarm-addrs in help text

### DIFF
--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -297,7 +297,7 @@ func serve(cmd *cobra.Command) error {
 		cmd.Println()
 		cmd.Println("To connect another node to this private one, run the following command in your shell:")
 		cmd.Printf(
-			"%s serve %s --private-internal-ipfs --peer %s --ipfs-swarm-addr %s\n",
+			"%s serve %s --private-internal-ipfs --peer %s --ipfs-swarm-addrs %s\n",
 			os.Args[0], nodeType, peerAddress, ipfsSwarmAddress,
 		)
 

--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -273,9 +273,6 @@ func serve(cmd *cobra.Command) error {
 	}
 
 	if ipfsConfig.PrivateInternal && libp2pCfg.PeerConnect == DefaultPeerConnect {
-		// other nodes can be just compute nodes
-		// no need to spawn 1+ requester nodes
-		nodeType := "--node-type compute"
 
 		if isComputeNode && !isRequesterNode {
 			cmd.Println("Make sure there's at least one requester node in your network.")
@@ -294,12 +291,28 @@ func serve(cmd *cobra.Command) error {
 		peerAddress := pickP2pAddress(libp2pHost.Addrs()).Encapsulate(p2pAddr).String()
 		ipfsSwarmAddress := pickP2pAddress(ipfsAddresses).String()
 
-		cmd.Println()
-		cmd.Println("To connect another node to this private one, run the following command in your shell:")
-		cmd.Printf(
-			"%s serve %s --private-internal-ipfs --peer %s --ipfs-swarm-addrs %s\n",
-			os.Args[0], nodeType, peerAddress, ipfsSwarmAddress,
-		)
+		sb := strings.Builder{}
+		sb.WriteString("\n")
+		sb.WriteString("To connect another node to this private one, run the following command in your shell:\n")
+
+		sb.WriteString(fmt.Sprintf("%s serve ", os.Args[0]))
+		// other nodes can be just compute nodes
+		// no need to spawn 1+ requester nodes
+		sb.WriteString(fmt.Sprintf("%s=compute ",
+			configflags.FlagNameForKey(types.NodeType, configflags.NodeTypeFlags...)))
+
+		sb.WriteString(fmt.Sprintf("%s ",
+			configflags.FlagNameForKey(types.NodeIPFSPrivateInternal, configflags.IPFSFlags...)))
+
+		sb.WriteString(fmt.Sprintf("%s=%s ",
+			configflags.FlagNameForKey(types.NodeLibp2pPeerConnect, configflags.Libp2pFlags...),
+			peerAddress,
+		))
+		sb.WriteString(fmt.Sprintf("%s=%s ",
+			configflags.FlagNameForKey(types.NodeIPFSSwarmAddresses, configflags.IPFSFlags...),
+			ipfsSwarmAddress,
+		))
+		cmd.Println(sb.String())
 
 		summaryBuilder := strings.Builder{}
 		summaryBuilder.WriteString(fmt.Sprintf(

--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 
+	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
@@ -118,11 +119,17 @@ func getIPFSConfig() (types.IpfsConfig, error) {
 		return types.IpfsConfig{}, err
 	}
 	if ipfsConfig.Connect != "" && ipfsConfig.PrivateInternal {
-		return types.IpfsConfig{}, fmt.Errorf("--private-internal-ipfs cannot be used with --ipfs-connect")
+		return types.IpfsConfig{}, fmt.Errorf("%s cannot be used with %s",
+			configflags.FlagNameForKey(types.NodeIPFSPrivateInternal, configflags.IPFSFlags...),
+			configflags.FlagNameForKey(types.NodeIPFSConnect, configflags.IPFSFlags...),
+		)
 	}
 
 	if ipfsConfig.Connect != "" && len(ipfsConfig.GetSwarmAddresses()) != 0 {
-		return types.IpfsConfig{}, fmt.Errorf("--ipfs-swarm-addrs cannot be used with --ipfs-connect")
+		return types.IpfsConfig{}, fmt.Errorf("%s cannot be used with %s",
+			configflags.FlagNameForKey(types.NodeIPFSSwarmAddresses, configflags.IPFSFlags...),
+			configflags.FlagNameForKey(types.NodeIPFSConnect, configflags.IPFSFlags...),
+		)
 	}
 	return ipfsConfig, nil
 }

--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
@@ -121,7 +122,7 @@ func getIPFSConfig() (types.IpfsConfig, error) {
 	}
 
 	if ipfsConfig.Connect != "" && len(ipfsConfig.GetSwarmAddresses()) != 0 {
-		return types.IpfsConfig{}, fmt.Errorf("--ipfs-swarm-addr cannot be used with --ipfs-connect")
+		return types.IpfsConfig{}, fmt.Errorf("--ipfs-swarm-addrs cannot be used with --ipfs-connect")
 	}
 	return ipfsConfig, nil
 }

--- a/cmd/util/flags/configflags/names.go
+++ b/cmd/util/flags/configflags/names.go
@@ -1,0 +1,28 @@
+package configflags
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+)
+
+// FlagDefForKey accepts a configuration key and slice of Definition's containing the key.
+// It returns the Definition for the specific key or panics if the key is not part of the definition.
+func FlagDefForKey(key string, def ...Definition) Definition {
+	f, found := lo.Find(def, func(item Definition) bool {
+		return item.ConfigPath == key
+	})
+	if !found {
+		// represents a developer error to call this method with invalid key and definition pair.
+		panic(fmt.Sprintf("Key: %s not found in Definition: %+v", key, def))
+	}
+
+	return f
+}
+
+// FlagNameForKey accepts a configuration key and slice of Definition's containing the key.
+// It returns the name of the flag corresponding to the key prefixed with `--`, or panics if the key
+// is not part of the definition.
+func FlagNameForKey(key string, def ...Definition) string {
+	return "--" + FlagDefForKey(key, def...).FlagName
+}


### PR DESCRIPTION
Flag name is now `--ipfs-swarm-addrs` instead of `--ipfs-swarm-addr`. We were displaying the old flag name in the help text after the improvements from #2792 landed 