### PR TITLE
fix: Pass existing repo to print devstack node info

### DIFF
--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -226,7 +226,7 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 		return err
 	}
 
-	nodeInfoOutput, err := stack.PrintNodeInfo(ctx, cm)
+	nodeInfoOutput, err := stack.PrintNodeInfo(ctx, fsRepo, cm)
 	if err != nil {
 		return fmt.Errorf("failed to print node info: %w", err)
 	}

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -11,7 +11,6 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/phayes/freeport"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
@@ -298,15 +297,7 @@ func createIPFSNode(ctx context.Context,
 }
 
 //nolint:funlen
-func (stack *DevStack) PrintNodeInfo(ctx context.Context, cm *system.CleanupManager) (string, error) {
-	fsRepo, err := repo.NewFS(viper.GetString("repo"))
-	if err != nil {
-		return "", err
-	}
-	if err := fsRepo.Open(); err != nil {
-		return "", err
-	}
-
+func (stack *DevStack) PrintNodeInfo(ctx context.Context, fsRepo *repo.FsRepo, cm *system.CleanupManager) (string, error) {
 	if !config.DevstackGetShouldPrintInfo() {
 		return "", nil
 	}


### PR DESCRIPTION
Currently print node info (called only from devstack) tries to re-open the fsrepo, but fails to do so, and this results in us not being able to run the devstack.

It is however already opened and initialised in the calling function and so now we pass it in to the method instead.
