### PR TITLE
Provide option to turn on HTTPS for SDK

### DIFF
--- a/python/bacalhau_sdk/config.py
+++ b/python/bacalhau_sdk/config.py
@@ -63,11 +63,15 @@ def init_config():
     # Parse out defaults and override with environment variables if they exist
     # before setting the configuration host.
     u = urlparse(conf.host)
+    api_scheme: str = "http"
+    scheme: str = os.getenv("BACALHAU_HTTPS", "")
+    if scheme:
+        api_scheme = "https"
+
     api_host: str = os.getenv("BACALHAU_API_HOST", u.hostname)
     api_port: str = os.getenv("BACALHAU_API_PORT", str(u.port))
 
-    # TODO: Allow TLS and not just http
-    conf.host = "http://{}:{}".format(api_host, api_port)
+    conf.host = "{}://{}:{}".format(api_scheme, api_host, api_port)
     log.debug("Host is set to: %s", conf.host)
 
     # Remove trailing slash from host

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -102,6 +102,12 @@ def test_init_config():
     assert isinstance(conf, Configuration)
     assert conf.host == "http://bootstrap.production.bacalhau.org:1234"
 
+    os.environ["BACALHAU_HTTPS"] = "1"
+    conf = init_config()
+    assert isinstance(conf, Configuration)
+    assert conf.host == "https://bootstrap.production.bacalhau.org:1234"
+    os.environ["BACALHAU_HTTPS"]
+
     os.environ["BACALHAU_API_HOST"] = "1.1.1.1"
     os.environ["BACALHAU_API_PORT"] = "9999"
     conf = init_config()

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -106,7 +106,7 @@ def test_init_config():
     conf = init_config()
     assert isinstance(conf, Configuration)
     assert conf.host == "https://bootstrap.production.bacalhau.org:1234"
-    os.environ["BACALHAU_HTTPS"]
+    del os.environ["BACALHAU_HTTPS"]
 
     os.environ["BACALHAU_API_HOST"] = "1.1.1.1"
     os.environ["BACALHAU_API_PORT"] = "9999"


### PR DESCRIPTION
Currently the use of http is hard-coded.  This minimal change allows the user to specify the use of HTTPS by setting the `BACALHAU_HTTPS` environment variable - leaving the default as http to avoid breakage.

When breaking changes make sense, we should move to specifying the scheme as part of the API_HOST and default to https, but for now this ensures users can continue to use the SDK without immediate breakage.
