### PR TITLE
feat: write a simple config migration

### DIFF
--- a/pkg/config/migrations/set.go
+++ b/pkg/config/migrations/set.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+)
+
+var set migrationList
+
+func GetMigrations() ([]Migration, error) {
+	return set.GetMigrations()
+}
+
+func init() {
+	set = NewMigrationList()
+}
+
+type Migration interface {
+	Sequence() int
+	Migrate(config types.BacalhauConfig) (types.BacalhauConfig, error)
+}
+
+type mig struct {
+	seq       int
+	migration MigrationFn
+}
+
+func (m mig) Sequence() int {
+	return m.seq
+}
+
+func (m mig) Migrate(config types.BacalhauConfig) (types.BacalhauConfig, error) {
+	return m.migration(config)
+}
+
+type migrationList struct {
+	ms map[int]mig
+}
+
+func NewMigrationList() migrationList { // nolint: revive
+	return migrationList{map[int]mig{}}
+}
+
+// Register adds a migration to the migration list. This should be called in an init function.
+func (ml *migrationList) Register(seq int, mf MigrationFn) {
+	if seq <= 0 {
+		panic(fmt.Sprintf("invalid migration number: %d", seq))
+	}
+
+	if _, exists := ml.ms[seq]; exists {
+		panic(fmt.Sprintf("duplicate migration registered: %d", seq))
+	}
+
+	ml.ms[seq] = mig{
+		seq:       seq,
+		migration: mf,
+	}
+}
+
+type MigrationFn = func(config types.BacalhauConfig) (types.BacalhauConfig, error)
+
+func (ml *migrationList) GetMigrations() ([]Migration, error) {
+	// Check patch list is consistent with no gaps
+	count := len(ml.ms)
+
+	// migration 0 must not exist - it's the base schema by definition
+	if _, exists := ml.ms[0]; exists {
+		return nil, fmt.Errorf("found migration 0, which should not exist")
+	}
+
+	// index from 1 since schema seq 0 is the base and not in `ml`
+	for i := 1; i <= count; i++ {
+		if _, exists := ml.ms[i]; !exists {
+			return nil, fmt.Errorf("missing migration %d", i)
+		}
+	}
+
+	migs := make([]Migration, 0, count)
+	for i := 1; i <= count; i++ {
+		migs = append(migs, ml.ms[i])
+	}
+	return migs, nil
+}

--- a/pkg/config/migrations/v1_2.go
+++ b/pkg/config/migrations/v1_2.go
@@ -1,0 +1,61 @@
+package migrations
+
+import "github.com/bacalhau-project/bacalhau/pkg/config/types"
+
+var (
+	oldSwarmPeers = []string{
+		"/ip4/35.245.115.191/tcp/4001/p2p/12D3KooWE4wfAknWtY9mQ4eAA8zrFGeZa7X2Kh4nBP2tZgDSt7Rh",
+		"/ip4/35.245.115.191/udp/4001/quic/p2p/12D3KooWE4wfAknWtY9mQ4eAA8zrFGeZa7X2Kh4nBP2tZgDSt7Rh",
+		"/ip4/35.245.61.251/tcp/4001/p2p/12D3KooWD8zeukHTMyuPtQBoUUPqtEnaA7NwFXWcVywUJtCVPske",
+		"/ip4/35.245.61.251/udp/4001/quic/p2p/12D3KooWD8zeukHTMyuPtQBoUUPqtEnaA7NwFXWcVywUJtCVPske",
+		"/ip4/35.245.251.239/tcp/4001/p2p/12D3KooWAg1YdehZxcZhetcgA6KP8TLGX6Fq4h9PUswnUWoStVNc",
+		"/ip4/35.245.251.239/udp/4001/quic/p2p/12D3KooWAg1YdehZxcZhetcgA6KP8TLGX6Fq4h9PUswnUWoStVNc",
+		"/ip4/34.150.153.87/tcp/4001/p2p/12D3KooWGE4R98vokeLsRVdTv8D6jhMnifo81mm7NMRV8WJPNVHb",
+		"/ip4/34.150.153.87/udp/4001/quic/p2p/12D3KooWGE4R98vokeLsRVdTv8D6jhMnifo81mm7NMRV8WJPNVHb",
+		"/ip4/34.91.247.176/tcp/4001/p2p/12D3KooWSNKPM5PBchoqn774bpQ4j4QbL3VoyX6mH6vTyWXqE3kH",
+		"/ip4/34.91.247.176/udp/4001/quic/p2p/12D3KooWSNKPM5PBchoqn774bpQ4j4QbL3VoyX6mH6vTyWXqE3kH",
+	}
+
+	oldBootstrapPeers = []string{
+		"/ip4/35.245.115.191/tcp/1235/p2p/QmdZQ7ZbhnvWY1J12XYKGHApJ6aufKyLNSvf8jZBrBaAVL",
+		"/ip4/35.245.61.251/tcp/1235/p2p/QmXaXu9N5GNetatsvwnTfQqNtSeKAD6uCmarbh3LMRYAcF",
+		"/ip4/35.245.251.239/tcp/1235/p2p/QmYgxZiySj3MRkwLSL4X2MF5F9f2PMhAE3LV49XkfNL1o3",
+	}
+)
+
+func init() {
+	// this migration removes any IPFS swarm peers or Bootstrap peers that are incorrect from the v1.0.4 upgrade.
+	// if no incorrect values are present they are left as is.
+	set.Register(1, func(current types.BacalhauConfig) (types.BacalhauConfig, error) {
+		migrated := current
+		if haveSameElements(oldSwarmPeers, migrated.Node.IPFS.SwarmAddresses) {
+			migrated.Node.IPFS.SwarmAddresses = []string{}
+		}
+		if haveSameElements(oldBootstrapPeers, migrated.Node.BootstrapAddresses) {
+			migrated.Node.BootstrapAddresses = []string{}
+		}
+		return migrated, nil
+	})
+}
+
+// haveSameElements returns true if arr1 and arr2 have the same elements, false otherwise.
+func haveSameElements(arr1, arr2 []string) bool {
+	if len(arr1) != len(arr2) {
+		return false
+	}
+
+	elementCount := make(map[string]int)
+
+	for _, item := range arr1 {
+		elementCount[item]++
+	}
+
+	for _, item := range arr2 {
+		if count, exists := elementCount[item]; !exists || count == 0 {
+			return false
+		}
+		elementCount[item]--
+	}
+
+	return true
+}

--- a/pkg/repo/version.go
+++ b/pkg/repo/version.go
@@ -9,7 +9,9 @@ import (
 )
 
 const (
-	// RepoVersion1 is the current repo versioning.
+	// RepoVersion2 is the current repo versioning.
+	RepoVersion2 = 2
+	// RepoVersion1 is the current repo versioning for v1-v1.1.4
 	RepoVersion1 = 1
 	// RepoVersionFile is the name of the repo file containing the repo version.
 	RepoVersionFile = "repo.version"
@@ -19,8 +21,8 @@ type RepoVersion struct {
 	Version int
 }
 
-func (fsr *FsRepo) writeVersion() error {
-	repoVersion := RepoVersion{Version: RepoVersion1}
+func (fsr *FsRepo) writeVersion(version int) error {
+	repoVersion := RepoVersion{Version: version}
 	versionJSON, err := json.Marshal(repoVersion)
 	if err != nil {
 		return err


### PR DESCRIPTION
- we should delete this asap once it fixes the problem
- migrates users with v1.1.4 config values (repo version 1) to no longer contain incorrect values in config
  - will allow `bacalhau get` to work with ipfs
  - will allow `bacalhau serve --peer=confg` to work with correct peers.