### PR TITLE
disable execution timeout for long running jobs

### DIFF
--- a/pkg/orchestrator/transformer/job.go
+++ b/pkg/orchestrator/transformer/job.go
@@ -37,9 +37,13 @@ type JobDefaults struct {
 // DefaultsApplier is a transformer that applies default values to the job.
 func DefaultsApplier(defaults JobDefaults) JobTransformer {
 	f := func(ctx context.Context, job *models.Job) error {
-		for _, task := range job.Tasks {
-			if task.Timeouts.GetExecutionTimeout() <= 0 {
-				task.Timeouts.ExecutionTimeout = int64(defaults.ExecutionTimeout.Seconds())
+
+		// only apply default execution timeout to non-long running jobs
+		if !job.IsLongRunning() {
+			for _, task := range job.Tasks {
+				if task.Timeouts.GetExecutionTimeout() <= 0 {
+					task.Timeouts.ExecutionTimeout = int64(defaults.ExecutionTimeout.Seconds())
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
This PR fixes an issue where default execution timeout is still applied to long running jobs in the compute side, causing them to fail.  While no timeout is applied and no result is expected, the existing go routine that is waiting is still there so that it can release the allocated resources in case of failure or cancellation.