### PR TITLE
Add update checking to Bacalhau nodes

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -278,6 +278,18 @@ func NewNode(
 		IntervalConfig:   nodeInfoPublisherInterval,
 	})
 
+	// Start periodic software update checks.
+	updateCheckCtx, stopUpdateChecks := context.WithCancel(ctx)
+	version.RunUpdateChecker(
+		updateCheckCtx,
+		func(ctx context.Context) (*models.BuildVersionInfo, error) { return nil, nil },
+		version.LogUpdateResponse,
+	)
+	config.CleanupManager.RegisterCallback(func() error {
+		stopUpdateChecks()
+		return nil
+	})
+
 	// cleanup libp2p resources in the desired order
 	config.CleanupManager.RegisterCallbackWithContext(func(ctx context.Context) error {
 		if computeNode != nil {

--- a/pkg/version/update.go
+++ b/pkg/version/update.go
@@ -6,9 +6,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
+	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/config"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 const endpoint = "http://update.bacalhau.org/version"
@@ -29,12 +36,14 @@ func CheckForUpdate(
 	}
 
 	q := u.Query()
-	q.Set("clientVersion", currentClientVersion.GitVersion)
-	if currentServerVersion.GitVersion != "" {
+	if currentClientVersion != nil && currentClientVersion.GitVersion != "" {
+		q.Set("clientVersion", currentClientVersion.GitVersion)
+		q.Set("operatingSystem", currentClientVersion.GOOS)
+		q.Set("architecture", currentClientVersion.GOARCH)
+	}
+	if currentServerVersion != nil && currentServerVersion.GitVersion != "" {
 		q.Set("serverVersion", currentServerVersion.GitVersion)
 	}
-	q.Set("operatingSystem", currentClientVersion.GOOS)
-	q.Set("architecture", currentClientVersion.GOARCH)
 	q.Set("userID", clientID)
 
 	u.RawQuery = q.Encode()
@@ -62,4 +71,137 @@ func CheckForUpdate(
 	}
 
 	return &updateCheck, nil
+}
+
+func LogUpdateResponse(ctx context.Context, ucr *UpdateCheckResponse) {
+	if ucr != nil && ucr.Message != "" {
+		log.Ctx(ctx).Info().Str("NewVersion", ucr.Version.GitVersion).Msg(strings.ReplaceAll(ucr.Message, "\n", " "))
+	}
+}
+
+// RunUpdateChecker starts a goroutine that will periodically make an update
+// check according to the configured update frequency and check skipping. The
+// goroutine is ended by canceling the passed context. `getServerVersion` is
+// allowed to return a nil version if there is no server to communicate with
+// (e.g. because the node running the update check is the server).
+func RunUpdateChecker(
+	ctx context.Context,
+	getServerVersion func(context.Context) (*models.BuildVersionInfo, error),
+	responseCallback func(context.Context, *UpdateCheckResponse),
+) {
+	updateFrequency := config.GetUpdateCheckFrequency()
+	if updateFrequency <= 0 {
+		log.Ctx(ctx).Warn().Dur(types.UpdateCheckFrequency, updateFrequency).Msg("Update frequency is zero or less so no update checks will run")
+		return
+	}
+
+	clientVersion := Get()
+	clientID, err := config.GetClientID()
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("Failed to read client ID")
+		return
+	}
+
+	runUpdateCheck := func() {
+		// Check this every time, to handle programmatic changes to config that
+		// may switch this on or off.
+		if skip, err := config.Get[bool](types.UpdateSkipChecks); skip || err != nil {
+			log.Ctx(ctx).Debug().Err(err).Bool(types.UpdateSkipChecks, skip).Msg("Skipping update check due to config")
+			return
+		}
+
+		// The server may update itself between checks, so always ask the server
+		// for its current version.
+		serverVersion, err := getServerVersion(ctx)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("Failed to read server version")
+			serverVersion = nil
+		}
+
+		updateResponse, err := CheckForUpdate(ctx, clientVersion, serverVersion, clientID)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("Failed to perform update check")
+		}
+
+		if err == nil {
+			responseCallback(ctx, updateResponse)
+			err = writeNewLastCheckTime()
+			log.Ctx(ctx).WithLevel(logger.ErrOrDebug(err)).Err(err).Msg("Completed update check")
+		}
+	}
+
+	lastCheck, err := readLastCheckTime()
+	if err != nil {
+		log.Ctx(ctx).Warn().Err(err).Msg("Error reading update check state – will perform check anyway")
+		lastCheck = time.UnixMilli(0)
+	}
+
+	// Count down the remaining time between the last check and the next check,
+	// and then reset the ticker to start doing regular periodic checks. This is fine
+	// because the ticker will not have fired before the initial timer.
+	initialPeriod := time.Until(lastCheck.Add(updateFrequency))
+	initialTimer := time.NewTimer(initialPeriod)
+	updateTicker := time.NewTicker(updateFrequency)
+
+	go func() {
+		for {
+			select {
+			case <-initialTimer.C:
+				runUpdateCheck()
+				updateTicker.Reset(updateFrequency)
+			case <-updateTicker.C:
+				runUpdateCheck()
+			case <-ctx.Done():
+				initialTimer.Stop()
+				updateTicker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+type updateState struct {
+	LastCheck time.Time
+}
+
+func readLastCheckTime() (time.Time, error) {
+	path, err := config.Get[string](types.UpdateCheckStatePath)
+	if err != nil {
+		return time.Now(), errors.Wrap(err, "error getting repo path")
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return time.Now(), errors.Wrap(err, "error opening update state file")
+	}
+	defer file.Close()
+
+	var state updateState
+	err = json.NewDecoder(file).Decode(&state)
+	if err != nil {
+		return time.Now(), errors.Wrap(err, "error reading update state")
+	}
+
+	return state.LastCheck, nil
+}
+
+func writeNewLastCheckTime() error {
+	path, err := config.Get[string](types.UpdateCheckStatePath)
+	if err != nil {
+		return errors.Wrap(err, "error getting repo path")
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return errors.Wrap(err, "error creating update state file")
+	}
+	defer file.Close()
+
+	state := updateState{LastCheck: time.Now()}
+	err = json.NewEncoder(file).Encode(&state)
+	if err != nil {
+		return errors.Wrap(err, "error writing update state")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Following #2894, short-running commands like `bacalhau list` will run an update check.

If we just extended this to `bacalhau serve`, nodes would run a check on first boot but then won't subsequently run any more checks.

Instead, we now run the update check every 24 hours, and for those commands write any results into the log. Existing behaviour where version updates are written to the output for client commands is retained.

Resolves #2896.