### PR TITLE
fix: fail CI if go generate results in changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,7 @@ jobs:
             if [[ -n $(git status --porcelain) ]]; then
               echo "Error: changes found after running go generate"
               git status --porcelain
+              git diff
               exit 1
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,20 +334,31 @@ jobs:
           command: |
             make install-pre-commit
 
-      - run:
-          name: Cache Precommit
-          command: |
-            cp .pre-commit-config.yaml pre-commit-cache-key.txt
-            poetry run python --version --version >> pre-commit-cache-key.txt
+      #- run:
+          #name: Cache Precommit
+          #command: |
+            #cp .pre-commit-config.yaml pre-commit-cache-key.txt
+            #poetry run python --version --version >> pre-commit-cache-key.txt
 
       - restore_cache:
           name: Restoring pre-commit cache
           key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
 
       - run:
+          name: Run go generate
+          command: |
+            go generate ./...
+            if [[ -n $(git status --porcelain) ]]; then
+              echo "Error: changes found after running go generate"
+              git status --porcelain
+              exit 1
+            fi
+      - run:
           name: Run linter
           command: |
             make precommit
+
+
 
   performance_job:
     resource_class: bacalhau-project/self-hosted-bacalhau

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ all: build
 
 # Run init repo after cloning it
 .PHONY: init
-init:
+init: generate-tools
 	@ops/repo_init.sh 1>/dev/null
 	@echo "Build environment initialized."
 


### PR DESCRIPTION
- very similar to our go mod tidy check. We need to ensure we have not modified code that requires codegen to be run after the change. e.g. changes to the config structure, or changes to our mocks