### PR TITLE
fix migration of new jobs submitted with local directory

### DIFF
--- a/pkg/models/migration/legacy/to.go
+++ b/pkg/models/migration/legacy/to.go
@@ -160,11 +160,14 @@ func ToLegacyStorageSpec(storage *models.SpecConfig) (model.StorageSpec, error) 
 			URL:           storage.Params["URL"].(string),
 		}, nil
 	case models.StorageSourceLocalDirectory:
-		return model.StorageSpec{
+		storageSpec := model.StorageSpec{
 			StorageSource: model.StorageSourceLocalDirectory,
 			Path:          storage.Params["SourcePath"].(string),
-			ReadWrite:     storage.Params["ReadWrite"].(bool),
-		}, nil
+		}
+		if storage.Params["ReadWrite"] != nil {
+			storageSpec.ReadWrite = storage.Params["ReadWrite"].(bool)
+		}
+		return storageSpec, nil
 	case models.StorageSourceS3:
 		s3Spec := &model.S3StorageSpec{
 			Bucket: storage.Params["Bucket"].(string),


### PR DESCRIPTION
localDirectory storage source allows an optional parameters ReadWrite, but handling and migrating a job spec where ReadWrite is not passed fails with nil pointer exception. This PR fixes that