### PR TITLE
Choose better log stream addresses internally

### DIFF
--- a/pkg/compute/logstream/network.go
+++ b/pkg/compute/logstream/network.go
@@ -1,0 +1,71 @@
+package logstream
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/samber/lo"
+)
+
+type AddressType int
+
+const (
+	PrivateAddress  = 0
+	PublicAddress   = 1
+	LoopbackAddress = 2
+	Unspecified     = 3
+	LinkLocal       = 4
+)
+
+func findTCPAddress(host host.Host) string {
+	peerID := host.ID().Pretty()
+	hostAddr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID))
+
+	addresses := SortAddresses(host.Addrs())
+
+	for _, addr := range addresses {
+		for _, protocol := range addr.Protocols() {
+			if protocol.Name == "tcp" {
+				return addr.Encapsulate(hostAddr).String()
+			}
+		}
+	}
+
+	// If we can't find any TCP records, then we'll try with the first record
+	addr := host.Addrs()[0]
+	return addr.Encapsulate(hostAddr).String()
+}
+
+func getIPForAddress(addr multiaddr.Multiaddr) net.IP {
+	ip, err := addr.ValueForProtocol(multiaddr.P_IP4)
+	if err != nil {
+		ip, _ = addr.ValueForProtocol(multiaddr.P_IP6)
+	}
+	return net.ParseIP(ip)
+}
+
+func SortAddresses(addresses []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	grouped := lo.GroupBy[multiaddr.Multiaddr, AddressType](addresses, func(item multiaddr.Multiaddr) AddressType {
+		ip := getIPForAddress(item)
+		if ip.IsLoopback() {
+			return LoopbackAddress
+		} else if ip.IsPrivate() {
+			return PrivateAddress
+		} else if ip.IsUnspecified() {
+			return Unspecified
+		} else if ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() {
+			return LinkLocal
+		}
+
+		return PublicAddress
+	})
+
+	sorted := make([]multiaddr.Multiaddr, 0, len(addresses))
+	sorted = append(sorted, grouped[PrivateAddress]...)
+	sorted = append(sorted, grouped[PublicAddress]...)
+	sorted = append(sorted, grouped[LoopbackAddress]...)
+	sorted = append(sorted, grouped[Unspecified]...)
+	return append(sorted, grouped[LinkLocal]...)
+}

--- a/pkg/compute/logstream/network.go
+++ b/pkg/compute/logstream/network.go
@@ -1,11 +1,13 @@
 package logstream
 
 import (
+	"context"
 	"fmt"
 	"net"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/multiformats/go-multiaddr"
+	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 )
 
@@ -19,7 +21,7 @@ const (
 	LinkLocal       = 4
 )
 
-func findTCPAddress(host host.Host) string {
+func findTCPAddress(ctx context.Context, host host.Host) string {
 	peerID := host.ID().Pretty()
 	hostAddr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID))
 
@@ -28,6 +30,7 @@ func findTCPAddress(host host.Host) string {
 	for _, addr := range addresses {
 		for _, protocol := range addr.Protocols() {
 			if protocol.Name == "tcp" {
+				log.Ctx(ctx).Info().Stringer("Address", addr).Msg("Selected address for logstreams")
 				return addr.Encapsulate(hostAddr).String()
 			}
 		}

--- a/pkg/compute/logstream/network_test.go
+++ b/pkg/compute/logstream/network_test.go
@@ -1,0 +1,101 @@
+//go:build unit || !integration
+
+package logstream_test
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/suite"
+)
+
+type NetworkTestSuite struct {
+	suite.Suite
+}
+
+func TestNetworkTestSuite(t *testing.T) {
+	suite.Run(t, new(NetworkTestSuite))
+}
+
+// "127.0.0.0/8",    // IPv4 loopback
+// "10.0.0.0/8",     // RFC1918
+// "172.16.0.0/12",  // RFC1918
+// "192.168.0.0/16", // RFC1918
+// "169.254.0.0/16", // RFC3927 link-local
+// "::1/128",        // IPv6 loopback
+// "fe80::/10",      // IPv6 link-local
+// "fc00::/7",       // IPv6 unique local addr
+
+func (s *NetworkTestSuite) TestMultiAddrSorting() {
+
+	type testcase struct {
+		name      string
+		addresses []string
+		expected  []string
+	}
+	testcases := []testcase{
+		{
+			name: "simple",
+			addresses: []string{
+				"/ip4/127.0.0.1/tcp/2112",
+				"/ip4/172.16.1.1/tcp/2112",
+				"/ip6/::/tcp/2112",
+				"/ip4/200.10.10.10/tcp/2112",
+			},
+			expected: []string{
+				"/ip4/172.16.1.1/tcp/2112",
+				"/ip4/200.10.10.10/tcp/2112",
+				"/ip4/127.0.0.1/tcp/2112",
+				"/ip6/::/tcp/2112",
+			},
+		},
+		{
+			name: "less simple",
+			addresses: []string{
+				"/ip4/127.0.0.1/tcp/2112",
+				"/ip4/172.16.1.1/tcp/2112",
+				"/ip4/172.16.2.2/tcp/2112",
+				"/ip6/::/tcp/2112",
+				"/ip4/200.10.10.10/tcp/2112",
+			},
+			expected: []string{
+				// expect those in same class to maintain order
+				"/ip4/172.16.1.1/tcp/2112",
+				"/ip4/172.16.2.2/tcp/2112",
+				"/ip4/200.10.10.10/tcp/2112",
+				"/ip4/127.0.0.1/tcp/2112",
+				"/ip6/::/tcp/2112",
+			},
+		},
+		{
+			name: "link-local",
+			addresses: []string{
+				"/ip4/169.254.1.1/tcp/2112",
+				"/ip4/127.0.0.1/tcp/2112",
+			},
+			expected: []string{
+				"/ip4/127.0.0.1/tcp/2112",
+				"/ip4/169.254.1.1/tcp/2112",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			maddrs := make([]multiaddr.Multiaddr, len(tc.addresses))
+			for i, addr := range tc.addresses {
+				maddrs[i], _ = multiaddr.NewMultiaddr(addr)
+			}
+
+			sortedAddresses := logstream.SortAddresses(maddrs)
+			actualResults := lo.Map(sortedAddresses, func(item multiaddr.Multiaddr, _ int) string {
+				return item.String()
+			})
+
+			s.Require().EqualValues(tc.expected, actualResults)
+		})
+	}
+
+}

--- a/pkg/compute/logstream/network_test.go
+++ b/pkg/compute/logstream/network_test.go
@@ -19,15 +19,6 @@ func TestNetworkTestSuite(t *testing.T) {
 	suite.Run(t, new(NetworkTestSuite))
 }
 
-// "127.0.0.0/8",    // IPv4 loopback
-// "10.0.0.0/8",     // RFC1918
-// "172.16.0.0/12",  // RFC1918
-// "192.168.0.0/16", // RFC1918
-// "169.254.0.0/16", // RFC3927 link-local
-// "::1/128",        // IPv6 loopback
-// "fe80::/10",      // IPv6 link-local
-// "fc00::/7",       // IPv6 unique local addr
-
 func (s *NetworkTestSuite) TestMultiAddrSorting() {
 
 	type testcase struct {

--- a/pkg/compute/logstream/server.go
+++ b/pkg/compute/logstream/server.go
@@ -3,11 +3,8 @@ package logstream
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"reflect"
-
-	"github.com/multiformats/go-multiaddr"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
@@ -39,23 +36,6 @@ func NewLogStreamServer(options LogStreamServerOptions) *LogStreamServer {
 	}
 	svr.host.SetStreamHandler(LogsProcotolID, svr.Handle)
 	return svr
-}
-
-func findTCPAddress(host host.Host) string {
-	peerID := host.ID().Pretty()
-	hostAddr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID))
-
-	for _, addr := range host.Addrs() {
-		for _, protocol := range addr.Protocols() {
-			if protocol.Name == "tcp" {
-				return addr.Encapsulate(hostAddr).String()
-			}
-		}
-	}
-
-	// If we can't find TCP, then we'll go with the first record
-	addr := host.Addrs()[0]
-	return addr.Encapsulate(hostAddr).String()
 }
 
 func (s *LogStreamServer) Handle(stream network.Stream) {

--- a/pkg/compute/logstream/server.go
+++ b/pkg/compute/logstream/server.go
@@ -32,7 +32,7 @@ func NewLogStreamServer(options LogStreamServerOptions) *LogStreamServer {
 		host:           options.Host,
 		executionStore: options.ExecutionStore,
 		executors:      options.Executors,
-		Address:        findTCPAddress(options.Host),
+		Address:        findTCPAddress(options.Ctx, options.Host),
 	}
 	svr.host.SetStreamHandler(LogsProcotolID, svr.Handle)
 	return svr


### PR DESCRIPTION
Currently when the requester node wants to read the logs from a compute node, it asks the compute node which responds with the first TCP address it can find (this may be ip4 or ip6). If it fails to do this, it will instead just use the first address in the list of addresses for the host.

We are encountering situations where a loopback address is being chosen in preference to a private network address which is preferable in nearly all cases (except devstack).

This PR attempts to order the available addresses into a more effective ordering. The addresses that are chosen from are ordered by:

* Private addresses (from RFC1918)
* Public addresses
* Loopback addresses (e.g. 127.0.0.1)
* Unspecified addresses (such as ip6 ::)
* Link local addresses (from RFC3927)