### PR TITLE
Fix bug in date formatting during test assertion

### DIFF
--- a/pkg/publisher/s3/publisher_test.go
+++ b/pkg/publisher/s3/publisher_test.go
@@ -93,7 +93,7 @@ func (s *PublisherTestSuite) TestDateSubstitution() {
 	parts := strings.Split(str, "/")
 
 	n := time.Now()
-	s.Require().Equal(fmt.Sprintf("%d%d%d", n.Year(), n.Month(), n.Day()), parts[0], "date was incorrect")
+	s.Require().Equal(fmt.Sprintf("%d%02d%02d", n.Year(), n.Month(), n.Day()), parts[0], "date was incorrect")
 
 	// Check the time is all numbers
 	_, err := strconv.Atoi(parts[1])


### PR DESCRIPTION
Will currently break on dates where the month or day only have one digit, and so we ensure we zero pad those fields in the date.