### PR TITLE
Fix builds for OSX 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,13 @@ executors:
       image: ubuntu-2204:2022.07.1
       resource_class: arm.xlarge
   darwin-amd64:
-    # Note - not an actual ARM macOS machine (https://circleci.canny.io/cloud-feature-requests/p/support-new-m1-arm-based-macs)
     macos:
       xcode: "14.2.0"
     resource_class: macos.x86.medium.gen2
+  darwin-arm64:
+    macos:
+      xcode: "14.2.0"
+    resource_class: macos.m1.medium.gen1
   windows-amd64:
     machine:
       image: windows-server-2022-gui:current
@@ -29,7 +32,7 @@ commands:
     parameters:
       executor:
         type: enum
-        enum: ["linux-amd64", "linux-arm64", "darwin-amd64", "windows-amd64"]
+        enum: ["linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64"]
     steps:
     - run:
         name: Set GOVER
@@ -54,6 +57,7 @@ commands:
         condition:
           or:
           - equal: ["darwin-amd64", << parameters.executor >>]
+          - equal: ["darwin-arm64", << parameters.executor >>]
           - equal: ["linux-amd64", << parameters.executor >>]
           - equal: ["linux-arm64", << parameters.executor >>]
         steps:
@@ -102,7 +106,7 @@ jobs:
     parameters:
       executor:
         type: enum
-        enum: ["linux-amd64", "linux-arm64", "darwin-amd64", "windows-amd64"]
+        enum: ["linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64"]
       target_arch:
         type: enum
         enum: ["amd64", "arm64", "armv6", "armv7"]
@@ -790,11 +794,14 @@ workflows:
   test_darwin_arm64:
     jobs:
     - build:
-        name: test-darwin-arm64
-        executor: darwin-amd64
-        target_os: darwin
-        target_arch: arm64
-        run_tests: false
+        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          parameters:
+            target_os: ["darwin"]
+            target_arch: ["arm64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
         filters:
           branches:
             ignore: main
@@ -830,27 +837,11 @@ workflows:
             target_arch: ["amd64", "arm64"]
             run_tests: [true]
             build_tags: ["unit", "integration"]
-          exclude:
-          - target_os: "darwin"
-            target_arch: "arm64"
-            run_tests: true
-            build_tags: "unit"
-          - target_os: "darwin"
-            target_arch: "arm64"
-            run_tests: true
-            build_tags: "integration"
         filters: &filters_main_only
           branches: # this yaml anchor is setting these values to "filters_main_only"
             only: main
           tags:
             ignore: /.*/
-    - build:
-        name: build-darwin-arm64
-        executor: darwin-amd64
-        target_os: darwin
-        target_arch: arm64
-        run_tests: false
-        filters: *filters_main_only
     - build:
         name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
         executor: << matrix.target_os >>-<< matrix.target_arch >>
@@ -882,7 +873,6 @@ workflows:
         name: Build coverage report
         requires:
         - build-generic
-        - build-darwin-arm64
         - build-windows
         - build-arm
     - build_swagger:
@@ -931,16 +921,6 @@ workflows:
           - target_os: windows
             target_arch: arm64
             run_tests: false
-          - target_os: darwin
-            target_arch: arm64
-            run_tests: false
-        filters: *filters_tags_only
-    - build:
-        name: build-darwin-arm64
-        executor: darwin-amd64
-        target_os: darwin
-        target_arch: arm64
-        run_tests: false
         filters: *filters_tags_only
     - build:
         name: build-linux-<< matrix.target_arch >>
@@ -956,7 +936,6 @@ workflows:
         name: release-all-binaries
         requires:
         - build-generic
-        - build-darwin-arm64
         - build-arm
         filters: *filters_tags_only
     - docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ executors:
   darwin-amd64:
     # Note - not an actual ARM macOS machine (https://circleci.canny.io/cloud-feature-requests/p/support-new-m1-arm-based-macs)
     macos:
-      xcode: 13.4.1
-    resource_class: large
+      xcode: "14.2.0"
+    resource_class: macos.x86.medium.gen2
   windows-amd64:
     machine:
       image: windows-server-2022-gui:current
@@ -31,61 +31,61 @@ commands:
         type: enum
         enum: ["linux-amd64", "linux-arm64", "darwin-amd64", "windows-amd64"]
     steps:
-      - run:
-          name: Set GOVER
-          command: |
-            go_spec=$(grep 'go [[:digit:]].[[:digit:]]*' go.work | cut -d' ' -f2)
-            version=$(curl --silent --show-error --location --fail "https://go.dev/dl/?mode=json&include=all" | \
-              jq --arg v "$go_spec" --raw-output '[.[] | select(.stable) | select(.version | startswith("go"+$v)) | .version | ltrimstr("go")] | sort_by(split(".") | map(tonumber)) | reverse | .[0]')
-            echo "Latest Go version for $go_spec is $version"
-            echo "export GOVER=$version" >> $BASH_ENV
+    - run:
+        name: Set GOVER
+        command: |
+          go_spec=$(grep 'go [[:digit:]].[[:digit:]]*' go.work | cut -d' ' -f2)
+          version=$(curl --silent --show-error --location --fail "https://go.dev/dl/?mode=json&include=all" | \
+            jq --arg v "$go_spec" --raw-output '[.[] | select(.stable) | select(.version | startswith("go"+$v)) | .version | ltrimstr("go")] | sort_by(split(".") | map(tonumber)) | reverse | .[0]')
+          echo "Latest Go version for $go_spec is $version"
+          echo "export GOVER=$version" >> $BASH_ENV
 
-      - when:
-          condition:
-            equal: ["windows-amd64", << parameters.executor >>]
-          steps:
-            - run:
-                name: Install Go
-                command: |
-                  rm -rf /c/Program\ Files/Go
-                  curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.<< parameters.executor >>.zip | tar --extract --gzip --file=- --directory=/c/Program\ Files
+    - when:
+        condition:
+          equal: ["windows-amd64", << parameters.executor >>]
+        steps:
+        - run:
+            name: Install Go
+            command: |
+              rm -rf /c/Program\ Files/Go
+              curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.<< parameters.executor >>.zip | tar --extract --gzip --file=- --directory=/c/Program\ Files
 
-      - when:
-          condition:
-            or:
-              - equal: ["darwin-amd64", << parameters.executor >>]
-              - equal: ["linux-amd64", << parameters.executor >>]
-              - equal: ["linux-arm64", << parameters.executor >>]
-          steps:
-            - run:
-                name: Install Go
-                command: |
-                  sudo rm -fr /usr/local/go /usr/local/bin/go
-                  curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.<< parameters.executor >>.tar.gz | sudo tar --extract --gzip --file=- --directory=/usr/local
-                  sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+    - when:
+        condition:
+          or:
+          - equal: ["darwin-amd64", << parameters.executor >>]
+          - equal: ["linux-amd64", << parameters.executor >>]
+          - equal: ["linux-arm64", << parameters.executor >>]
+        steps:
+        - run:
+            name: Install Go
+            command: |
+              sudo rm -fr /usr/local/go /usr/local/bin/go
+              curl --silent --show-error --location --fail https://go.dev/dl/go$GOVER.<< parameters.executor >>.tar.gz | sudo tar --extract --gzip --file=- --directory=/usr/local
+              sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 
-      - run:
-          name: Set GOCACHE
-          command: echo "export GOCACHE=$HOME/.cache/go-build" >> $BASH_ENV
+    - run:
+        name: Set GOCACHE
+        command: echo "export GOCACHE=$HOME/.cache/go-build" >> $BASH_ENV
 
-      - run:
-          name: Set GOPATH
-          command: echo "export GOPATH=$HOME/go" >> $BASH_ENV
+    - run:
+        name: Set GOPATH
+        command: echo "export GOPATH=$HOME/go" >> $BASH_ENV
 
-      - restore_cache:
-          name: Restoring Go cache
-          key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
+    - restore_cache:
+        name: Restoring Go cache
+        key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
 
-      - run:
-          name: Install packages
-          command: go mod tidy
+    - run:
+        name: Install packages
+        command: go mod tidy
 
-      - save_cache:
-          name: Saving Go cache
-          key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - ~/go/pkg/mod
+    - save_cache:
+        name: Saving Go cache
+        key: go-mod-{{ arch }}-{{ checksum "go.sum" }}
+        paths:
+        - ~/.cache/go-build
+        - ~/go/pkg/mod
 
 
 jobs:
@@ -115,131 +115,131 @@ jobs:
         type: string
         default: ""
     steps:
-      - checkout
+    - checkout
 
-      - when:
-          condition:
-            equal: ["windows", << parameters.target_os >>]
-          steps:
-            - run:
-                name: Install GNU Make
-                command: |
-                  choco install -y make
-                  choco install -y jq
-                shell: powershell.exe
+    - when:
+        condition:
+          equal: ["windows", << parameters.target_os >>]
+        steps:
+        - run:
+            name: Install GNU Make
+            command: |
+              choco install -y make
+              choco install -y jq
+            shell: powershell.exe
 
-      - install_go:
-          executor: << parameters.executor >>
+    - install_go:
+        executor: << parameters.executor >>
 
-      - run:
-          name: Init tools
-          command: |
-            make init
-            go version
-            which go
+    - run:
+        name: Init tools
+        command: |
+          make init
+          go version
+          which go
 
-      - run:
-          name: Build
-          command: make build-ci
+    - run:
+        name: Build
+        command: make build-ci
 
-      - when:
-          condition:
-            equal: [true, << parameters.run_tests >>]
-          steps:
-            - run:
-                name: "Setup BACALHAU_ENVIRONMENT environment variable"
-                command: echo 'export BACALHAU_ENVIRONMENT=test' >> "$BASH_ENV"
-            - run:
-                name: Test Go
-                environment:
-                  LOG_LEVEL: debug
-                  TEST_BUILD_TAGS: << parameters.build_tags >>
-                  TEST_PARALLEL_PACKAGES: 4 # This is set to 4 as xlarge instances have at least 8 CPUs, and we want to leave some CPU for the Docker instances
-                command: |
-                  export GOBIN=${HOME}/bin
-                  export PATH=$GOBIN:$PATH
-                  go install gotest.tools/gotestsum@v1.8.2
-                  make test-and-report
+    - when:
+        condition:
+          equal: [true, << parameters.run_tests >>]
+        steps:
+        - run:
+            name: "Setup BACALHAU_ENVIRONMENT environment variable"
+            command: echo 'export BACALHAU_ENVIRONMENT=test' >> "$BASH_ENV"
+        - run:
+            name: Test Go
+            environment:
+              LOG_LEVEL: debug
+              TEST_BUILD_TAGS: << parameters.build_tags >>
+              TEST_PARALLEL_PACKAGES: 4 # This is set to 4 as xlarge instances have at least 8 CPUs, and we want to leave some CPU for the Docker instances
+            command: |
+              export GOBIN=${HOME}/bin
+              export PATH=$GOBIN:$PATH
+              go install gotest.tools/gotestsum@v1.8.2
+              make test-and-report
 
-                no_output_timeout: 20m
-            - store_test_results:
-                path: .
-            - persist_to_workspace:
-                root: coverage/
-                paths:
-                  - "*.coverage"
+            no_output_timeout: 20m
+        - store_test_results:
+            path: .
+        - persist_to_workspace:
+            root: coverage/
+            paths:
+            - "*.coverage"
 
-      - when:
-          condition:
-            and:
-              - equal: ["linux", << parameters.target_os >>]
-              - equal: ["amd64", << parameters.target_arch >>]
-              - equal: [true, << parameters.run_tests >>]
-          steps:
-            - run:
-                name: Test Python SDK
-                command: |
-                  sudo apt install python3.10 -y
-                  curl -sSL https://install.python-poetry.org | python3 -
-                  cd python
-                  # Unsetting locale because of https://github.com/python-poetry/poetry/issues/3412
-                  env LANG= LANGUAGE= LC_ALL= /home/circleci/.local/bin/poetry lock --no-update --no-interaction
-                  # Using '--no-ansi' because of https://github.com/python-poetry/poetry/issues/7184
-                  env LANG= LANGUAGE= LC_ALL= /home/circleci/.local/bin/poetry install --no-root --no-interaction --no-ansi --with test
-                  # Run tests
-                  cd ..
-                  make test-python
-            - run:
-                name: Test Python Airflow Provider
-                command: |
-                  cd integration/airflow
-                  pip3 install -r dev-requirements.txt
-                  tox
-                  cd ../..
-            - run:
-                name: Upload results
-                command: |
-                  export DEBIAN_FRONTEND=noninteractive
-                  sudo apt install python3.10 -y
-                  python3 -m pip install --upgrade pip
-                  pip3 install gsutil
-                  export SHA="<< pipeline.git.revision >>"
-                  export DATETIME="$(date -u +"%FT%H%MZ")"
-                  if [ "<<pipeline.git.tag>>" != "" ]; then
-                    export TEST_RESULTS_FILENAME="<<pipeline.git.tag>>-$DATETIME-$SHA.xml"
-                  else
-                    export TEST_RESULTS_FILENAME="<<pipeline.git.branch>>-$DATETIME-$SHA.xml"
-                  fi
-                  # Credentials for project: bacalhau-cicd
-                  # Account:
-                  echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
-                  if [[ "${TEST_RESULTS_FILENAME}" == *"/"* ]]; then
-                    mkdir -p $(dirname "${TEST_RESULTS_FILENAME}")
-                  fi
-                  mv unittests.xml "${TEST_RESULTS_FILENAME}"
-                  gsutil cp "$TEST_RESULTS_FILENAME" "gs://$GCS_TEST_RESULTS_BUCKET"
+    - when:
+        condition:
+          and:
+          - equal: ["linux", << parameters.target_os >>]
+          - equal: ["amd64", << parameters.target_arch >>]
+          - equal: [true, << parameters.run_tests >>]
+        steps:
+        - run:
+            name: Test Python SDK
+            command: |
+              sudo apt install python3.10 -y
+              curl -sSL https://install.python-poetry.org | python3 -
+              cd python
+              # Unsetting locale because of https://github.com/python-poetry/poetry/issues/3412
+              env LANG= LANGUAGE= LC_ALL= /home/circleci/.local/bin/poetry lock --no-update --no-interaction
+              # Using '--no-ansi' because of https://github.com/python-poetry/poetry/issues/7184
+              env LANG= LANGUAGE= LC_ALL= /home/circleci/.local/bin/poetry install --no-root --no-interaction --no-ansi --with test
+              # Run tests
+              cd ..
+              make test-python
+        - run:
+            name: Test Python Airflow Provider
+            command: |
+              cd integration/airflow
+              pip3 install -r dev-requirements.txt
+              tox
+              cd ../..
+        - run:
+            name: Upload results
+            command: |
+              export DEBIAN_FRONTEND=noninteractive
+              sudo apt install python3.10 -y
+              python3 -m pip install --upgrade pip
+              pip3 install gsutil
+              export SHA="<< pipeline.git.revision >>"
+              export DATETIME="$(date -u +"%FT%H%MZ")"
+              if [ "<<pipeline.git.tag>>" != "" ]; then
+                export TEST_RESULTS_FILENAME="<<pipeline.git.tag>>-$DATETIME-$SHA.xml"
+              else
+                export TEST_RESULTS_FILENAME="<<pipeline.git.branch>>-$DATETIME-$SHA.xml"
+              fi
+              # Credentials for project: bacalhau-cicd
+              # Account:
+              echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
+              if [[ "${TEST_RESULTS_FILENAME}" == *"/"* ]]; then
+                mkdir -p $(dirname "${TEST_RESULTS_FILENAME}")
+              fi
+              mv unittests.xml "${TEST_RESULTS_FILENAME}"
+              gsutil cp "$TEST_RESULTS_FILENAME" "gs://$GCS_TEST_RESULTS_BUCKET"
 
-      - run:
-          name: Build tarball
-          command: |
-            echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
-            echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
-            export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
-            make build-bacalhau-tgz
+    - run:
+        name: Build tarball
+        command: |
+          echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
+          echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
+          export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
+          make build-bacalhau-tgz
 
-      - when:
-          condition:
-            not:
-              equal: ["integration", << parameters.build_tags >>]
-          steps:
-            - persist_to_workspace:
-                root: dist/
-                paths:
-                  - "*.tar.gz"
-                  - "*.sha256"
+    - when:
+        condition:
+          not:
+            equal: ["integration", << parameters.build_tags >>]
+        steps:
+        - persist_to_workspace:
+            root: dist/
+            paths:
+            - "*.tar.gz"
+            - "*.sha256"
 
-      - store_artifacts:
-          path: dist/
+    - store_artifacts:
+        path: dist/
 
   build_canary:
     parallelism: 1
@@ -249,57 +249,57 @@ jobs:
     working_directory: ~/repo
     executor: linux-amd64
     steps:
-      - checkout
+    - checkout
 
-      - install_go:
-          executor: linux-amd64
+    - install_go:
+        executor: linux-amd64
 
-      - run:
-          name: Install Executor Plugins
-          command: make install-plugins
+    - run:
+        name: Install Executor Plugins
+        command: make install-plugins
 
-      - run:
-          name: Set canary dependency
-          working_directory: ops/aws/canary/lambda
-          command: make update
+    - run:
+        name: Set canary dependency
+        working_directory: ops/aws/canary/lambda
+        command: make update
 
-      - run:
-          name: Build
-          working_directory: ops/aws/canary/lambda
-          command: make build -j
+    - run:
+        name: Build
+        working_directory: ops/aws/canary/lambda
+        command: make build -j
 
-      - run:
-          name: Run tests
-          working_directory: ops/aws/canary/lambda
-          command: |
-            export GOBIN=${HOME}/bin
-            export PATH=$GOBIN:$PATH
-            go install gotest.tools/gotestsum@v1.8.2
-            make test
+    - run:
+        name: Run tests
+        working_directory: ops/aws/canary/lambda
+        command: |
+          export GOBIN=${HOME}/bin
+          export PATH=$GOBIN:$PATH
+          go install gotest.tools/gotestsum@v1.8.2
+          make test
 
-      - store_test_results:
-          path: ops/aws/canary/lambda/tests.xml
+    - store_test_results:
+        path: ops/aws/canary/lambda/tests.xml
 
   coverage:
     executor: linux-amd64
     environment:
       GOPROXY: https://proxy.golang.org
     steps:
-      - checkout
+    - checkout
 
-      - attach_workspace:
-          at: coverage/
+    - attach_workspace:
+        at: coverage/
 
-      - run:
-          name: Install gocovmerge
-          command: go install github.com/wadey/gocovmerge@latest
+    - run:
+        name: Install gocovmerge
+        command: go install github.com/wadey/gocovmerge@latest
 
-      - run:
-          name: Build coverage report
-          command: make coverage-report
+    - run:
+        name: Build coverage report
+        command: make coverage-report
 
-      - store_artifacts:
-          path: coverage/coverage.html
+    - store_artifacts:
+        path: coverage/coverage.html
 
   lint:
     parallelism: 1
@@ -309,45 +309,45 @@ jobs:
     working_directory: ~/repo
     executor: linux-amd64
     steps:
-      - checkout
+    - checkout
 
-      - run:
-          name: Init tools
-          command: |
-            make init
+    - run:
+        name: Init tools
+        command: |
+          make init
 
-      - install_go:
-          executor: linux-amd64
+    - install_go:
+        executor: linux-amd64
 
-      - run:
-          name: Install golangci-lint
-          command: |
-            echo "Installing GOLANGCILINT: ${GOLANGCILINT}"
-            # binary will be /usr/local/go/bin/bin/golangci-lint
-            # For some reason, .circlerc (I don't know where this file is generated) reports `go env GOPATH` as '/home/circleci/.go_workspace:/usr/local/go_workspace' (with the colon)
-            # This breaks normal pathing. So just installing in ./bin/
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINDIR=${HOME}/bin sh -s ${GOLANGCILINT}
-            golangci-lint version
+    - run:
+        name: Install golangci-lint
+        command: |
+          echo "Installing GOLANGCILINT: ${GOLANGCILINT}"
+          # binary will be /usr/local/go/bin/bin/golangci-lint
+          # For some reason, .circlerc (I don't know where this file is generated) reports `go env GOPATH` as '/home/circleci/.go_workspace:/usr/local/go_workspace' (with the colon)
+          # This breaks normal pathing. So just installing in ./bin/
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINDIR=${HOME}/bin sh -s ${GOLANGCILINT}
+          golangci-lint version
 
-      - run:
-          name: Install Pre-commit
-          command: |
-            make install-pre-commit
+    - run:
+        name: Install Pre-commit
+        command: |
+          make install-pre-commit
 
-      - run:
-          name: Cache Precommit
-          command: |
-            cp .pre-commit-config.yaml pre-commit-cache-key.txt
-            poetry run python --version --version >> pre-commit-cache-key.txt
+    - run:
+        name: Cache Precommit
+        command: |
+          cp .pre-commit-config.yaml pre-commit-cache-key.txt
+          poetry run python --version --version >> pre-commit-cache-key.txt
 
-      - restore_cache:
-          name: Restoring pre-commit cache
-          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+    - restore_cache:
+        name: Restoring pre-commit cache
+        key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
 
-      - run:
-          name: Run linter
-          command: |
-            make precommit
+    - run:
+        name: Run linter
+        command: |
+          make precommit
 
   performance_job:
     resource_class: bacalhau-project/self-hosted-bacalhau
@@ -356,96 +356,96 @@ jobs:
     environment:
       GCS_PERF_RESULTS_BUCKET: gs://bacalhau-global-storage/perf-results
     steps:
-      - checkout
-      - attach_workspace:
-          at: dist/
-      - run:
-          name: Unpack build
-          command: |
-            mkdir -p bin/linux_amd64
-            tar -C bin/linux_amd64 -xf dist/*.tar.gz
-      - run:
-          name: Run performance test
-          command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- -y
-            source $HOME/.cargo/env
-            cargo install hyperfine
-            (
-              cd benchmark
-              bash start_and_run.sh
-            )
-      - run:
-          name: Upload results
-          env:
-          command: |
-            export PATH="$HOME/.local/bin:${PATH}"
-            export DATETIME="$(date -u +"%FT%H%MZ")"
-            if test -z "${CIRCLE_TAG}"; then
-              export CIRCLE_TAG="v0.0.0-xxxxxxx"
-            fi
-            pip3 install gsutil
-            echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
-            gsutil -m cp benchmark/results/* "${GCS_PERF_RESULTS_BUCKET}/${DATETIME}-${CIRCLE_BRANCH}-${CIRCLE_TAG}-${CIRCLE_SHA1}"
-      - heroku/install
-      - run:
-          name: Update dashboard
-          command: |
-            heroku run build --app bacalhau-dashboards
+    - checkout
+    - attach_workspace:
+        at: dist/
+    - run:
+        name: Unpack build
+        command: |
+          mkdir -p bin/linux_amd64
+          tar -C bin/linux_amd64 -xf dist/*.tar.gz
+    - run:
+        name: Run performance test
+        command: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs  | sh -s -- -y
+          source $HOME/.cargo/env
+          cargo install hyperfine
+          (
+            cd benchmark
+            bash start_and_run.sh
+          )
+    - run:
+        name: Upload results
+        env:
+        command: |
+          export PATH="$HOME/.local/bin:${PATH}"
+          export DATETIME="$(date -u +"%FT%H%MZ")"
+          if test -z "${CIRCLE_TAG}"; then
+            export CIRCLE_TAG="v0.0.0-xxxxxxx"
+          fi
+          pip3 install gsutil
+          echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
+          gsutil -m cp benchmark/results/* "${GCS_PERF_RESULTS_BUCKET}/${DATETIME}-${CIRCLE_BRANCH}-${CIRCLE_TAG}-${CIRCLE_SHA1}"
+    - heroku/install
+    - run:
+        name: Update dashboard
+        command: |
+          heroku run build --app bacalhau-dashboards
 
   release:
     executor: linux-amd64
     steps:
-      - checkout
-      - attach_workspace:
-          at: dist/
-      - run:
-          name: Install gh
-          command: |
-            wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb
-            sudo dpkg -i gh_2.14.7_linux_amd64.deb
-            echo "$BACALHAU_RELEASE_TOKEN" | gh auth login --with-token
-      - run:
-          name: Uploading to Release - << pipeline.git.tag >>
-          command: |
-            TAG="<< pipeline.git.tag >>"
-            echo "TAG = ${TAG}"
-            find dist/
-            gh release upload $TAG dist/*
+    - checkout
+    - attach_workspace:
+        at: dist/
+    - run:
+        name: Install gh
+        command: |
+          wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb
+          sudo dpkg -i gh_2.14.7_linux_amd64.deb
+          echo "$BACALHAU_RELEASE_TOKEN" | gh auth login --with-token
+    - run:
+        name: Uploading to Release - << pipeline.git.tag >>
+        command: |
+          TAG="<< pipeline.git.tag >>"
+          echo "TAG = ${TAG}"
+          find dist/
+          gh release upload $TAG dist/*
 
   release_python:
     executor: linux-amd64
     working_directory: ~/repo
     steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/py_dist
-      - run:
-          name: Copy dist files
-          command: |
-            mkdir -p clients/python/dist
-            cp /tmp/py_dist/bacalhau_apiclient* clients/python/dist
-            mkdir -p python/dist
-            cp /tmp/py_dist/bacalhau_sdk* python/dist
-            mkdir -p integration/airflow/dist
-            cp /tmp/py_dist/bacalhau_airflow* integration/airflow/dist
-      - run :
-          name: Release python apiclient
-          command: |
-            make release-python-apiclient
-      - run:
-          name: Install Python SDK pre-requistes
-          command: |
-            curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
-            echo 'export PATH="/home/circleci/.local/bin:$PATH"' >> "$BASH_ENV"
-      - run :
-          name: Release python sdk
-          command: |
-            make release-python-sdk
-      - run :
-          name: Release python Airflow integration
-          command: |
-            pip3 install twine==4.0.2
-            make release-bacalhau-airflow
+    - checkout
+    - attach_workspace:
+        at: /tmp/py_dist
+    - run:
+        name: Copy dist files
+        command: |
+          mkdir -p clients/python/dist
+          cp /tmp/py_dist/bacalhau_apiclient* clients/python/dist
+          mkdir -p python/dist
+          cp /tmp/py_dist/bacalhau_sdk* python/dist
+          mkdir -p integration/airflow/dist
+          cp /tmp/py_dist/bacalhau_airflow* integration/airflow/dist
+    - run:
+        name: Release python apiclient
+        command: |
+          make release-python-apiclient
+    - run:
+        name: Install Python SDK pre-requistes
+        command: |
+          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
+          echo 'export PATH="/home/circleci/.local/bin:$PATH"' >> "$BASH_ENV"
+    - run:
+        name: Release python sdk
+        command: |
+          make release-python-sdk
+    - run:
+        name: Release python Airflow integration
+        command: |
+          pip3 install twine==4.0.2
+          make release-bacalhau-airflow
 
   update_metadata:
     executor: linux-amd64
@@ -455,15 +455,15 @@ jobs:
       METADATA_FILENAME:
         type: string
     steps:
-      - checkout
-      - run:
-          name: Update Metadata
-          command: |
-            export GOOGLE_APPLICATION_CREDENTIALS="/tmp/UPDATE_METADATA_CREDENTIALS.json"
-            echo "${UPDATE_METADATA_CREDENTIALS_CONTENT_B64}" | base64 --decode > "${GOOGLE_APPLICATION_CREDENTIALS}"
-            cd ops
-            pip3 install -r requirements.txt
-            python3 update_metadata.py "<< parameters.METADATA_BUCKET >>" "<< parameters.METADATA_FILENAME >>"
+    - checkout
+    - run:
+        name: Update Metadata
+        command: |
+          export GOOGLE_APPLICATION_CREDENTIALS="/tmp/UPDATE_METADATA_CREDENTIALS.json"
+          echo "${UPDATE_METADATA_CREDENTIALS_CONTENT_B64}" | base64 --decode > "${GOOGLE_APPLICATION_CREDENTIALS}"
+          cd ops
+          pip3 install -r requirements.txt
+          python3 update_metadata.py "<< parameters.METADATA_BUCKET >>" "<< parameters.METADATA_FILENAME >>"
 
   build_swagger:
     executor: linux-amd64
@@ -473,63 +473,63 @@ jobs:
       TARGET_COMMIT: << pipeline.git.revision >>
     working_directory: ~/repo
     steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "b2:46:a2:7c:94:1f:84:be:99:70:1e:44:50:1e:33:2b"
-      - install_go:
-          executor: linux-amd64
-      - run:
-          name: Install Swagger
-          command: |
-            export GOBIN=${HOME}/bin
-            export PATH=$GOBIN:$PATH
-            go install github.com/swaggo/swag/cmd/swag@v1.8.10
-      - run:
-          name: Build Swagger Docs
-          command: |
-            export GOBIN=${HOME}/bin
-            export PATH=$GOBIN:$PATH
-            make swagger-docs
-      - persist_to_workspace:
-          root: docs
-          paths:
-            - swagger.json
+    - checkout
+    - add_ssh_keys:
+        fingerprints:
+        - "b2:46:a2:7c:94:1f:84:be:99:70:1e:44:50:1e:33:2b"
+    - install_go:
+        executor: linux-amd64
+    - run:
+        name: Install Swagger
+        command: |
+          export GOBIN=${HOME}/bin
+          export PATH=$GOBIN:$PATH
+          go install github.com/swaggo/swag/cmd/swag@v1.8.10
+    - run:
+        name: Build Swagger Docs
+        command: |
+          export GOBIN=${HOME}/bin
+          export PATH=$GOBIN:$PATH
+          make swagger-docs
+    - persist_to_workspace:
+        root: docs
+        paths:
+        - swagger.json
 
-      - when: # Only if the current branch is main, we push the swagger spec to the repo (via auto PR)
-          condition:
-            equal: ["main", << pipeline.git.branch >>]
-          steps:
-            - run:
-                name: Install gh
-                command: |
-                  wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb
-                  sudo dpkg -i gh_2.14.7_linux_amd64.deb
-                  echo "$GITHUB_PR_PAT" | gh auth login --with-token
-                  rm gh_2.14.7_linux_amd64.deb
-            - run:
-                name: Install human-id generator
-                command: |
-                  pip3 install human-id
-            - run:
-                name: Git commit
-                command: |
-                  git config user.email "$(git log --format='format:%ae' -n1)"
-                  git config user.name "$(git log --format='format:%an' -n1)"
-                  # Note: we delete this branch after the PR is merged
-                  GH_BRANCH_NAME=(ci-build-swagger-docs_$(humanid-gen --words 3 | grep -oE "^([^-]*-){1}[^-]*")-$(((RANDOM % $((100 - 1))) + 1)))
-                  git checkout -b $GH_BRANCH_NAME
-                  if test -n "$(git ls-files --modified | grep -e '^docs/')"; then
-                    git add --verbose -- ./docs
-                    COMMIT_MSG="Build swagger reference - this is an automatic commit"
-                    git commit -m "[circleci] $COMMIT_MSG [skip ci]"
-                    git push --set-upstream origin $GH_BRANCH_NAME
-                    # Note: if you close the PR below manually, you should delete the `ci-build-swagger-docs_*` branch as well
-                    PR_URL=$(gh pr create --fill --head $(git rev-parse --abbrev-ref HEAD) --base main --label schema --repo bacalhau-project/bacalhau)
-                    echo "Pull request: $PR_URL"
-                    sleep 3
-                    gh pr merge --auto --delete-branch -r $PR_URL
-                  fi
+    - when: # Only if the current branch is main, we push the swagger spec to the repo (via auto PR)
+        condition:
+          equal: ["main", << pipeline.git.branch >>]
+        steps:
+        - run:
+            name: Install gh
+            command: |
+              wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb
+              sudo dpkg -i gh_2.14.7_linux_amd64.deb
+              echo "$GITHUB_PR_PAT" | gh auth login --with-token
+              rm gh_2.14.7_linux_amd64.deb
+        - run:
+            name: Install human-id generator
+            command: |
+              pip3 install human-id
+        - run:
+            name: Git commit
+            command: |
+              git config user.email "$(git log --format='format:%ae' -n1)"
+              git config user.name "$(git log --format='format:%an' -n1)"
+              # Note: we delete this branch after the PR is merged
+              GH_BRANCH_NAME=(ci-build-swagger-docs_$(humanid-gen --words 3 | grep -oE "^([^-]*-){1}[^-]*")-$(((RANDOM % $((100 - 1))) + 1)))
+              git checkout -b $GH_BRANCH_NAME
+              if test -n "$(git ls-files --modified | grep -e '^docs/')"; then
+                git add --verbose -- ./docs
+                COMMIT_MSG="Build swagger reference - this is an automatic commit"
+                git commit -m "[circleci] $COMMIT_MSG [skip ci]"
+                git push --set-upstream origin $GH_BRANCH_NAME
+                # Note: if you close the PR below manually, you should delete the `ci-build-swagger-docs_*` branch as well
+                PR_URL=$(gh pr create --fill --head $(git rev-parse --abbrev-ref HEAD) --base main --label schema --repo bacalhau-project/bacalhau)
+                echo "Pull request: $PR_URL"
+                sleep 3
+                gh pr merge --auto --delete-branch -r $PR_URL
+              fi
 
   build_jsonschema_job:
     executor: linux-amd64
@@ -539,69 +539,69 @@ jobs:
       TARGET_COMMIT: << pipeline.git.revision >>
     working_directory: ~/repo
     steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "b2:46:a2:7c:94:1f:84:be:99:70:1e:44:50:1e:33:2b"
-      - install_go:
-          executor: linux-amd64
-      - run:
-          name: Build JSONSchema
-          command: |
-            make all_schemas
+    - checkout
+    - add_ssh_keys:
+        fingerprints:
+        - "b2:46:a2:7c:94:1f:84:be:99:70:1e:44:50:1e:33:2b"
+    - install_go:
+        executor: linux-amd64
+    - run:
+        name: Build JSONSchema
+        command: |
+          make all_schemas
 
-      - run:
-          name: Install gh
-          command: |
-            wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb
-            sudo dpkg -i gh_2.14.7_linux_amd64.deb
-            echo "$GITHUB_PR_PAT" | gh auth login --with-token
-            rm gh_2.14.7_linux_amd64.deb
-      - run:
-          name: Install human-id generator
-          command: |
-            pip3 install human-id
-      - run:
-          name: Git commit
-          command: |
-            git config user.email "enrico.rotundo@gmail.com"
-            git config user.name "enricorotundo"
-            # Note: we delete this branch after the PR is merged
-            GH_BRANCH_NAME=(ci-build-jsonschema_$(humanid-gen --words 3 | grep -oE "^([^-]*-){1}[^-]*")-$(((RANDOM % $((100 - 1))) + 1)))
-            git checkout -b $GH_BRANCH_NAME
-            if test -n "$(git ls-files --modified)"; then
-              git add --verbose -- ./schema.bacalhau.org
-              COMMIT_MSG="Build jsonschema - this is an automatic commit"
-              git commit -m "[circleci] $COMMIT_MSG [skip ci]"
-              git push --set-upstream origin $GH_BRANCH_NAME
-              # Note: if you close the PR below manually, you should delete the `ci-build-jsonschema_*` branch as well
-              PR_URL=$(gh pr create --fill --head $(git rev-parse --abbrev-ref HEAD) --base main --label schema --repo bacalhau-project/bacalhau)
-              echo "Pull request: $PR_URL"
-              sleep 3
-              gh pr merge --auto --delete-branch -r $PR_URL
-              curl \
-                -X POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${GH_PAGES_TOKEN}"\
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/bacalhau-project/bacalhau/dispatches \
-                -d '{"event_type":"build-schema-pages"}'
-            fi
+    - run:
+        name: Install gh
+        command: |
+          wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb
+          sudo dpkg -i gh_2.14.7_linux_amd64.deb
+          echo "$GITHUB_PR_PAT" | gh auth login --with-token
+          rm gh_2.14.7_linux_amd64.deb
+    - run:
+        name: Install human-id generator
+        command: |
+          pip3 install human-id
+    - run:
+        name: Git commit
+        command: |
+          git config user.email "enrico.rotundo@gmail.com"
+          git config user.name "enricorotundo"
+          # Note: we delete this branch after the PR is merged
+          GH_BRANCH_NAME=(ci-build-jsonschema_$(humanid-gen --words 3 | grep -oE "^([^-]*-){1}[^-]*")-$(((RANDOM % $((100 - 1))) + 1)))
+          git checkout -b $GH_BRANCH_NAME
+          if test -n "$(git ls-files --modified)"; then
+            git add --verbose -- ./schema.bacalhau.org
+            COMMIT_MSG="Build jsonschema - this is an automatic commit"
+            git commit -m "[circleci] $COMMIT_MSG [skip ci]"
+            git push --set-upstream origin $GH_BRANCH_NAME
+            # Note: if you close the PR below manually, you should delete the `ci-build-jsonschema_*` branch as well
+            PR_URL=$(gh pr create --fill --head $(git rev-parse --abbrev-ref HEAD) --base main --label schema --repo bacalhau-project/bacalhau)
+            echo "Pull request: $PR_URL"
+            sleep 3
+            gh pr merge --auto --delete-branch -r $PR_URL
+            curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_PAGES_TOKEN}"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/bacalhau-project/bacalhau/dispatches \
+              -d '{"event_type":"build-schema-pages"}'
+          fi
 
   docker:
     executor: linux-amd64
     steps:
-      - checkout
-      - run:
-          name: Login to GHCR
-          command: |
-            echo $GHCR_PAT | docker login ghcr.io -u circleci --password-stdin
-      - run:
-          name: Push application Docker image
-          command: |
-            docker context create buildx-build
-            docker buildx create --use buildx-build
-            make push-bacalhau-image
+    - checkout
+    - run:
+        name: Login to GHCR
+        command: |
+          echo $GHCR_PAT | docker login ghcr.io -u circleci --password-stdin
+    - run:
+        name: Push application Docker image
+        command: |
+          docker context create buildx-build
+          docker buildx create --use buildx-build
+          make push-bacalhau-image
 
   build_python_packages:
     executor: linux-amd64
@@ -610,59 +610,59 @@ jobs:
       # PYPI_VERSION: 0.3.24.dev8 # use this to set a custom version identifier (https://peps.python.org/pep-0440/)
     working_directory: ~/repo
     steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/swagger_spec
-      - run:
-          name: Copy swagger.json from workspace
-          command: |
-            cp /tmp/swagger_spec/swagger.json ./docs/swagger.json
-      - run:
-          name: Install Python API client pre-requistes
-          command: |
-            CODEGEN_BASE_URL="https://repo1.maven.org/maven2/io/swagger/codegen/v3"
-            wget ${CODEGEN_BASE_URL}/swagger-codegen-cli/3.0.41/swagger-codegen-cli-3.0.41.jar -O ${HOME}/bin/swagger-codegen-cli.jar
-            chmod +x ${HOME}/bin/swagger-codegen-cli.jar
-            ${HOME}/bin/swagger-codegen-cli.jar version
-      - run:
-          name: Build Python API client
-          command: |
-            make build-python-apiclient
-      - persist_to_workspace:
-          root: clients/python/dist
-          paths:
-            - bacalhau_apiclient-*.tar.gz
-            - bacalhau_apiclient-*.whl
-      - run:
-          name: Install Python SDK pre-requistes
-          command: |
-            curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
-            echo 'export PATH="/home/circleci/.local/bin:$PATH"' >> "$BASH_ENV"
-            cd python
-            /home/circleci/.local/bin/poetry run pip3 install black>=22.12.0 isort>=5.8.0 flake8>=6.0.0 mypy>=0.991 pre-commit>=2.12.0
-      - run:
-          name: Build Python SDK
-          command: |
-            make build-python-sdk
-      - persist_to_workspace:
-          root: python/dist
-          paths:
-            - bacalhau_sdk-*.tar.gz
-            - bacalhau_sdk-*.whl
-      - run:
-          name: Install bacalhau-airflow pre-requistes
-          command: |
-            cd integration/airflow
-            pip3 install -r dev-requirements.txt
-      - run:
-          name: Build Python Bacalhau Airflow
-          command: |
-            make build-bacalhau-airflow
-      - persist_to_workspace:
-          root: integration/airflow/dist
-          paths:
-            - bacalhau_airflow-*.tar.gz
-            - bacalhau_airflow-*.whl
+    - checkout
+    - attach_workspace:
+        at: /tmp/swagger_spec
+    - run:
+        name: Copy swagger.json from workspace
+        command: |
+          cp /tmp/swagger_spec/swagger.json ./docs/swagger.json
+    - run:
+        name: Install Python API client pre-requistes
+        command: |
+          CODEGEN_BASE_URL="https://repo1.maven.org/maven2/io/swagger/codegen/v3"
+          wget ${CODEGEN_BASE_URL}/swagger-codegen-cli/3.0.41/swagger-codegen-cli-3.0.41.jar -O ${HOME}/bin/swagger-codegen-cli.jar
+          chmod +x ${HOME}/bin/swagger-codegen-cli.jar
+          ${HOME}/bin/swagger-codegen-cli.jar version
+    - run:
+        name: Build Python API client
+        command: |
+          make build-python-apiclient
+    - persist_to_workspace:
+        root: clients/python/dist
+        paths:
+        - bacalhau_apiclient-*.tar.gz
+        - bacalhau_apiclient-*.whl
+    - run:
+        name: Install Python SDK pre-requistes
+        command: |
+          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
+          echo 'export PATH="/home/circleci/.local/bin:$PATH"' >> "$BASH_ENV"
+          cd python
+          /home/circleci/.local/bin/poetry run pip3 install black>=22.12.0 isort>=5.8.0 flake8>=6.0.0 mypy>=0.991 pre-commit>=2.12.0
+    - run:
+        name: Build Python SDK
+        command: |
+          make build-python-sdk
+    - persist_to_workspace:
+        root: python/dist
+        paths:
+        - bacalhau_sdk-*.tar.gz
+        - bacalhau_sdk-*.whl
+    - run:
+        name: Install bacalhau-airflow pre-requistes
+        command: |
+          cd integration/airflow
+          pip3 install -r dev-requirements.txt
+    - run:
+        name: Build Python Bacalhau Airflow
+        command: |
+          make build-bacalhau-airflow
+    - persist_to_workspace:
+        root: integration/airflow/dist
+        paths:
+        - bacalhau_airflow-*.tar.gz
+        - bacalhau_airflow-*.whl
 
 
 orbs:
@@ -673,315 +673,314 @@ orbs:
 workflows:
   lint:
     jobs:
-      - lint:
-          name: Run linters and static checkers
-          filters:
-            tags:
-              ignore: /.*/
+    - lint:
+        name: Run linters and static checkers
+        filters:
+          tags:
+            ignore: /.*/
 
   check_canary:
     jobs:
-      - build_canary:
-          name: Check canary build
-          filters:
-            tags:
-              ignore: /.*/
+    - build_canary:
+        name: Check canary build
+        filters:
+          tags:
+            ignore: /.*/
 
   build_swagger_spec:
     jobs:
     - build_swagger:
-          name: build-swagger-spec
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+        name: build-swagger-spec
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   # These workflow will run on all branches except 'main' and will not run on tags
   test_linux_amd64:
     jobs:
-      - build:
-          name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            parameters:
-              target_os: [ "linux" ]
-              target_arch: [ "amd64" ]
-              run_tests: [ true ]
-              build_tags: ["unit", "integration"]
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
-      - update_metadata:
-          name: Update metadata for dev branch test runs
-          METADATA_BUCKET: "bacalhau-global-storage"
-          METADATA_FILENAME: "LAST-TEST-RUNS-METADATA-OBJECT"
-          requires:
-            - test-linux-amd64-unit
-      - coverage:
-          name: Build coverage report
-          requires:
-            - build
+    - build:
+        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          parameters:
+            target_os: ["linux"]
+            target_arch: ["amd64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
+    - update_metadata:
+        name: Update metadata for dev branch test runs
+        METADATA_BUCKET: "bacalhau-global-storage"
+        METADATA_FILENAME: "LAST-TEST-RUNS-METADATA-OBJECT"
+        requires:
+        - test-linux-amd64-unit
+    - coverage:
+        name: Build coverage report
+        requires:
+        - build
 
   test_linux_arm64:
     jobs:
-      - build:
-          name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            parameters:
-              target_os: [ "linux" ]
-              target_arch: [ "arm64" ]
-              run_tests: [ true ]
-              build_tags: [ "unit", "integration" ]
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+    - build:
+        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          parameters:
+            target_os: ["linux"]
+            target_arch: ["arm64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   test_linux_armv6:
     jobs:
-      - build:
-          name: test-linux-armv6
-          executor: linux-arm64
-          target_os: linux
-          target_arch: armv6
-          run_tests: false
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+    - build:
+        name: test-linux-armv6
+        executor: linux-arm64
+        target_os: linux
+        target_arch: armv6
+        run_tests: false
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   test_linux_armv7:
     jobs:
-      - build:
-          name: test-linux-armv7
-          executor: linux-arm64
-          target_os: linux
-          target_arch: armv7
-          run_tests: false
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+    - build:
+        name: test-linux-armv7
+        executor: linux-arm64
+        target_os: linux
+        target_arch: armv7
+        run_tests: false
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   test_darwin_amd64:
     jobs:
-      - build:
-          name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            parameters:
-              target_os: [ "darwin" ]
-              target_arch: [ "amd64" ]
-              run_tests: [ true ]
-              build_tags: [ "unit", "integration" ]
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+    - build:
+        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          parameters:
+            target_os: ["darwin"]
+            target_arch: ["amd64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   test_darwin_arm64:
     jobs:
-      - build:
-          name: test-darwin-arm64
-          executor: darwin-amd64
-          target_os: darwin
-          target_arch: arm64
-          run_tests: false
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+    - build:
+        name: test-darwin-arm64
+        executor: darwin-amd64
+        target_os: darwin
+        target_arch: arm64
+        run_tests: false
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   test_windows_amd64:
     jobs:
-      - build:
-          name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            parameters:
-              target_os: [ "windows" ]
-              target_arch: [ "amd64" ]
-              run_tests: [ true ]
-              build_tags: ["unit", "integration"]
-          filters:
-            branches:
-              ignore: main
-            tags:
-              ignore: /.*/
+    - build:
+        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          parameters:
+            target_os: ["windows"]
+            target_arch: ["amd64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
+        filters:
+          branches:
+            ignore: main
+          tags:
+            ignore: /.*/
 
   main_only: # This workflow will only run on 'main' and will not run on tags
     jobs:
-      - build:
-          name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            alias: build-generic
-            parameters:
-              target_os: ["linux", "darwin"]
-              target_arch: ["amd64", "arm64"]
-              run_tests: [true]
-              build_tags: ["unit", "integration"]
-            exclude:
-              - target_os: "darwin"
-                target_arch: "arm64"
-                run_tests: true
-                build_tags: "unit"
-              - target_os: "darwin"
-                target_arch: "arm64"
-                run_tests: true
-                build_tags: "integration"
-          filters:
-            &filters_main_only # this yaml anchor is setting these values to "filters_main_only"
-            branches:
-              only: main
-            tags:
-              ignore: /.*/
-      - build:
-          name: build-darwin-arm64
-          executor: darwin-amd64
-          target_os: darwin
-          target_arch: arm64
-          run_tests: false
-          filters: *filters_main_only
-      - build:
-          name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            alias: build-windows
-            parameters:
-              target_os: ["windows"]
-              target_arch: ["amd64"]
-              run_tests: [true]
-              build_tags: ["unit", "integration"]
-          filters: *filters_main_only
-      - build:
-          name: build-linux-<< matrix.target_arch >>
-          executor: linux-arm64
-          target_os: linux
-          run_tests: false
-          matrix:
-            alias: build-arm
-            parameters:
-              target_arch: ["armv6", "armv7"]
-          filters: *filters_main_only
-      - update_metadata:
-          name: Update metadata for main test runs
-          requires:
-            - build-linux-amd64-unit
-          METADATA_BUCKET: "bacalhau-global-storage"
-          METADATA_FILENAME: "LAST-TEST-RUNS-METADATA-OBJECT"
-      - coverage:
-          name: Build coverage report
-          requires:
-            - build-generic
-            - build-darwin-arm64
-            - build-windows
-            - build-arm
-      - build_swagger:
-          name: build-swagger-spec
-          filters: *filters_main_only
-      - build_python_packages:
-          name: build-python-packages
-          requires:
-            - build-swagger-spec
-          filters: *filters_main_only
+    - build:
+        name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          alias: build-generic
+          parameters:
+            target_os: ["linux", "darwin"]
+            target_arch: ["amd64", "arm64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
+          exclude:
+          - target_os: "darwin"
+            target_arch: "arm64"
+            run_tests: true
+            build_tags: "unit"
+          - target_os: "darwin"
+            target_arch: "arm64"
+            run_tests: true
+            build_tags: "integration"
+        filters: &filters_main_only
+          branches: # this yaml anchor is setting these values to "filters_main_only"
+            only: main
+          tags:
+            ignore: /.*/
+    - build:
+        name: build-darwin-arm64
+        executor: darwin-amd64
+        target_os: darwin
+        target_arch: arm64
+        run_tests: false
+        filters: *filters_main_only
+    - build:
+        name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          alias: build-windows
+          parameters:
+            target_os: ["windows"]
+            target_arch: ["amd64"]
+            run_tests: [true]
+            build_tags: ["unit", "integration"]
+        filters: *filters_main_only
+    - build:
+        name: build-linux-<< matrix.target_arch >>
+        executor: linux-arm64
+        target_os: linux
+        run_tests: false
+        matrix:
+          alias: build-arm
+          parameters:
+            target_arch: ["armv6", "armv7"]
+        filters: *filters_main_only
+    - update_metadata:
+        name: Update metadata for main test runs
+        requires:
+        - build-linux-amd64-unit
+        METADATA_BUCKET: "bacalhau-global-storage"
+        METADATA_FILENAME: "LAST-TEST-RUNS-METADATA-OBJECT"
+    - coverage:
+        name: Build coverage report
+        requires:
+        - build-generic
+        - build-darwin-arm64
+        - build-windows
+        - build-arm
+    - build_swagger:
+        name: build-swagger-spec
+        filters: *filters_main_only
+    - build_python_packages:
+        name: build-python-packages
+        requires:
+        - build-swagger-spec
+        filters: *filters_main_only
 
   build_jsonschema: # Runs on new tags starting with 'v.'
     jobs:
-      - build:
-          name: build-linux-amd64
-          executor: linux-amd64
-          target_os: linux
-          target_arch: amd64
-          run_tests: false
-          filters: &filters_tags_only
-            branches:
-              ignore: /.*/ # don't run on any branches - only tags
-            tags:
-              # only run on tags that look like release tags e.g. v0.1.2 or
-              # v0.1.3alpha19 (actually v0.1.3anything...)
-              only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
-      - build_jsonschema_job:
-          name: run-jsonschema-gen-<< pipeline.git.branch >>
-          requires:
-            - build-linux-amd64
-          filters:
-            <<: *filters_tags_only
+    - build:
+        name: build-linux-amd64
+        executor: linux-amd64
+        target_os: linux
+        target_arch: amd64
+        run_tests: false
+        filters: &filters_tags_only
+          branches:
+            ignore: /.*/ # don't run on any branches - only tags
+          tags:
+            # only run on tags that look like release tags e.g. v0.1.2 or
+            # v0.1.3alpha19 (actually v0.1.3anything...)
+            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+    - build_jsonschema_job:
+        name: run-jsonschema-gen-<< pipeline.git.branch >>
+        requires:
+        - build-linux-amd64
+        filters:
+          !!merge <<: *filters_tags_only
 
   tags_only: # This workflow will only run on tags (specifically starting with 'v.') and will not run on branches
     jobs:
-      - build:
-          name: build-<< matrix.target_os >>-<< matrix.target_arch >>
-          executor: << matrix.target_os >>-<< matrix.target_arch >>
-          matrix:
-            alias: build-generic
-            parameters:
-              target_os: ["linux", "darwin", "windows"]
-              target_arch: ["amd64", "arm64"]
-              run_tests: [false]
-            exclude:
-              - target_os: windows
-                target_arch: arm64
-                run_tests: false
-              - target_os: darwin
-                target_arch: arm64
-                run_tests: false
-          filters: *filters_tags_only
-      - build:
-          name: build-darwin-arm64
-          executor: darwin-amd64
-          target_os: darwin
-          target_arch: arm64
-          run_tests: false
-          filters: *filters_tags_only
-      - build:
-          name: build-linux-<< matrix.target_arch >>
-          executor: linux-arm64
-          target_os: linux
-          run_tests: false
-          matrix:
-            alias: build-arm
-            parameters:
-              target_arch: ["armv6", "armv7"]
-          filters: *filters_tags_only
-      - release:
-          name: release-all-binaries
-          requires:
-            - build-generic
-            - build-darwin-arm64
-            - build-arm
-          filters: *filters_tags_only
-      - docker:
-          filters:
-            branches:
-              ignore: /.*/ # don't run on any branches - only tags
-            tags:
-              # only run on tags that STRICTLY look like release tags e.g. v0.1.2,
-              # NOT v0.1.3alpha19 (i.e. only build containers on real releases)
-              only: /^v([0-9]+).([0-9]+).([0-9]+)$/
-      - build_swagger:
-          name: build-swagger-spec
-          filters: *filters_tags_only
-      - build_python_packages:
-          name: build-python-packages
-          requires:
-            - build-swagger-spec
-          filters: *filters_tags_only
-      - release_python:
-          name: release-python-packages
-          requires:
-            - build-swagger-spec
-            - build-python-packages
-          filters: *filters_tags_only
+    - build:
+        name: build-<< matrix.target_os >>-<< matrix.target_arch >>
+        executor: << matrix.target_os >>-<< matrix.target_arch >>
+        matrix:
+          alias: build-generic
+          parameters:
+            target_os: ["linux", "darwin", "windows"]
+            target_arch: ["amd64", "arm64"]
+            run_tests: [false]
+          exclude:
+          - target_os: windows
+            target_arch: arm64
+            run_tests: false
+          - target_os: darwin
+            target_arch: arm64
+            run_tests: false
+        filters: *filters_tags_only
+    - build:
+        name: build-darwin-arm64
+        executor: darwin-amd64
+        target_os: darwin
+        target_arch: arm64
+        run_tests: false
+        filters: *filters_tags_only
+    - build:
+        name: build-linux-<< matrix.target_arch >>
+        executor: linux-arm64
+        target_os: linux
+        run_tests: false
+        matrix:
+          alias: build-arm
+          parameters:
+            target_arch: ["armv6", "armv7"]
+        filters: *filters_tags_only
+    - release:
+        name: release-all-binaries
+        requires:
+        - build-generic
+        - build-darwin-arm64
+        - build-arm
+        filters: *filters_tags_only
+    - docker:
+        filters:
+          branches:
+            ignore: /.*/ # don't run on any branches - only tags
+          tags:
+            # only run on tags that STRICTLY look like release tags e.g. v0.1.2,
+            # NOT v0.1.3alpha19 (i.e. only build containers on real releases)
+            only: /^v([0-9]+).([0-9]+).([0-9]+)$/
+    - build_swagger:
+        name: build-swagger-spec
+        filters: *filters_tags_only
+    - build_python_packages:
+        name: build-python-packages
+        requires:
+        - build-swagger-spec
+        filters: *filters_tags_only
+    - release_python:
+        name: release-python-packages
+        requires:
+        - build-swagger-spec
+        - build-python-packages
+        filters: *filters_tags_only
 
 
   # TODO: Disabling performance until we get a runner up and running again


### PR DESCRIPTION
CircleCI are [deprecating their x86 OSX machines](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718), on the basis that we can then build on arm64 - although there doesn't seem to be a good answer to "how do we test on osx x86?".

Some deprecations are happening in 2 weeks, which this PR hopes to avoid, and will then allow us to continue until the end of Jan 24 at which point x86 will no longer be available.

At the same time this PR switches to building `darwin-arm64` on an M1 machine. Best review by commit as the first contains an auto-format that touches lots of parts other than the actual change at the top.

```
  darwin-amd64:
    # Note - not an actual ARM macOS machine (https://circleci.canny.io/cloud-feature-requests/p/support-new-m1-arm-based-macs)
    macos:
      xcode: 15.1
    resource_class: macos.x86.medium.gen2
```
