### PR TITLE
don't wait for long running jobs

### DIFF
--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -25,11 +25,11 @@ import (
 const PrintoutCanceledButRunningNormally string = "printout canceled but running normally"
 
 var eventsWorthPrinting = map[models.JobStateType]eventStruct{
-	models.JobStateTypePending:   {Message: "Creating job for submission", IsTerminal: false, IsError: false},
-	models.JobStateTypeRunning:   {Message: "Job in progress", IsTerminal: false, IsError: false},
+	models.JobStateTypePending:   {Message: "Creating job for submission"},
+	models.JobStateTypeRunning:   {Message: "Job in progress"},
 	models.JobStateTypeFailed:    {Message: "Error while executing the job", IsTerminal: true, IsError: true},
-	models.JobStateTypeStopped:   {Message: "Job canceled", IsTerminal: true, IsError: false},
-	models.JobStateTypeCompleted: {Message: "Job finished", IsTerminal: true, IsError: false},
+	models.JobStateTypeStopped:   {Message: "Job canceled", IsTerminal: true},
+	models.JobStateTypeCompleted: {Message: "Job finished", IsTerminal: true},
 }
 
 type eventStruct struct {
@@ -265,6 +265,13 @@ To cancel the job, run:
 			} else {
 				spinner.Done(StopSuccess)
 			}
+			cmdShuttingDown = true
+			break
+		}
+
+		// If the job is long running, and it's running, we can stop the spinner
+		if resp.Job.IsLongRunning() && resp.Job.State.StateType == models.JobStateTypeRunning {
+			spinner.Done(StopSuccess)
 			cmdShuttingDown = true
 			break
 		}


### PR DESCRIPTION
The CLI will exit right after the job is marked as running - executions approved - instead of blocking waiting for a result that will never be published for long running jobs.

```
→ bacalhau job run service.yaml
Job successfully submitted. Job ID: j-18b36bd1-19e2-4a9b-85a0-42bb2e2ab5a9
Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

	Communicating with the network  ................  done ✅  0.0s
	   Creating job for submission  ................  done ✅  0.5s
	               Job in progress  ................  done ✅  0.0s

To get more details about the run, execute:
	bacalhau job describe j-18b36bd1-19e2-4a9b-85a0-42bb2e2ab5a9

To get more details about the run executions, execute:
	bacalhau job executions j-18b36bd1-19e2-4a9b-85a0-42bb2e2ab5a9
```