### PR TITLE
Increase the default job resource limits

### DIFF
--- a/pkg/config/configenv/dev.go
+++ b/pkg/config/configenv/dev.go
@@ -82,8 +82,8 @@ var DevelopmentComputeConfig = types.ComputeConfig{
 			GPU:    "",
 		},
 		DefaultJobResourceLimits: model.ResourceUsageConfig{
-			CPU:    "100m",
-			Memory: "100Mi",
+			CPU:    "500m",
+			Memory: "1Gb",
 			Disk:   "",
 			GPU:    "",
 		},

--- a/pkg/config/configenv/local.go
+++ b/pkg/config/configenv/local.go
@@ -73,8 +73,8 @@ var LocalComputeConfig = types.ComputeConfig{
 			GPU:    "",
 		},
 		DefaultJobResourceLimits: model.ResourceUsageConfig{
-			CPU:    "100m",
-			Memory: "100Mi",
+			CPU:    "500m",
+			Memory: "1Gb",
 			Disk:   "",
 			GPU:    "",
 		},

--- a/pkg/config/configenv/production.go
+++ b/pkg/config/configenv/production.go
@@ -90,8 +90,8 @@ var ProductionComputeConfig = types.ComputeConfig{
 			GPU:    "",
 		},
 		DefaultJobResourceLimits: model.ResourceUsageConfig{
-			CPU:    "100m",
-			Memory: "100Mi",
+			CPU:    "500m",
+			Memory: "1Gb",
 			Disk:   "",
 			GPU:    "",
 		},

--- a/pkg/config/configenv/staging.go
+++ b/pkg/config/configenv/staging.go
@@ -88,8 +88,8 @@ var StagingComputeConfig = types.ComputeConfig{
 			GPU:    "",
 		},
 		DefaultJobResourceLimits: model.ResourceUsageConfig{
-			CPU:    "100m",
-			Memory: "100Mi",
+			CPU:    "500m",
+			Memory: "1Gb",
 			Disk:   "",
 			GPU:    "",
 		},


### PR DESCRIPTION
They are currently too low and causing OOM errors for some users when they use more than 100Mb.  There is some leeway but not very much.

The memory has been increase to 1Gb which is high for simple short-lived script, but sufficient for something more complex or long-running. We should fine tune this when we have more data about usage.

Similarly the CPU share was currently 1/10 of a CPU, and this was causing scripts that should be running quickly (<10s) to take nearly a minute.  The default has been increased to .5 of a CPU. We should consider removing the CPU limit entirely for dockerised workloads and let the operating system share the CPU appropriately.