### PR TITLE
Adds SourcePath in conversion to legacy spec

### DIFF
--- a/pkg/models/migration/legacy/to.go
+++ b/pkg/models/migration/legacy/to.go
@@ -162,7 +162,7 @@ func ToLegacyStorageSpec(storage *models.SpecConfig) (model.StorageSpec, error) 
 	case models.StorageSourceLocalDirectory:
 		storageSpec := model.StorageSpec{
 			StorageSource: model.StorageSourceLocalDirectory,
-			Path:          storage.Params["SourcePath"].(string),
+			SourcePath:    storage.Params["SourcePath"].(string),
 		}
 		if readWrite, ok := storage.Params["ReadWrite"].(bool); ok {
 			storageSpec.ReadWrite = readWrite


### PR DESCRIPTION
Currently if you run a job with

```
bacalhau docker run -i "src=file://path,dst=/inputs" ...
```

when you call describe on that job, the Inputs contains an entry where StorageSource = localDirectory, but copying that spec into a yaml file and trying to pipe it through `bacalhau create` fails because of a missing SourcePath attribute in the StorageSource.

This PR ensures when converting from a new format spec to a legacy spec, we include the SourcePath as `SourcePath` and not `Path` as previously (which was still being overwritten with the dst value).

Fixes #2972 