### PR TITLE
refactor: allow ipfs-connect and ipfs-swarm-peer interop

### DIFF
--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -3,9 +3,11 @@ package serve
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 
@@ -125,12 +127,6 @@ func getIPFSConfig() (types.IpfsConfig, error) {
 		)
 	}
 
-	if ipfsConfig.Connect != "" && len(ipfsConfig.GetSwarmAddresses()) != 0 {
-		return types.IpfsConfig{}, fmt.Errorf("%s cannot be used with %s",
-			configflags.FlagNameForKey(types.NodeIPFSSwarmAddresses, configflags.IPFSFlags...),
-			configflags.FlagNameForKey(types.NodeIPFSConnect, configflags.IPFSFlags...),
-		)
-	}
 	return ipfsConfig, nil
 }
 
@@ -158,6 +154,27 @@ func SetupIPFSClient(ctx context.Context, cm *system.CleanupManager, ipfsCfg typ
 	client, err := ipfs.NewClientUsingRemoteHandler(ctx, ipfsCfg.Connect)
 	if err != nil {
 		return ipfs.Client{}, fmt.Errorf("error creating IPFS client: %s", err)
+	}
+
+	if len(ipfsCfg.SwarmAddresses) != 0 {
+		log.Ctx(ctx).Info().Int("count", len(ipfsCfg.SwarmAddresses)).Msg("attempting to connect to ipfs swarm address peers")
+		maddrs, err := ipfs.ParsePeersString(ipfsCfg.SwarmAddresses)
+		if err != nil {
+			return ipfs.Client{}, err
+		}
+		var wg sync.WaitGroup
+		for _, pi := range maddrs {
+			wg.Add(1)
+			go func(peerInfo peer.AddrInfo) {
+				defer wg.Done()
+				if err := client.API.Swarm().Connect(ctx, peerInfo); err != nil {
+					log.Ctx(ctx).Warn().Err(err).Msgf("failed to connect to peer %s with addresses %s", peerInfo.ID, peerInfo.Addrs)
+				} else {
+					log.Ctx(ctx).Info().Msgf("connected to peer %s with addresses %s", peerInfo.ID, peerInfo.Addrs)
+				}
+			}(pi)
+		}
+		wg.Wait()
 	}
 
 	return client, nil

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/rs/zerolog/log"
 )
 
 // specialFiles - i.e. anything that is not a volume
@@ -20,7 +21,7 @@ var specialFiles = map[string]bool{
 	model.DownloadFilenameExitCode: true,
 }
 
-// DownloadResult downloads published results from a storage source and saves
+// DownloadResults downloads published results from a storage source and saves
 // them to the specific download path. It supports downloading multiple results
 // from different jobs and will append the logs to the global log file. This
 // behavior is left from when we supported sharded jobs, and multiple results

--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -64,16 +64,7 @@ type Node struct {
 	apiAddresses []string
 }
 
-func NewNode(ctx context.Context, cm *system.CleanupManager) (*Node, error) {
-	var cfg types.IpfsConfig
-	if err := bac_config.ForKey(types.NodeIPFS, &cfg); err != nil {
-		return nil, err
-	}
-	return NewNodeWithConfig(ctx, cm, cfg)
-}
-
-// newNodeWithConfig creates a new IPFS node with the given configuration.
-// NOTE: use NewNode() or NewLocalNode() unless you know what you're doing.
+// NewNodeWithConfig creates a new in-process IPFS node with the given configuration.
 func NewNodeWithConfig(ctx context.Context, cm *system.CleanupManager, cfg types.IpfsConfig) (*Node, error) {
 	var err error
 	pluginOnce.Do(func() {
@@ -93,6 +84,7 @@ func NewNodeWithConfig(ctx context.Context, cm *system.CleanupManager, cfg types
 		}
 	}()
 
+	// TODO if cfg.PrivateInternal is true do we actually want to connect to peers?
 	if err = connectToPeers(ctx, api, ipfsNode, cfg.GetSwarmAddresses()); err != nil {
 		log.Ctx(ctx).Error().Msgf("ipfs node failed to connect to peers: %s", err)
 	}


### PR DESCRIPTION
- permits bacahlau to instruct its remote ipfs node to form connections with other ipfs nodes on the ipfs network.
- allows IPFS downloader to use a remote ipfs node as its client, falling back to a in-process node if no client is requested.