### PR TITLE
fix: separate flags for compute & requester job selection

### DIFF
--- a/cmd/util/flags/configflags/job_selection.go
+++ b/cmd/util/flags/configflags/job_selection.go
@@ -3,34 +3,72 @@ package configflags
 import "github.com/bacalhau-project/bacalhau/pkg/config/types"
 
 var JobSelectionFlags = []Definition{
+	//
+	// Requester Job Selection Policy
+	//
+	// TODO: https://github.com/bacalhau-project/bacalhau/issues/2929
+	// The flags are currently settable on the requester, however the requester does not support a JobSelectionPolicy
+	// setting the flags is a noop until the above issue is fixed.
 	{
-		FlagName:     "job-selection-data-locality",
+		FlagName:     "requester-job-selection-data-locality",
 		ConfigPath:   types.NodeRequesterJobSelectionPolicyLocality,
 		DefaultValue: Default.Node.Requester.JobSelectionPolicy.Locality,
 		Description:  `Only accept jobs that reference data we have locally ("local") or anywhere ("anywhere").`,
 	},
 	{
-		FlagName:     "job-selection-reject-stateless",
+		FlagName:     "requester-job-selection-reject-stateless",
 		ConfigPath:   types.NodeRequesterJobSelectionPolicyRejectStatelessJobs,
 		DefaultValue: Default.Node.Requester.JobSelectionPolicy.RejectStatelessJobs,
 		Description:  `Reject jobs that don't specify any data.`,
 	},
 	{
-		FlagName:     "job-selection-accept-networked",
+		FlagName:     "requester-job-selection-accept-networked",
 		ConfigPath:   types.NodeRequesterJobSelectionPolicyAcceptNetworkedJobs,
 		DefaultValue: Default.Node.Requester.JobSelectionPolicy.AcceptNetworkedJobs,
 		Description:  `Accept jobs that require network access.`,
 	},
 	{
-		FlagName:     "job-selection-probe-http",
+		FlagName:     "requester-job-selection-probe-http",
 		ConfigPath:   types.NodeRequesterJobSelectionPolicyProbeHTTP,
 		DefaultValue: Default.Node.Requester.JobSelectionPolicy.ProbeHTTP,
 		Description:  `Use the result of a HTTP POST to decide if we should take on the job.`,
 	},
 	{
-		FlagName:     "job-selection-probe-exec",
+		FlagName:     "requester-job-selection-probe-exec",
 		ConfigPath:   types.NodeRequesterJobSelectionPolicyProbeExec,
 		DefaultValue: Default.Node.Requester.JobSelectionPolicy.ProbeExec,
+		Description:  `Use the result of a exec an external program to decide if we should take on the job.`,
+	},
+	//
+	// Compute Job Selection Policy
+	{
+		FlagName:     "compute-job-selection-data-locality",
+		ConfigPath:   types.NodeComputeJobSelectionLocality,
+		DefaultValue: Default.Node.Compute.JobSelection.Locality,
+		Description:  `Only accept jobs that reference data we have locally ("local") or anywhere ("anywhere").`,
+	},
+	{
+		FlagName:     "compute-job-selection-reject-stateless",
+		ConfigPath:   types.NodeComputeJobSelectionRejectStatelessJobs,
+		DefaultValue: Default.Node.Compute.JobSelection.RejectStatelessJobs,
+		Description:  `Reject jobs that don't specify any data.`,
+	},
+	{
+		FlagName:     "compute-job-selection-accept-networked",
+		ConfigPath:   types.NodeComputeJobSelectionAcceptNetworkedJobs,
+		DefaultValue: Default.Node.Compute.JobSelection.AcceptNetworkedJobs,
+		Description:  `Accept jobs that require network access.`,
+	},
+	{
+		FlagName:     "compute-job-selection-probe-http",
+		ConfigPath:   types.NodeComputeJobSelectionProbeHTTP,
+		DefaultValue: Default.Node.Compute.JobSelection.ProbeHTTP,
+		Description:  `Use the result of a HTTP POST to decide if we should take on the job.`,
+	},
+	{
+		FlagName:     "compute-job-selection-probe-exec",
+		ConfigPath:   types.NodeComputeJobSelectionProbeExec,
+		DefaultValue: Default.Node.Compute.JobSelection.ProbeExec,
 		Description:  `Use the result of a exec an external program to decide if we should take on the job.`,
 	},
 }


### PR DESCRIPTION
- Compute and Requester nodes each have their own JobSelectionPolicy. This change separates the flags for each configured value.
- The Requester JobSelectionPolicy is currently unused and a TODO has been added (see code comment) to address it via: https://github.com/bacalhau-project/bacalhau/issues/2929
- closed #2898