### PR TITLE
put job back into default job folder name

### DIFF
--- a/cmd/util/download.go
+++ b/cmd/util/download.go
@@ -112,5 +112,5 @@ func ensureDefaultDownloadLocation(jobID string) (string, error) {
 }
 
 func GetDefaultJobFolder(jobID string) string {
-	return idgen.ShortID(jobID)
+	return fmt.Sprintf("job-%s", idgen.ShortID(jobID))
 }


### PR DESCRIPTION
Makes it easier to clean them all up in one go.