### PR TITLE
Fix CLI specification of wasm environment vars

### DIFF
--- a/cmd/cli/wasm/wasm_run.go
+++ b/cmd/cli/wasm/wasm_run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models/migration/legacy"
 	"github.com/ipfs/go-cid"
@@ -234,16 +235,18 @@ func CreateJob(ctx context.Context, cmdArgs []string, opts *WasmRunOptions) (*mo
 	}, nil
 }
 
+// parseArrayAsMap accepts a string array where each entry is A=B and
+// returns a map with {A: B}
 func parseArrayAsMap(inputArray []string) (map[string]string, error) {
-	if len(inputArray)%2 != 0 {
-		return nil, fmt.Errorf("array must have an even number of elements")
-	}
-
 	resultMap := make(map[string]string)
-	for i := 0; i < len(inputArray); i += 2 {
-		key := inputArray[i]
-		value := inputArray[i+1]
-		resultMap[key] = value
+
+	for _, v := range inputArray {
+		parts := strings.Split(v, "=")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed entry, expected = in: %s", v)
+		}
+
+		resultMap[parts[0]] = parts[1]
 	}
 
 	return resultMap, nil

--- a/cmd/cli/wasm/wasm_run_test.go
+++ b/cmd/cli/wasm/wasm_run_test.go
@@ -34,3 +34,16 @@ func (s *WasmRunSuite) Test_SupportsRelativeDirectory() {
 
 	_ = testutils.GetJobFromTestOutputLegacy(ctx, s.T(), s.Client, out)
 }
+
+func (s *WasmRunSuite) TestSpecifyingEnvVars() {
+	ctx := context.Background()
+	_, out, err := cmdtesting.ExecuteTestCobraCommand("wasm", "run",
+		"--api-host", s.Host,
+		"--api-port", fmt.Sprint(s.Port),
+		"../../../testdata/wasm/env/main.wasm",
+		"-e A=B,C=D",
+	)
+	s.Require().NoError(err)
+
+	_ = testutils.GetJobFromTestOutputLegacy(ctx, s.T(), s.Client, out)
+}


### PR DESCRIPTION
Previously when specifying env vars, using A=B resulted in

```
creating job: wasm env vars invalid: array must have an even number of elements
```

and relying on them being specified on the command line as "A,B" which seems counter-intuitive (and is probably a bug).

This PR changes parsing of the `-e` flag to accept a list of A=B specifiers