### PR TITLE
ENG-116 Fix downloads when in private internal mode.

### DIFF
--- a/cmd/util/logging.go
+++ b/cmd/util/logging.go
@@ -80,7 +80,7 @@ func Logs(cmd *cobra.Command, jobID string, follow, history bool) error {
 // ApplyPorcelainLogLevel sets the log level of loggers running on user-facing
 // "porcelain" commands to be zerolog.FatalLevel to reduce noise shown to users.
 func ApplyPorcelainLogLevel(cmd *cobra.Command, _ []string) {
-	if _, err := zerolog.ParseLevel(os.Getenv("LOG_LEVEL")); err != nil {
+	if _, err := zerolog.ParseLevel(os.Getenv("LOG_LEVEL")); err == nil {
 		return
 	}
 

--- a/pkg/config/configenv/dev.go
+++ b/pkg/config/configenv/dev.go
@@ -50,9 +50,12 @@ var Development = types.BacalhauConfig{
 		IPFS: types.IpfsConfig{
 			Connect:         "",
 			PrivateInternal: true,
+			// Swarm addresses of the IPFS nodes. Find these by running: `env IPFS_PATH=/data/ipfs ipfs id`.
 			SwarmAddresses: []string{
-				"/ip4/34.88.135.65/tcp/1235/p2p/QmfRDVYnEcPassyJFGQw8Wt4t9QuA843uuKPVNEVNm4Smo",
-				"/ip4/35.228.112.50/tcp/1235/p2p/QmQM1yRXyKGAfFtYpPSy5grHSief3fic6YjLEWQYpmiGTM",
+				"/ip4/34.88.135.65/tcp/4001/p2p/12D3KooWMYUaxS32AucbSN4Y9ae6CPfHcZiLxteAQpbjTBHexG6N",
+				"/ip4/34.88.135.65/udp/4001/quic/p2p/12D3KooWMYUaxS32AucbSN4Y9ae6CPfHcZiLxteAQpbjTBHexG6N",
+				"/ip4/35.228.112.50/tcp/4001/p2p/12D3KooWJE4HiVBbyUp2x3B98xKukKbN76zvU4FN8Uvc1NWZYzHS",
+				"/ip4/35.228.112.50/udp/4001/quic/p2p/12D3KooWJE4HiVBbyUp2x3B98xKukKbN76zvU4FN8Uvc1NWZYzHS",
 			},
 		},
 		Compute:   DevelopmentComputeConfig,

--- a/pkg/config/configenv/production.go
+++ b/pkg/config/configenv/production.go
@@ -51,10 +51,18 @@ var Production = types.BacalhauConfig{
 		IPFS: types.IpfsConfig{
 			Connect:         "",
 			PrivateInternal: true,
+			// Swarm addresses of the IPFS nodes. Find these by running: `env IPFS_PATH=/data/ipfs ipfs id`.
 			SwarmAddresses: []string{
-				"/ip4/35.245.115.191/tcp/1235/p2p/QmdZQ7ZbhnvWY1J12XYKGHApJ6aufKyLNSvf8jZBrBaAVL",
-				"/ip4/35.245.61.251/tcp/1235/p2p/QmXaXu9N5GNetatsvwnTfQqNtSeKAD6uCmarbh3LMRYAcF",
-				"/ip4/35.245.251.239/tcp/1235/p2p/QmYgxZiySj3MRkwLSL4X2MF5F9f2PMhAE3LV49XkfNL1o3",
+				"/ip4/35.245.115.191/tcp/4001/p2p/12D3KooWE4wfAknWtY9mQ4eAA8zrFGeZa7X2Kh4nBP2tZgDSt7Rh",
+				"/ip4/35.245.115.191/udp/4001/quic/p2p/12D3KooWE4wfAknWtY9mQ4eAA8zrFGeZa7X2Kh4nBP2tZgDSt7Rh",
+				"/ip4/35.245.61.251/tcp/4001/p2p/12D3KooWD8zeukHTMyuPtQBoUUPqtEnaA7NwFXWcVywUJtCVPske",
+				"/ip4/35.245.61.251/udp/4001/quic/p2p/12D3KooWD8zeukHTMyuPtQBoUUPqtEnaA7NwFXWcVywUJtCVPske",
+				"/ip4/35.245.251.239/tcp/4001/p2p/12D3KooWAg1YdehZxcZhetcgA6KP8TLGX6Fq4h9PUswnUWoStVNc",
+				"/ip4/35.245.251.239/udp/4001/quic/p2p/12D3KooWAg1YdehZxcZhetcgA6KP8TLGX6Fq4h9PUswnUWoStVNc",
+				"/ip4/34.150.153.87/tcp/4001/p2p/12D3KooWGE4R98vokeLsRVdTv8D6jhMnifo81mm7NMRV8WJPNVHb",
+				"/ip4/34.150.153.87/udp/4001/quic/p2p/12D3KooWGE4R98vokeLsRVdTv8D6jhMnifo81mm7NMRV8WJPNVHb",
+				"/ip4/34.91.247.176/tcp/4001/p2p/12D3KooWSNKPM5PBchoqn774bpQ4j4QbL3VoyX6mH6vTyWXqE3kH",
+				"/ip4/34.91.247.176/udp/4001/quic/p2p/12D3KooWSNKPM5PBchoqn774bpQ4j4QbL3VoyX6mH6vTyWXqE3kH",
 			},
 		},
 		Compute:   ProductionComputeConfig,

--- a/pkg/config/configenv/staging.go
+++ b/pkg/config/configenv/staging.go
@@ -51,10 +51,16 @@ var Staging = types.BacalhauConfig{
 		IPFS: types.IpfsConfig{
 			Connect:         "",
 			PrivateInternal: true,
+			// Swarm addresses of the IPFS nodes. Find these by running: `env IPFS_PATH=/data/ipfs ipfs id`.
 			SwarmAddresses: []string{
-				"/ip4/34.85.197.247/tcp/1235/p2p/QmcWJnVXJ82DKJq8ED79LADR4ZBTnwgTK7yn6JQbNVMbbC",
-				"/ip4/35.245.163.45/tcp/1235/p2p/QmXRdLruWyETS2Z8XFrXxBFYXctfjT8T9mZWyuqwUm6rQk",
-				"/ip4/35.199.63.137/tcp/1235/p2p/QmVXwmdZUHsa88UHRKwQvvapguAXgHxd2uvVEpHrhjchAH",
+				"/ip4/34.85.197.247/tcp/4001/p2p/12D3KooWDaveKrxPZSCrHY2hjsk4pcWVSCE3eUKFotmKWL8nJDZi",
+				"/ip4/34.85.197.247/udp/4001/quic/p2p/12D3KooWDaveKrxPZSCrHY2hjsk4pcWVSCE3eUKFotmKWL8nJDZi",
+				"/ip4/35.245.163.45/tcp/4001/p2p/12D3KooWDzhR9PAsCNc2xY7v6NQJ4oKEmhvpwaxKCS3Jbxw36G3C",
+				"/ip4/35.245.163.45/udp/4001/quic/p2p/12D3KooWDzhR9PAsCNc2xY7v6NQJ4oKEmhvpwaxKCS3Jbxw36G3C",
+				"/ip4/35.199.63.137/tcp/4001/p2p/12D3KooWKFN8bf1yK1n2zXZMUp2NpTcCLn9szcpYiwrrg9YbrKap",
+				"/ip4/35.199.63.137/udp/4001/quic/p2p/12D3KooWKFN8bf1yK1n2zXZMUp2NpTcCLn9szcpYiwrrg9YbrKap",
+				"/ip4/35.188.227.44/tcp/4001/p2p/12D3KooWGzqdeV1oM7voQghTtnwSQmmfadPswTweDTtya6qMJC3j",
+				"/ip4/35.188.227.44/udp/4001/quic/p2p/12D3KooWGzqdeV1oM7voQghTtnwSQmmfadPswTweDTtya6qMJC3j",
 			},
 		},
 		Compute:   StagingComputeConfig,


### PR DESCRIPTION
Private internal mode is used to run an ephemeral IPFS node only for downloading results from jobs. It turns out that the config needs bootstrap nodes to be defined for this to work. This commit keeps the bootstrap nodes in place but applies the other local-only config as per the kubo "test" profile.

Resolves ENG-116.