### PR TITLE
Experimental: Make cancel call inline rather than a go-routine

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -453,11 +453,10 @@ func (e *BaseExecutor) Cancel(ctx context.Context, state store.LocalExecutionSta
 func (e *BaseExecutor) handleFailure(ctx context.Context, state store.LocalExecutionState, err error, operation string) {
 	execution := state.Execution
 
+	// If there was a call to cancel for this execution, then we must NOT
+	// record a failure as it may trigger a race condition.
 	_, found := e.debugCancelledExecutions[execution.ID]
 	if found {
-		fmt.Println("~~~~~~~~")
-		fmt.Println("NOT handling failure as execution was cancelled")
-		fmt.Println("~~~~~~~~")
 		return
 	}
 

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -448,26 +448,26 @@ func (e *BaseExecutor) Cancel(ctx context.Context, state store.LocalExecutionSta
 }
 
 func (e *BaseExecutor) handleFailure(ctx context.Context, state store.LocalExecutionState, err error, operation string) {
-	execution := state.Execution
-	log.Ctx(ctx).Error().Err(err).Msgf("%s execution %s failed", operation, execution.ID)
-	updateError := e.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
-		ExecutionID: execution.ID,
-		NewState:    store.ExecutionStateFailed,
-		Comment:     err.Error(),
-	})
+	// execution := state.Execution
+	// log.Ctx(ctx).Error().Err(err).Msgf("%s execution %s failed", operation, execution.ID)
+	// updateError := e.store.UpdateExecutionState(ctx, store.UpdateExecutionStateRequest{
+	// 	ExecutionID: execution.ID,
+	// 	NewState:    store.ExecutionStateFailed,
+	// 	Comment:     err.Error(),
+	// })
 
-	if updateError != nil {
-		log.Ctx(ctx).Error().Err(updateError).Msgf("Failed to update execution (%s) state to failed: %s", execution.ID, updateError)
-	} else {
-		e.callback.OnComputeFailure(ctx, ComputeError{
-			ExecutionMetadata: NewExecutionMetadata(execution),
-			RoutingMetadata: RoutingMetadata{
-				SourcePeerID: e.ID,
-				TargetPeerID: state.RequesterNodeID,
-			},
-			Err: err.Error(),
-		})
-	}
+	// if updateError != nil {
+	// 	log.Ctx(ctx).Error().Err(updateError).Msgf("Failed to update execution (%s) state to failed: %s", execution.ID, updateError)
+	// } else {
+	// 	e.callback.OnComputeFailure(ctx, ComputeError{
+	// 		ExecutionMetadata: NewExecutionMetadata(execution),
+	// 		RoutingMetadata: RoutingMetadata{
+	// 			SourcePeerID: e.ID,
+	// 			TargetPeerID: state.RequesterNodeID,
+	// 		},
+	// 		Err: err.Error(),
+	// 	})
+	// }
 }
 
 // compile-time interface check

--- a/pkg/compute/executor_buffer.go
+++ b/pkg/compute/executor_buffer.go
@@ -212,19 +212,16 @@ func (s *ExecutorBuffer) deque() {
 
 func (s *ExecutorBuffer) Cancel(ctx context.Context, localExecutionState store.LocalExecutionState) error {
 	// TODO: Enqueue cancel tasks
-
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Cancel")
 	defer span.End()
 
-	execution := localExecutionState.Execution
-
-	err := s.delegateService.Cancel(ctx, localExecutionState)
-	if err == nil {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-
-		delete(s.running, execution.ID)
+	if err := s.delegateService.Cancel(ctx, localExecutionState); err != nil {
+		return err
 	}
+
+	s.mu.Lock()
+	delete(s.running, localExecutionState.Execution.ID)
+	s.mu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Currently when we call cancel, the executor buffer calls Cancel on the underlying executor inside a go-routine, which potentially introduces a race condition on slow platforms.

This is an experimental PR to see if it materially affects performance, and whether it resolves the race condition on those slow platforms.