### PR TITLE
Fix race condition in noop executor

### DIFF
--- a/pkg/executor/noop/executor.go
+++ b/pkg/executor/noop/executor.go
@@ -69,8 +69,9 @@ type handlerResult struct {
 }
 
 func (e *executionHandler) run(ctx context.Context) {
+	defer close(e.done)
+
 	if e.isEmpty {
-		close(e.done)
 		e.result = &handlerResult{
 			err: nil,
 			result: &models.RunCommandResult{
@@ -85,7 +86,6 @@ func (e *executionHandler) run(ctx context.Context) {
 		return
 	}
 	result, err := e.jobHandler(ctx, e.jobID, e.resultsDir)
-	close(e.done)
 	e.result = &handlerResult{
 		err:    err,
 		result: result,


### PR DESCRIPTION
Previously the code was closing the done channel, and then setting the result. Unfortunately, there is a goroutine waiting for the done channel to close to then process the result. Occassionally this fails in tests with a nil pointer error similar as it was doing this...

```go
// in handler
close(e.done)
e.result = {...}

// in executor
case <-handler.done:
     ...
     if handler.result.err != nil
```