### PR TITLE
Use correct path when updating legacy local dir storage spec

### DIFF
--- a/pkg/models/migration/legacy/from.go
+++ b/pkg/models/migration/legacy/from.go
@@ -155,7 +155,7 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 		res = &models.SpecConfig{
 			Type: models.StorageSourceLocalDirectory,
 			Params: localdirectory.Source{
-				SourcePath: legacy.Path,
+				SourcePath: legacy.SourcePath,
 				ReadWrite:  legacy.ReadWrite,
 			}.ToMap(),
 		}

--- a/pkg/models/migration/legacy/from.go
+++ b/pkg/models/migration/legacy/from.go
@@ -1,6 +1,7 @@
 package legacy
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -117,6 +118,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 	var res *models.SpecConfig
 	switch legacy.StorageSource {
 	case model.StorageSourceIPFS:
+		if legacy.CID == "" {
+			return nil, errors.New("invalid legacy storage spec - missing CID")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceIPFS,
 			Params: ipfs_storage.Source{
@@ -124,6 +129,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 			}.ToMap(),
 		}
 	case model.StorageSourceURLDownload:
+		if legacy.URL == "" {
+			return nil, errors.New("invalid legacy storage spec - missing URL")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceURL,
 			Params: urldownload.Source{
@@ -131,6 +140,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 			}.ToMap(),
 		}
 	case model.StorageSourceRepoClone:
+		if legacy.Repo == "" {
+			return nil, errors.New("invalid legacy storage spec - missing Repo")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceRepoClone,
 			Params: repo.Source{
@@ -138,6 +151,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 			}.ToMap(),
 		}
 	case model.StorageSourceRepoCloneLFS:
+		if legacy.Repo == "" {
+			return nil, errors.New("invalid legacy storage spec - missing Repo")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceRepoCloneLFS,
 			Params: repo.Source{
@@ -145,6 +162,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 			}.ToMap(),
 		}
 	case model.StorageSourceInline:
+		if legacy.URL == "" {
+			return nil, errors.New("invalid legacy storage spec - missing URL")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceInline,
 			Params: inline.Source{
@@ -152,6 +173,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 			}.ToMap(),
 		}
 	case model.StorageSourceLocalDirectory:
+		if legacy.SourcePath == "" {
+			return nil, errors.New("invalid legacy storage spec - missing SourcePath")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceLocalDirectory,
 			Params: localdirectory.Source{
@@ -160,6 +185,10 @@ func FromLegacyStorageSpec(legacy model.StorageSpec) (*models.SpecConfig, error)
 			}.ToMap(),
 		}
 	case model.StorageSourceS3:
+		if legacy.S3 == nil {
+			return nil, errors.New("invalid legacy storage spec - missing S3 details")
+		}
+
 		res = &models.SpecConfig{
 			Type: models.StorageSourceS3,
 			Params: s3helper.SourceSpec{

--- a/pkg/models/migration/legacy/from_test.go
+++ b/pkg/models/migration/legacy/from_test.go
@@ -1,0 +1,176 @@
+//go:build unit || !integration
+
+package legacy_test
+
+import (
+	"testing"
+
+	_ "github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/model"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/models/migration/legacy"
+	"github.com/stretchr/testify/suite"
+)
+
+type LegacyFromSuite struct {
+	suite.Suite
+}
+
+func TestLegacyFromSuite(t *testing.T) {
+	suite.Run(t, new(LegacyFromSuite))
+}
+
+func (s *LegacyFromSuite) TestLegacyStorageSpec() {
+	testcases := []struct {
+		name        string
+		arg         model.StorageSpec
+		expected    *models.SpecConfig
+		expectError bool
+	}{
+		{
+			name: "ipfs_ok",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceIPFS,
+				CID:           "abcdefghi",
+			},
+			expected: &models.SpecConfig{
+				Type: models.StorageSourceIPFS,
+				Params: map[string]interface{}{
+					"CID": "abcdefghi",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "ipfs_err",
+			arg:         model.StorageSpec{StorageSource: model.StorageSourceIPFS},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "s3_ok",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+				S3: &model.S3StorageSpec{
+					Bucket: "bucket",
+				},
+			},
+			expected: &models.SpecConfig{
+				Type: models.StorageSourceS3,
+				Params: map[string]interface{}{
+					"Bucket":         "bucket",
+					"ChecksumSHA256": "",
+					"Endpoint":       "",
+					"Key":            "",
+					"Region":         "",
+					"VersionID":      "",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "s3_err",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceS3,
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "url_ok",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceURLDownload,
+				URL:           "http://localhost",
+			},
+			expected: &models.SpecConfig{
+				Type: models.StorageSourceURL,
+				Params: map[string]interface{}{
+					"URL": "http://localhost",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "url_err",
+			arg:         model.StorageSpec{StorageSource: model.StorageSourceURLDownload},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "url_err_invalid",
+			arg:  model.StorageSpec{StorageSource: model.StorageSourceURLDownload},
+			expected: &models.SpecConfig{
+				Type: models.StorageSourceURL,
+				Params: map[string]interface{}{
+					"CID": "http://localhost",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "inline_ok",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceInline,
+				URL:           "data://",
+			},
+			expected: &models.SpecConfig{
+				Type: models.StorageSourceInline,
+				Params: map[string]interface{}{
+					"URL": "data://",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "inline_err",
+			arg:         model.StorageSpec{StorageSource: model.StorageSourceURLDownload},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "local_ok",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceLocalDirectory,
+				SourcePath:    "/tmp",
+				ReadWrite:     false,
+			},
+			expected: &models.SpecConfig{
+				Type: models.StorageSourceLocalDirectory,
+				Params: map[string]interface{}{
+					"SourcePath": "/tmp",
+					"ReadWrite":  false,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "local_err",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceLocalDirectory,
+				Path:          "/tmp",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "invalid",
+			arg: model.StorageSpec{
+				StorageSource: model.StorageSourceType(10000),
+			},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			config, err := legacy.FromLegacyStorageSpec(tc.arg)
+			if tc.expectError {
+				s.Require().Error(err)
+				return
+			}
+
+			s.Require().Equal(tc.expected, config)
+		})
+	}
+}


### PR DESCRIPTION
Previously was using target directory for the SpecConfig and so the check whether the folder was in the allowed list never succeeded.

e.g. when running devstack like this 

```
bacalhau devstack --allow-listed-local-paths "/tmp/data"
```

and running a job like this 

```
bacalhau docker run -i src=file:/tmp/data,dst=/inputs/data ubuntu /bin/sh -- -c "ls -al /inputs/data"
```

it would fail as the storage spec would decode the SpecConfig and try to compare `/tmp/data` against `/inputs/data`.

It now does the correct thing.