### PR TITLE
Changes the Publisher interface to take an Execution rather than an ExecutionID

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -405,7 +405,7 @@ func (e *BaseExecutor) publish(ctx context.Context, localExecutionState store.Lo
 		err = fmt.Errorf("failed to get publisher %s: %w", execution.Job.Task().Publisher.Type, err)
 		return
 	}
-	publishedResult, err = jobPublisher.PublishResult(ctx, *execution, *execution.Job, resultFolder)
+	publishedResult, err = jobPublisher.PublishResult(ctx, execution, resultFolder)
 	if err != nil {
 		err = fmt.Errorf("failed to publish result: %w", err)
 		return

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -405,7 +405,7 @@ func (e *BaseExecutor) publish(ctx context.Context, localExecutionState store.Lo
 		err = fmt.Errorf("failed to get publisher %s: %w", execution.Job.Task().Publisher.Type, err)
 		return
 	}
-	publishedResult, err = jobPublisher.PublishResult(ctx, execution.ID, *execution.Job, resultFolder)
+	publishedResult, err = jobPublisher.PublishResult(ctx, *execution, *execution.Job, resultFolder)
 	if err != nil {
 		err = fmt.Errorf("failed to publish result: %w", err)
 		return

--- a/pkg/publisher/fanout/publisher.go
+++ b/pkg/publisher/fanout/publisher.go
@@ -136,7 +136,7 @@ func (f *fanoutPublisher) ValidateJob(ctx context.Context, j models.Job) error {
 // PublishResult implements publisher.Publisher
 func (f *fanoutPublisher) PublishResult(
 	ctx context.Context,
-	executionID string,
+	execution models.Execution,
 	job models.Job,
 	resultPath string,
 ) (models.SpecConfig, error) {
@@ -144,7 +144,7 @@ func (f *fanoutPublisher) PublishResult(
 	ctx = log.Ctx(ctx).With().Str("Method", "PublishResult").Logger().WithContext(ctx)
 
 	valueChannel, errorChannel := fanout(ctx, f.publishers, func(p publisher.Publisher) (models.SpecConfig, error) {
-		return p.PublishResult(ctx, executionID, job, resultPath)
+		return p.PublishResult(ctx, execution, job, resultPath)
 	})
 
 	timeoutChannel := make(chan bool, 1)

--- a/pkg/publisher/fanout/publisher.go
+++ b/pkg/publisher/fanout/publisher.go
@@ -136,15 +136,14 @@ func (f *fanoutPublisher) ValidateJob(ctx context.Context, j models.Job) error {
 // PublishResult implements publisher.Publisher
 func (f *fanoutPublisher) PublishResult(
 	ctx context.Context,
-	execution models.Execution,
-	job models.Job,
+	execution *models.Execution,
 	resultPath string,
 ) (models.SpecConfig, error) {
 	var err error
 	ctx = log.Ctx(ctx).With().Str("Method", "PublishResult").Logger().WithContext(ctx)
 
 	valueChannel, errorChannel := fanout(ctx, f.publishers, func(p publisher.Publisher) (models.SpecConfig, error) {
-		return p.PublishResult(ctx, execution, job, resultPath)
+		return p.PublishResult(ctx, execution, resultPath)
 	})
 
 	timeoutChannel := make(chan bool, 1)

--- a/pkg/publisher/fanout/publisher_test.go
+++ b/pkg/publisher/fanout/publisher_test.go
@@ -78,7 +78,7 @@ func (m *FakePublisher) ValidateJob(context.Context, models.Job) error {
 }
 
 // PublishResult implements publisher.Publisher
-func (m *FakePublisher) PublishResult(context.Context, models.Execution, models.Job, string) (models.SpecConfig, error) {
+func (m *FakePublisher) PublishResult(context.Context, *models.Execution, string) (models.SpecConfig, error) {
 	time.Sleep(m.sleepTime)
 	return m.PublishedResult, m.PublishedResultErr
 }
@@ -131,7 +131,7 @@ func runTestCase(t *testing.T, name string, testCase fanoutTestCase) {
 		require.Equal(t, testCase.expectPublisher.isInstalled, result)
 	})
 	t.Run(name+"/PublishResult", func(t *testing.T) {
-		result, err := testCase.publisher.PublishResult(context.Background(), models.Execution{}, models.Job{}, "")
+		result, err := testCase.publisher.PublishResult(context.Background(), &models.Execution{}, "")
 		require.Equal(t, testCase.expectPublisher.PublishedResultErr == nil, err == nil, err)
 		require.Equal(t, testCase.expectPublisher.PublishedResult, result)
 	})

--- a/pkg/publisher/fanout/publisher_test.go
+++ b/pkg/publisher/fanout/publisher_test.go
@@ -78,7 +78,7 @@ func (m *FakePublisher) ValidateJob(context.Context, models.Job) error {
 }
 
 // PublishResult implements publisher.Publisher
-func (m *FakePublisher) PublishResult(context.Context, string, models.Job, string) (models.SpecConfig, error) {
+func (m *FakePublisher) PublishResult(context.Context, models.Execution, models.Job, string) (models.SpecConfig, error) {
 	time.Sleep(m.sleepTime)
 	return m.PublishedResult, m.PublishedResultErr
 }
@@ -131,7 +131,7 @@ func runTestCase(t *testing.T, name string, testCase fanoutTestCase) {
 		require.Equal(t, testCase.expectPublisher.isInstalled, result)
 	})
 	t.Run(name+"/PublishResult", func(t *testing.T) {
-		result, err := testCase.publisher.PublishResult(context.Background(), "", models.Job{}, "")
+		result, err := testCase.publisher.PublishResult(context.Background(), models.Execution{}, models.Job{}, "")
 		require.Equal(t, testCase.expectPublisher.PublishedResultErr == nil, err == nil, err)
 		require.Equal(t, testCase.expectPublisher.PublishedResult, result)
 	})

--- a/pkg/publisher/ipfs/publisher.go
+++ b/pkg/publisher/ipfs/publisher.go
@@ -43,8 +43,7 @@ func (publisher *IPFSPublisher) ValidateJob(ctx context.Context, j models.Job) e
 
 func (publisher *IPFSPublisher) PublishResult(
 	ctx context.Context,
-	execution models.Execution,
-	j models.Job,
+	execution *models.Execution,
 	resultPath string,
 ) (models.SpecConfig, error) {
 	cid, err := publisher.IPFSClient.Put(ctx, resultPath)

--- a/pkg/publisher/ipfs/publisher.go
+++ b/pkg/publisher/ipfs/publisher.go
@@ -43,7 +43,7 @@ func (publisher *IPFSPublisher) ValidateJob(ctx context.Context, j models.Job) e
 
 func (publisher *IPFSPublisher) PublishResult(
 	ctx context.Context,
-	executionID string,
+	execution models.Execution,
 	j models.Job,
 	resultPath string,
 ) (models.SpecConfig, error) {

--- a/pkg/publisher/noop/publisher.go
+++ b/pkg/publisher/noop/publisher.go
@@ -9,10 +9,10 @@ import (
 
 type PublisherHandlerIsInstalled func(ctx context.Context) (bool, error)
 type PublisherHandlerPublishResult func(
-	ctx context.Context, executionID string, job models.Job, resultPath string) (models.SpecConfig, error)
+	ctx context.Context, execution models.Execution, job models.Job, resultPath string) (models.SpecConfig, error)
 
 func ErrorResultPublisher(err error) PublisherHandlerPublishResult {
-	return func(ctx context.Context, executionID string, job models.Job, resultPath string) (models.SpecConfig, error) {
+	return func(ctx context.Context, execution models.Execution, job models.Job, resultPath string) (models.SpecConfig, error) {
 		return models.SpecConfig{}, err
 	}
 }
@@ -52,9 +52,9 @@ func (publisher *NoopPublisher) ValidateJob(ctx context.Context, j models.Job) e
 }
 
 func (publisher *NoopPublisher) PublishResult(
-	ctx context.Context, executionID string, job models.Job, resultPath string) (models.SpecConfig, error) {
+	ctx context.Context, execution models.Execution, job models.Job, resultPath string) (models.SpecConfig, error) {
 	if publisher.externalHooks.PublishResult != nil {
-		return publisher.externalHooks.PublishResult(ctx, executionID, job, resultPath)
+		return publisher.externalHooks.PublishResult(ctx, execution, job, resultPath)
 	}
 	return models.SpecConfig{}, nil
 }

--- a/pkg/publisher/noop/publisher.go
+++ b/pkg/publisher/noop/publisher.go
@@ -9,10 +9,10 @@ import (
 
 type PublisherHandlerIsInstalled func(ctx context.Context) (bool, error)
 type PublisherHandlerPublishResult func(
-	ctx context.Context, execution models.Execution, job models.Job, resultPath string) (models.SpecConfig, error)
+	ctx context.Context, execution *models.Execution, resultPath string) (models.SpecConfig, error)
 
 func ErrorResultPublisher(err error) PublisherHandlerPublishResult {
-	return func(ctx context.Context, execution models.Execution, job models.Job, resultPath string) (models.SpecConfig, error) {
+	return func(ctx context.Context, execution *models.Execution, resultPath string) (models.SpecConfig, error) {
 		return models.SpecConfig{}, err
 	}
 }
@@ -52,9 +52,9 @@ func (publisher *NoopPublisher) ValidateJob(ctx context.Context, j models.Job) e
 }
 
 func (publisher *NoopPublisher) PublishResult(
-	ctx context.Context, execution models.Execution, job models.Job, resultPath string) (models.SpecConfig, error) {
+	ctx context.Context, execution *models.Execution, resultPath string) (models.SpecConfig, error) {
 	if publisher.externalHooks.PublishResult != nil {
-		return publisher.externalHooks.PublishResult(ctx, execution, job, resultPath)
+		return publisher.externalHooks.PublishResult(ctx, execution, resultPath)
 	}
 	return models.SpecConfig{}, nil
 }

--- a/pkg/publisher/s3/publisher.go
+++ b/pkg/publisher/s3/publisher.go
@@ -48,7 +48,7 @@ func (publisher *Publisher) ValidateJob(_ context.Context, j models.Job) error {
 
 func (publisher *Publisher) PublishResult(
 	ctx context.Context,
-	executionID string,
+	execution models.Execution,
 	j models.Job,
 	resultPath string,
 ) (models.SpecConfig, error) {
@@ -58,20 +58,20 @@ func (publisher *Publisher) PublishResult(
 	}
 
 	if spec.Compress {
-		return publisher.publishArchive(ctx, spec, executionID, j, resultPath)
+		return publisher.publishArchive(ctx, spec, execution, j, resultPath)
 	}
-	return publisher.publishDirectory(ctx, spec, executionID, j, resultPath)
+	return publisher.publishDirectory(ctx, spec, execution, j, resultPath)
 }
 
 func (publisher *Publisher) publishArchive(
 	ctx context.Context,
 	spec s3helper.PublisherSpec,
-	executionID string,
+	execution models.Execution,
 	j models.Job,
 	resultPath string,
 ) (models.SpecConfig, error) {
 	client := publisher.clientProvider.GetClient(spec.Endpoint, spec.Region)
-	key := ParsePublishedKey(spec.Key, executionID, j, true)
+	key := ParsePublishedKey(spec.Key, execution, j, true)
 
 	// Create a new GZIP writer that writes to the file.
 	targetFile, err := os.CreateTemp(publisher.localDir, "bacalhau-archive-*.tar.gz")
@@ -120,12 +120,12 @@ func (publisher *Publisher) publishArchive(
 func (publisher *Publisher) publishDirectory(
 	ctx context.Context,
 	spec s3helper.PublisherSpec,
-	executionID string,
+	execution models.Execution,
 	j models.Job,
 	resultPath string,
 ) (models.SpecConfig, error) {
 	client := publisher.clientProvider.GetClient(spec.Endpoint, spec.Region)
-	key := ParsePublishedKey(spec.Key, executionID, j, false)
+	key := ParsePublishedKey(spec.Key, execution, j, false)
 
 	// Walk the directory tree and upload each file to S3.
 	err := filepath.Walk(resultPath, func(path string, info os.FileInfo, err error) error {

--- a/pkg/publisher/s3/publisher.go
+++ b/pkg/publisher/s3/publisher.go
@@ -48,30 +48,28 @@ func (publisher *Publisher) ValidateJob(_ context.Context, j models.Job) error {
 
 func (publisher *Publisher) PublishResult(
 	ctx context.Context,
-	execution models.Execution,
-	j models.Job,
+	execution *models.Execution,
 	resultPath string,
 ) (models.SpecConfig, error) {
-	spec, err := s3helper.DecodePublisherSpec(j.Task().Publisher)
+	spec, err := s3helper.DecodePublisherSpec(execution.Job.Task().Publisher)
 	if err != nil {
 		return models.SpecConfig{}, err
 	}
 
 	if spec.Compress {
-		return publisher.publishArchive(ctx, spec, execution, j, resultPath)
+		return publisher.publishArchive(ctx, spec, execution, resultPath)
 	}
-	return publisher.publishDirectory(ctx, spec, execution, j, resultPath)
+	return publisher.publishDirectory(ctx, spec, execution, resultPath)
 }
 
 func (publisher *Publisher) publishArchive(
 	ctx context.Context,
 	spec s3helper.PublisherSpec,
-	execution models.Execution,
-	j models.Job,
+	execution *models.Execution,
 	resultPath string,
 ) (models.SpecConfig, error) {
 	client := publisher.clientProvider.GetClient(spec.Endpoint, spec.Region)
-	key := ParsePublishedKey(spec.Key, execution, j, true)
+	key := ParsePublishedKey(spec.Key, execution, true)
 
 	// Create a new GZIP writer that writes to the file.
 	targetFile, err := os.CreateTemp(publisher.localDir, "bacalhau-archive-*.tar.gz")
@@ -120,12 +118,11 @@ func (publisher *Publisher) publishArchive(
 func (publisher *Publisher) publishDirectory(
 	ctx context.Context,
 	spec s3helper.PublisherSpec,
-	execution models.Execution,
-	j models.Job,
+	execution *models.Execution,
 	resultPath string,
 ) (models.SpecConfig, error) {
 	client := publisher.clientProvider.GetClient(spec.Endpoint, spec.Region)
-	key := ParsePublishedKey(spec.Key, execution, j, false)
+	key := ParsePublishedKey(spec.Key, execution, false)
 
 	// Walk the directory tree and upload each file to S3.
 	err := filepath.Walk(resultPath, func(path string, info os.FileInfo, err error) error {

--- a/pkg/publisher/s3/publisher_test.go
+++ b/pkg/publisher/s3/publisher_test.go
@@ -89,7 +89,7 @@ func (s *PublisherTestSuite) TestDateSubstitution() {
 		}.ToMap(),
 	}
 
-	str := ParsePublishedKey("{date}/{time}", "e1", *job, false)
+	str := ParsePublishedKey("{date}/{time}", models.Execution{ID: "e1"}, *job, false)
 	parts := strings.Split(str, "/")
 
 	n := time.Now()
@@ -327,7 +327,7 @@ func (s *PublisherTestSuite) publish(ctx context.Context, publisherConfig s3help
 		Type:   models.PublisherS3,
 		Params: publisherConfig.ToMap(),
 	}
-	return s.publisher.PublishResult(ctx, executionID, *job, resultPath)
+	return s.publisher.PublishResult(ctx, models.Execution{}, *job, resultPath)
 }
 
 func (s *PublisherTestSuite) equalS3Content(expected string, uploaded s3helper.SourceSpec, suffix string) {

--- a/pkg/publisher/s3/publisher_test.go
+++ b/pkg/publisher/s3/publisher_test.go
@@ -327,7 +327,7 @@ func (s *PublisherTestSuite) publish(ctx context.Context, publisherConfig s3help
 		Type:   models.PublisherS3,
 		Params: publisherConfig.ToMap(),
 	}
-	return s.publisher.PublishResult(ctx, models.Execution{}, *job, resultPath)
+	return s.publisher.PublishResult(ctx, models.Execution{ID: executionID}, *job, resultPath)
 }
 
 func (s *PublisherTestSuite) equalS3Content(expected string, uploaded s3helper.SourceSpec, suffix string) {

--- a/pkg/publisher/s3/publisher_test.go
+++ b/pkg/publisher/s3/publisher_test.go
@@ -89,7 +89,7 @@ func (s *PublisherTestSuite) TestDateSubstitution() {
 		}.ToMap(),
 	}
 
-	str := ParsePublishedKey("{date}/{time}", models.Execution{ID: "e1"}, *job, false)
+	str := ParsePublishedKey("{date}/{time}", &models.Execution{ID: "e1", Job: job}, false)
 	parts := strings.Split(str, "/")
 
 	n := time.Now()
@@ -327,7 +327,7 @@ func (s *PublisherTestSuite) publish(ctx context.Context, publisherConfig s3help
 		Type:   models.PublisherS3,
 		Params: publisherConfig.ToMap(),
 	}
-	return s.publisher.PublishResult(ctx, models.Execution{ID: executionID}, *job, resultPath)
+	return s.publisher.PublishResult(ctx, &models.Execution{ID: executionID, Job: job}, resultPath)
 }
 
 func (s *PublisherTestSuite) equalS3Content(expected string, uploaded s3helper.SourceSpec, suffix string) {

--- a/pkg/publisher/s3/utils.go
+++ b/pkg/publisher/s3/utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 )
 
-func ParsePublishedKey(key string, executionID string, job models.Job, archive bool) string {
+func ParsePublishedKey(key string, execution models.Execution, job models.Job, archive bool) string {
 	if archive && !strings.HasSuffix(key, ".tar.gz") {
 		key = key + ".tar.gz"
 	}
@@ -20,7 +20,8 @@ func ParsePublishedKey(key string, executionID string, job models.Job, archive b
 		key = key + "/"
 	}
 
-	key = strings.ReplaceAll(key, "{executionID}", executionID)
+	key = strings.ReplaceAll(key, "{nodeID}", execution.NodeID)
+	key = strings.ReplaceAll(key, "{executionID}", execution.ID)
 	key = strings.ReplaceAll(key, "{jobID}", job.ID)
 	key = strings.ReplaceAll(key, "{date}", time.Now().Format("20060102"))
 	key = strings.ReplaceAll(key, "{time}", time.Now().Format("150405"))

--- a/pkg/publisher/s3/utils.go
+++ b/pkg/publisher/s3/utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 )
 
-func ParsePublishedKey(key string, execution models.Execution, job models.Job, archive bool) string {
+func ParsePublishedKey(key string, execution *models.Execution, archive bool) string {
 	if archive && !strings.HasSuffix(key, ".tar.gz") {
 		key = key + ".tar.gz"
 	}
@@ -22,7 +22,7 @@ func ParsePublishedKey(key string, execution models.Execution, job models.Job, a
 
 	key = strings.ReplaceAll(key, "{nodeID}", execution.NodeID)
 	key = strings.ReplaceAll(key, "{executionID}", execution.ID)
-	key = strings.ReplaceAll(key, "{jobID}", job.ID)
+	key = strings.ReplaceAll(key, "{jobID}", execution.Job.ID)
 	key = strings.ReplaceAll(key, "{date}", time.Now().Format("20060102"))
 	key = strings.ReplaceAll(key, "{time}", time.Now().Format("150405"))
 	return key

--- a/pkg/publisher/tracing/tracing.go
+++ b/pkg/publisher/tracing/tracing.go
@@ -34,12 +34,12 @@ func (t *tracingPublisher) ValidateJob(ctx context.Context, j models.Job) error 
 }
 
 func (t *tracingPublisher) PublishResult(
-	ctx context.Context, execution models.Execution, j models.Job, resultPath string,
+	ctx context.Context, execution *models.Execution, resultPath string,
 ) (models.SpecConfig, error) {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.PublishResult", t.name))
 	defer span.End()
 
-	return t.delegate.PublishResult(ctx, execution, j, resultPath)
+	return t.delegate.PublishResult(ctx, execution, resultPath)
 }
 
 var _ publisher.Publisher = &tracingPublisher{}

--- a/pkg/publisher/tracing/tracing.go
+++ b/pkg/publisher/tracing/tracing.go
@@ -34,12 +34,12 @@ func (t *tracingPublisher) ValidateJob(ctx context.Context, j models.Job) error 
 }
 
 func (t *tracingPublisher) PublishResult(
-	ctx context.Context, executionID string, j models.Job, resultPath string,
+	ctx context.Context, execution models.Execution, j models.Job, resultPath string,
 ) (models.SpecConfig, error) {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.PublishResult", t.name))
 	defer span.End()
 
-	return t.delegate.PublishResult(ctx, executionID, j, resultPath)
+	return t.delegate.PublishResult(ctx, execution, j, resultPath)
 }
 
 var _ publisher.Publisher = &tracingPublisher{}

--- a/pkg/publisher/types.go
+++ b/pkg/publisher/types.go
@@ -30,7 +30,7 @@ type Publisher interface {
 	// (e.g. notify slack)
 	PublishResult(
 		ctx context.Context,
-		executionID string,
+		execution models.Execution,
 		job models.Job,
 		resultPath string,
 	) (models.SpecConfig, error)

--- a/pkg/publisher/types.go
+++ b/pkg/publisher/types.go
@@ -30,8 +30,7 @@ type Publisher interface {
 	// (e.g. notify slack)
 	PublishResult(
 		ctx context.Context,
-		execution models.Execution,
-		job models.Job,
+		execution *models.Execution,
 		resultPath string,
 	) (models.SpecConfig, error)
 }


### PR DESCRIPTION
PublishResults requires an executionID as a parameter, and so this PR changes it to accept an Execution instead, allowing for better substitutions elewhere (e.g. nodeID in s3 prefix)