### PR TITLE
Fix output volume being added twice

### DIFF
--- a/cmd/util/flags/cliflags/spec.go
+++ b/cmd/util/flags/cliflags/spec.go
@@ -62,7 +62,7 @@ func SpecFlags(settings *SpecFlagSettings) *pflag.FlagSet {
 		"output",
 		"o",
 		settings.OutputVolumes,
-		`name:path of the output data volumes. 'outputs:/outputs' is always added.`,
+		`name:path of the output data volumes`,
 	)
 	flags.StringSliceVarP(
 		&settings.EnvVar,

--- a/cmd/util/parse/parse.go
+++ b/cmd/util/parse/parse.go
@@ -47,8 +47,7 @@ func NodeSelector(nodeSelector string) ([]model.LabelSelectorRequirement, error)
 }
 
 func JobOutputs(ctx context.Context, outputVolumes []string) ([]model.StorageSpec, error) {
-	outputVolumesMap := make(map[string]model.StorageSpec)
-	outputVolumes = append(outputVolumes, "outputs:/outputs")
+	outputVolumesMap := make(map[string]model.StorageSpec, len(outputVolumes))
 
 	for _, outputVolume := range outputVolumes {
 		slices := strings.Split(outputVolume, ":")

--- a/cmd/util/parse/parse_test.go
+++ b/cmd/util/parse/parse_test.go
@@ -1,0 +1,22 @@
+package parse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobOutputsDoesNotAddDefaults(t *testing.T) {
+	specs, err := JobOutputs(context.Background(), []string{})
+	require.NoError(t, err)
+	require.Empty(t, specs)
+}
+
+func TestJobOutputsCreatesCorrectSpec(t *testing.T) {
+	specs, err := JobOutputs(context.Background(), []string{"outputs:/outputs"})
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	require.Equal(t, "outputs", specs[0].Name)
+	require.Equal(t, "/outputs", specs[0].Path)
+}


### PR DESCRIPTION
We don't need to always add the outputs directory – if the user specifies a different directory then we just don't add it. It's only a default.