### PR TITLE
fix: don't panic when constructing a compute config

### DIFF
--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -49,7 +49,7 @@ func GetComputeConfig() (node.ComputeConfig, error) {
 			ProbeExec:           cfg.JobSelection.ProbeExec,
 		},
 		LogRunningExecutionsInterval: time.Duration(cfg.Logging.LogRunningExecutionsInterval),
-	}), nil
+	})
 }
 
 func GetRequesterConfig() (node.RequesterConfig, error) {

--- a/cmd/testing/base.go
+++ b/cmd/testing/base.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
@@ -32,16 +33,16 @@ func (s *BaseSuite) SetupTest() {
 	logger.ConfigureTestLogging(s.T())
 	util.Fatal = util.FakeFatalErrorHandler
 
+	computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+		JobSelectionPolicy: node.JobSelectionPolicy{
+			Locality: semantic.Anywhere,
+		},
+	})
+	s.Require().NoError(err)
 	ctx := context.Background()
 	stack := teststack.Setup(ctx, s.T(),
 		devstack.WithNumberOfHybridNodes(1),
-		devstack.WithComputeConfig(
-			node.NewComputeConfigWith(node.ComputeConfigParams{
-				JobSelectionPolicy: node.JobSelectionPolicy{
-					Locality: semantic.Anywhere,
-				},
-			}),
-		),
+		devstack.WithComputeConfig(computeConfig),
 		devstack.WithRequesterConfig(
 			node.NewRequesterConfigWith(
 				node.RequesterConfigParams{

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -76,7 +76,10 @@ func Setup(
 	fsRepo *repo.FsRepo,
 	opts ...ConfigOption,
 ) (*DevStack, error) {
-	stackConfig := defaultDevStackConfig()
+	stackConfig, err := defaultDevStackConfig()
+	if err != nil {
+		return nil, err
+	}
 	for _, opt := range opts {
 		opt(stackConfig)
 	}

--- a/pkg/devstack/option.go
+++ b/pkg/devstack/option.go
@@ -12,9 +12,13 @@ import (
 
 type ConfigOption = func(cfg *DevStackConfig)
 
-func defaultDevStackConfig() *DevStackConfig {
+func defaultDevStackConfig() (*DevStackConfig, error) {
+	computeConfig, err := node.NewComputeConfigWithDefaults()
+	if err != nil {
+		return nil, err
+	}
 	return &DevStackConfig{
-		ComputeConfig:          node.NewComputeConfigWithDefaults(),
+		ComputeConfig:          computeConfig,
 		RequesterConfig:        node.NewRequesterConfigWithDefaults(),
 		NodeDependencyInjector: node.NodeDependencyInjector{},
 		NodeOverrides:          nil,
@@ -33,7 +37,7 @@ func defaultDevStackConfig() *DevStackConfig {
 		DisabledFeatures:           node.FeatureConfig{},
 		AllowListedLocalPaths:      nil,
 		ExecutorPlugins:            false,
-	}
+	}, nil
 }
 
 type DevStackConfig struct {

--- a/pkg/publicapi/test/util_test.go
+++ b/pkg/publicapi/test/util_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/require"
+
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
 	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
@@ -12,8 +15,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/phayes/freeport"
-	"github.com/stretchr/testify/require"
 )
 
 func setupNodeForTest(t *testing.T) (*node.Node, *client.Client) {
@@ -36,12 +37,14 @@ func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.No
 	libp2pHost, err := libp2p.NewHost(libp2pPort, privKey)
 	require.NoError(t, err)
 
+	computeConfig, err := node.NewComputeConfigWithDefaults()
+	require.NoError(t, err)
 	nodeConfig := node.NodeConfig{
 		CleanupManager:            cm,
 		Host:                      libp2pHost,
 		HostAddress:               "0.0.0.0",
 		APIPort:                   0,
-		ComputeConfig:             node.NewComputeConfigWithDefaults(),
+		ComputeConfig:             computeConfig,
 		RequesterNodeConfig:       node.NewRequesterConfigWithDefaults(),
 		APIServerConfig:           apiCfg,
 		IsRequesterNode:           true,

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -43,11 +43,13 @@ type ComputeSuite struct {
 }
 
 func (s *ComputeSuite) SetupSuite() {
-	s.config = node.NewComputeConfigWith(node.ComputeConfigParams{
+	cfg, err := node.NewComputeConfigWith(node.ComputeConfigParams{
 		TotalResourceLimits: models.Resources{
 			CPU: 2,
 		},
 	})
+	s.Require().NoError(err)
+	s.config = cfg
 }
 
 func (s *ComputeSuite) SetupTest() {

--- a/pkg/test/devstack/jobselection_test.go
+++ b/pkg/test/devstack/jobselection_test.go
@@ -43,12 +43,14 @@ func (suite *DevstackJobSelectionSuite) TestSelectAllJobs() {
 			suite.T().Skip("https://github.com/bacalhau-project/bacalhau/issues/361")
 		}
 
+		computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+			JobSelectionPolicy: testCase.policy,
+		})
+		suite.Require().NoError(err)
 		testScenario := scenario.Scenario{
 			Stack: &scenario.StackConfig{
 				DevStackOptions: &devstack.DevStackOptions{NumberOfHybridNodes: testCase.nodeCount},
-				ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-					JobSelectionPolicy: testCase.policy,
-				}),
+				ComputeConfig:   computeConfig,
 			},
 			Inputs:  scenario.PartialAdd(testCase.addFilesCount, scenario.WasmCsvTransform(suite.T()).Inputs),
 			Outputs: scenario.WasmCsvTransform(suite.T()).Outputs,

--- a/pkg/test/devstack/timeout_test.go
+++ b/pkg/test/devstack/timeout_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -53,15 +54,18 @@ func (suite *DevstackTimeoutSuite) TestRunningTimeout() {
 	}
 
 	runTest := func(testCase TestCase) {
+		computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+			JobNegotiationTimeout:                 testCase.computeJobNegotiationTimeout,
+			MinJobExecutionTimeout:                testCase.computeMinJobExecutionTimeout,
+			MaxJobExecutionTimeout:                testCase.computeMaxJobExecutionTimeout,
+			JobExecutionTimeoutClientIDBypassList: testCase.computeJobExecutionBypassList,
+		})
+		suite.Require().NoError(err)
+
 		testScenario := scenario.Scenario{
 			Stack: &scenario.StackConfig{
 				DevStackOptions: &devstack.DevStackOptions{NumberOfHybridNodes: testCase.nodeCount},
-				ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-					JobNegotiationTimeout:                 testCase.computeJobNegotiationTimeout,
-					MinJobExecutionTimeout:                testCase.computeMinJobExecutionTimeout,
-					MaxJobExecutionTimeout:                testCase.computeMaxJobExecutionTimeout,
-					JobExecutionTimeoutClientIDBypassList: testCase.computeJobExecutionBypassList,
-				}),
+				ComputeConfig:   computeConfig,
 				RequesterConfig: node.NewRequesterConfigWith(node.RequesterConfigParams{
 					JobDefaults: transformer.JobDefaults{
 						ExecutionTimeout: testCase.requesterDefaultJobExecutionTimeout,

--- a/pkg/test/devstack/url_test.go
+++ b/pkg/test/devstack/url_test.go
@@ -49,13 +49,15 @@ func runURLTest(
 
 	allContent := testCase.files[fmt.Sprintf("/%s", testCase.file1)] + testCase.files[fmt.Sprintf("/%s", testCase.file2)]
 
+	computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+		JobSelectionPolicy: node.JobSelectionPolicy{
+			Locality: semantic.Anywhere,
+		},
+	})
+	suite.Require().NoError(err)
 	testScenario := scenario.Scenario{
 		Stack: &scenario.StackConfig{
-			ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-				JobSelectionPolicy: node.JobSelectionPolicy{
-					Locality: semantic.Anywhere,
-				},
-			}),
+			ComputeConfig: computeConfig,
 		},
 		Inputs: scenario.ManyStores(
 			scenario.URLDownload(svr, testCase.file1, testCase.mount1),
@@ -218,13 +220,15 @@ func (s *URLTestSuite) TestIPFSURLCombo() {
 	}))
 	defer svr.Close()
 
+	computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+		JobSelectionPolicy: node.JobSelectionPolicy{
+			Locality: semantic.Anywhere,
+		},
+	})
+	s.Require().NoError(err)
 	testScenario := scenario.Scenario{
 		Stack: &scenario.StackConfig{
-			ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-				JobSelectionPolicy: node.JobSelectionPolicy{
-					Locality: semantic.Anywhere,
-				},
-			}),
+			ComputeConfig: computeConfig,
 		},
 		Inputs: scenario.ManyStores(
 			scenario.StoredText(IPFSContent, path.Join(ipfsmount, ipfsfile)),

--- a/pkg/test/requester/retries_test.go
+++ b/pkg/test/requester/retries_test.go
@@ -48,6 +48,11 @@ func (s *RetriesSuite) SetupSuite() {
 	logger.ConfigureTestLogging(s.T())
 	setup.SetupBacalhauRepoForTesting(s.T())
 
+	computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+		BidSemanticStrategy: bidstrategy.NewFixedBidStrategy(false, false),
+		BidResourceStrategy: bidstrategy.NewFixedBidStrategy(false, false),
+	})
+	s.Require().NoError(err)
 	nodeOverrides := []node.NodeConfig{
 		{
 			Labels: map[string]string{
@@ -59,10 +64,7 @@ func (s *RetriesSuite) SetupSuite() {
 			Labels: map[string]string{
 				"name": "bid-rejector",
 			},
-			ComputeConfig: node.NewComputeConfigWith(node.ComputeConfigParams{
-				BidSemanticStrategy: bidstrategy.NewFixedBidStrategy(false, false),
-				BidResourceStrategy: bidstrategy.NewFixedBidStrategy(false, false),
-			}),
+			ComputeConfig: computeConfig,
 		},
 		{
 			Labels: map[string]string{

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -90,7 +90,11 @@ func (s *ScenarioRunner) setupStack(config *StackConfig) (*devstack.DevStack, *s
 	}
 
 	if config.ComputeConfig.TotalResourceLimits.IsZero() {
-		config.ComputeConfig = node.NewComputeConfigWithDefaults()
+		// TODO(forrest): [correctness] if the provided compute config has one `0` field we override the whole thing.
+		// we probably want to merge these instead.
+		cfg, err := node.NewComputeConfigWithDefaults()
+		s.Require().NoError(err)
+		config.ComputeConfig = cfg
 	}
 	stack := testutils.Setup(s.Ctx, s.T(),
 		append(config.DevStackOptions.Options(),


### PR DESCRIPTION
return an error instead of panicking if creating a compute config fails. Use multierror for config validation.
Added a TODO here, we probably don't need to fix this now, but worth looking into in a follow on. https://github.com/bacalhau-project/bacalhau/blob/e168bf54fea6f05cf41041c84d56954fd868ffc0/pkg/test/scenario/suite.go#L93

closes: https://expanso.atlassian.net/browse/GDAY-90