### PR TITLE
Set release versions for staging/prod

### DIFF
--- a/ops/terraform/production.tfvars
+++ b/ops/terraform/production.tfvars
@@ -1,4 +1,4 @@
-bacalhau_version            = "v1.1.0"
+bacalhau_version            = "v1.1.3"
 bacalhau_port               = "1235"
 bacalhau_node_id_0          = "QmdZQ7ZbhnvWY1J12XYKGHApJ6aufKyLNSvf8jZBrBaAVL"
 bacalhau_node_id_1          = "QmXaXu9N5GNetatsvwnTfQqNtSeKAD6uCmarbh3LMRYAcF"

--- a/ops/terraform/staging.tfvars
+++ b/ops/terraform/staging.tfvars
@@ -1,5 +1,7 @@
-bacalhau_version            = ""
-bacalhau_branch             = "main"
+bacalhau_version            = "v1.1.3-rc1"
+# Uncomment following line to deploy a branch to staging instead of 
+# a specific version
+# bacalhau_branch             = "main"
 bacalhau_port               = "1235"
 bacalhau_node_id_0          = "QmcWJnVXJ82DKJq8ED79LADR4ZBTnwgTK7yn6JQbNVMbbC"
 bacalhau_node_id_1          = "QmXRdLruWyETS2Z8XFrXxBFYXctfjT8T9mZWyuqwUm6rQk"


### PR DESCRIPTION
This ensures that someone redeploying does not deploy the wrong version. Also, added a comment on the bacalhau_branch setting for staging explaining how you can set it to try deploying a specific branch.