### PR TITLE
Show node ranking failures in the CLI (again)

### DIFF
--- a/pkg/orchestrator/selection/ranking/features.go
+++ b/pkg/orchestrator/selection/ranking/features.go
@@ -74,7 +74,7 @@ func (s *featureNodeRanker) rankNode(ctx context.Context, node models.NodeInfo, 
 
 		if !found {
 			// Target wasn't found – we can end early as we won't use this node.
-			return orchestrator.RankUnsuitable, fmt.Sprintf("does not support %T %s, only %s", requiredKey, requiredKey, providedKeys)
+			return orchestrator.RankUnsuitable, fmt.Sprintf("does not support %s, only %s", requiredKey, providedKeys)
 		}
 	}
 


### PR DESCRIPTION
We used to show a list of nodes that had failed ranking when not enough nodes were found to run the job. At some point we regressed and no longer showed those errors, leading to lots of confusion around why jobs aren't running. This commit restores the view of node ranking failures being passed to the CLI.