### PR TITLE
Fix output volume being added twice

### DIFF
--- a/cmd/util/flags/cliflags/spec.go
+++ b/cmd/util/flags/cliflags/spec.go
@@ -62,7 +62,8 @@ func SpecFlags(settings *SpecFlagSettings) *pflag.FlagSet {
 		"output",
 		"o",
 		settings.OutputVolumes,
-		`name:path of the output data volumes. 'outputs:/outputs' is always added.`,
+		`name:path of the output data volumes. `+
+			`'outputs:/outputs' is always added unless '/outputs' is mapped to a different name.`,
 	)
 	flags.StringSliceVarP(
 		&settings.EnvVar,

--- a/cmd/util/parse/parse.go
+++ b/cmd/util/parse/parse.go
@@ -46,9 +46,14 @@ func NodeSelector(nodeSelector string) ([]model.LabelSelectorRequirement, error)
 	return model.ToLabelSelectorRequirements(requirements...), nil
 }
 
+var DefaultOutputSpec = model.StorageSpec{
+	StorageSource: model.StorageSourceIPFS,
+	Name:          "outputs",
+	Path:          "/outputs",
+}
+
 func JobOutputs(ctx context.Context, outputVolumes []string) ([]model.StorageSpec, error) {
-	outputVolumesMap := make(map[string]model.StorageSpec)
-	outputVolumes = append(outputVolumes, "outputs:/outputs")
+	outputVolumesMap := make(map[string]model.StorageSpec, len(outputVolumes)+1)
 
 	for _, outputVolume := range outputVolumes {
 		slices := strings.Split(outputVolume, ":")
@@ -74,6 +79,10 @@ func JobOutputs(ctx context.Context, outputVolumes []string) ([]model.StorageSpe
 			Name:          slices[0],
 			Path:          slices[1],
 		}
+	}
+
+	if _, found := outputVolumesMap[DefaultOutputSpec.Path]; !found {
+		outputVolumesMap[DefaultOutputSpec.Path] = DefaultOutputSpec
 	}
 
 	var returnOutputVolumes []model.StorageSpec

--- a/cmd/util/parse/parse_test.go
+++ b/cmd/util/parse/parse_test.go
@@ -1,0 +1,59 @@
+//go:build unit || !integration
+
+package parse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func outputsContain(specs []model.StorageSpec, name, path string) assert.Comparison {
+	return func() (success bool) {
+		for _, spec := range specs {
+			if spec.Name == name && spec.Path == path {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func TestJobOutputsAddsDefault(t *testing.T) {
+	specs, err := JobOutputs(context.Background(), []string{})
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	require.Equal(t, DefaultOutputSpec, specs[0])
+}
+
+func TestJobOutputDoesNotAddDefaultTwice(t *testing.T) {
+	specs, err := JobOutputs(context.Background(), []string{"test:" + DefaultOutputSpec.Path})
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	require.Equal(t, "test", specs[0].Name)
+	require.Equal(t, DefaultOutputSpec.Path, specs[0].Path)
+}
+
+func TestJobOutputsDoesNotAddPathTwice(t *testing.T) {
+	specs, err := JobOutputs(context.Background(), []string{"a:/a", "b:/a"})
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+	require.Contains(t, specs, DefaultOutputSpec)
+	require.Condition(t, outputsContain(specs, "b", "/a"))
+}
+
+func TestJobOutputsCreatesCorrectSpec(t *testing.T) {
+	specs, err := JobOutputs(context.Background(), []string{"something:/else"})
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+	require.Contains(t, specs, DefaultOutputSpec)
+	require.Condition(t, outputsContain(specs, "something", "/else"))
+}
+
+func TestJobOutputsRejectsInvalidSpecs(t *testing.T) {
+	_, err := JobOutputs(context.Background(), []string{"invalid"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
We don't need to print a warning message if the user has already specified a different outputs directory. We only need to add the directory if `/outputs` isn't already mapped to something.