### PR TITLE
Linting fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/davecgh/go-spew v1.1.1
+	github.com/distribution/reference v0.5.0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/fatih/structs v1.1.0
 	github.com/ghodss/yaml v1.0.0
@@ -105,7 +106,6 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
@@ -169,7 +169,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dgraph-io/badger v1.6.2 // indirect
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
-	github.com/docker/distribution v2.8.3+incompatible
+	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/bacalhau-project/bacalhau/pkg/util/generic"
 )
 
 type BaseExecutorParams struct {
@@ -38,7 +37,6 @@ type BaseExecutor struct {
 	ID               string
 	callback         Callback
 	store            store.ExecutionStore
-	cancellers       generic.SyncMap[string, context.CancelFunc]
 	Storages         storage.StorageProvider
 	executors        executor.ExecutorProvider
 	publishers       publisher.PublisherProvider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,8 +42,9 @@ var (
 )
 
 const (
-	configType = "yaml"
-	configName = "config"
+	configType     = "yaml"
+	configName     = "config"
+	configFileMode = 0666
 )
 
 func Init(path string) (types.BacalhauConfig, error) {
@@ -132,7 +133,7 @@ func Migrate(path string) error {
 	}
 
 	// open the file for writing and truncate it.
-	fw, err := os.OpenFile(configPath, os.O_WRONLY|os.O_TRUNC, 0666)
+	fw, err := os.OpenFile(configPath, os.O_WRONLY|os.O_TRUNC, configFileMode)
 	if err != nil {
 		return fmt.Errorf("failed to open config file for writing at %q: %w", configPath, err)
 	}

--- a/pkg/config/migrations/set.go
+++ b/pkg/config/migrations/set.go
@@ -39,7 +39,7 @@ type migrationList struct {
 	ms map[int]mig
 }
 
-func NewMigrationList() migrationList { // nolint: revive
+func NewMigrationList() migrationList {
 	return migrationList{map[int]mig{}}
 }
 

--- a/pkg/config/migrations/set.go
+++ b/pkg/config/migrations/set.go
@@ -12,6 +12,7 @@ func GetMigrations() ([]Migration, error) {
 	return set.GetMigrations()
 }
 
+//nolint:gochecknoinits
 func init() {
 	set = NewMigrationList()
 }

--- a/pkg/config/migrations/v1_2.go
+++ b/pkg/config/migrations/v1_2.go
@@ -23,7 +23,7 @@ var (
 	}
 )
 
-//noling:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	// this migration removes any IPFS swarm peers or Bootstrap peers that are incorrect from the v1.0.4 upgrade.
 	// if no incorrect values are present they are left as is.

--- a/pkg/config/migrations/v1_2.go
+++ b/pkg/config/migrations/v1_2.go
@@ -23,6 +23,7 @@ var (
 	}
 )
 
+//noling:gochecknoinits
 func init() {
 	// this migration removes any IPFS swarm peers or Bootstrap peers that are incorrect from the v1.0.4 upgrade.
 	// if no incorrect values are present they are left as is.

--- a/pkg/devstack/option.go
+++ b/pkg/devstack/option.go
@@ -14,10 +14,15 @@ type ConfigOption = func(cfg *DevStackConfig)
 
 func defaultDevStackConfig() (*DevStackConfig, error) {
 	computeConfig, err := node.NewComputeConfigWithDefaults()
+	if err != nil {
+		return nil, err
+	}
+
 	requesterConfig, err := node.NewRequesterConfigWithDefaults()
 	if err != nil {
 		return nil, err
 	}
+
 	return &DevStackConfig{
 		ComputeConfig:          computeConfig,
 		RequesterConfig:        requesterConfig,

--- a/pkg/docker/image_id.go
+++ b/pkg/docker/image_id.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 )
 
 const (

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -60,9 +60,9 @@ func (*Executor) ShouldBidBasedOnUsage(
 // WebAssembly1:  linear memory objects have sizes measured in pages. Each page is 65536 (2^16) bytes.
 // In WebAssembly version 1, a linear memory can have at most 65536 pages, for a total of 2^32 bytes (4 gibibytes).
 
-const WASM_ARCH = 32
-const WASM_PAGE_SIZE = 65536
-const WASM_MAX_PAGES_LIMIT = 1 << (WASM_ARCH / 2)
+const WasmArch = 32
+const WasmPageSize = 65536
+const WasmMaxPagesLimit = 1 << (WasmArch / 2)
 
 // Start initiates an execution based on the provided RunCommandRequest.
 func (e *Executor) Start(ctx context.Context, request *executor.RunCommandRequest) error {
@@ -82,10 +82,10 @@ func (e *Executor) Start(ctx context.Context, request *executor.RunCommandReques
 	// limit is not specified as a multiple of that.
 	engineConfig := wazero.NewRuntimeConfig().WithCloseOnContextDone(true)
 	if request.Resources.Memory > 0 {
-		requestedPages := request.Resources.Memory/WASM_PAGE_SIZE + math.Min(request.Resources.Memory%WASM_PAGE_SIZE, 1)
-		if requestedPages > WASM_MAX_PAGES_LIMIT {
+		requestedPages := request.Resources.Memory/WasmPageSize + math.Min(request.Resources.Memory%WasmPageSize, 1)
+		if requestedPages > WasmMaxPagesLimit {
 			err := fmt.Errorf("requested memory exceeds the wasm limit - %d > 4GB", request.Resources.Memory)
-			log.Err(err).Msgf("requested memory exceeds maximum limit: %d > %d", requestedPages, WASM_MAX_PAGES_LIMIT)
+			log.Err(err).Msgf("requested memory exceeds maximum limit: %d > %d", requestedPages, WasmMaxPagesLimit)
 			return err
 		}
 		engineConfig = engineConfig.WithMemoryLimitPages(uint32(requestedPages))

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -50,6 +50,7 @@ type Server struct {
 	useTLS     bool
 }
 
+//nolint:funlen
 func NewAPIServer(params ServerParams) (*Server, error) {
 	server := &Server{
 		Router:  params.Router,

--- a/pkg/requester/jobtransform/migrate_publisher.go
+++ b/pkg/requester/jobtransform/migrate_publisher.go
@@ -10,8 +10,10 @@ import (
 func NewPublisherMigrator() Transformer {
 	return func(ctx context.Context, job *model.Job) (modified bool, err error) {
 		if model.IsValidPublisher(job.Spec.PublisherSpec.Type) {
+			//nolint:staticcheck
 			job.Spec.Publisher = job.Spec.PublisherSpec.Type
 		} else {
+			//nolint:staticcheck
 			job.Spec.PublisherSpec.Type = job.Spec.Publisher
 		}
 		return true, nil

--- a/pkg/s3/middleware/drop_accept_encoding.go
+++ b/pkg/s3/middleware/drop_accept_encoding.go
@@ -29,6 +29,8 @@ const (
 // do not support the Accept-Encoding header.
 // It does this by dropping the Accept-Encoding header before the request is signed, and restoring it after the request is signed.
 // https://stackoverflow.com/questions/73717477/gcp-cloud-storage-golang-aws-sdk2-upload-file-with-s3-interoperability-creds/74382598#74382598
+//
+//nolint:lll
 func DropAcceptEncoding(o *s3.Options) {
 	o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
 		// Return early if the signing middleware is not present, such as with PresignGetObject requests.
@@ -53,6 +55,8 @@ func DropAcceptEncoding(o *s3.Options) {
 
 // dropAcceptEncodingHeader is a middleware function that removes the Accept-Encoding header from the request.
 // This is necessary for compatibility with certain S3-like storage providers.
+//
+//nolint:lll
 var dropAcceptEncodingHeader = middleware.FinalizeMiddlewareFunc(DropAcceptEncodingMiddlewareID,
 	func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (out middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
 		req, ok := in.Request.(*smithyhttp.Request)
@@ -76,6 +80,8 @@ var dropAcceptEncodingHeader = middleware.FinalizeMiddlewareFunc(DropAcceptEncod
 
 // restoreAcceptEncodingHeader is a middleware function that restores the Accept-Encoding header to the request.
 // This is done after the request is signed to maintain compatibility with certain S3-like storage providers.
+//
+//nolint:lll
 var restoreAcceptEncodingHeader = middleware.FinalizeMiddlewareFunc(RestoreAcceptEncodingMiddlewareID,
 	func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (out middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
 		req, ok := in.Request.(*smithyhttp.Request)

--- a/pkg/s3/middleware/drop_accept_encoding.go
+++ b/pkg/s3/middleware/drop_accept_encoding.go
@@ -28,9 +28,7 @@ const (
 // that modifies the request headers to be compatible with S3-like services that
 // do not support the Accept-Encoding header.
 // It does this by dropping the Accept-Encoding header before the request is signed, and restoring it after the request is signed.
-// https://stackoverflow.com/questions/73717477/gcp-cloud-storage-golang-aws-sdk2-upload-file-with-s3-interoperability-creds/74382598#74382598
-//
-//nolint:lll
+// https://stackoverflow.com/a/74382598
 func DropAcceptEncoding(o *s3.Options) {
 	o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
 		// Return early if the signing middleware is not present, such as with PresignGetObject requests.
@@ -55,10 +53,10 @@ func DropAcceptEncoding(o *s3.Options) {
 
 // dropAcceptEncodingHeader is a middleware function that removes the Accept-Encoding header from the request.
 // This is necessary for compatibility with certain S3-like storage providers.
-//
-//nolint:lll
 var dropAcceptEncodingHeader = middleware.FinalizeMiddlewareFunc(DropAcceptEncodingMiddlewareID,
-	func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (out middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
+	func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (
+		out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+	) {
 		req, ok := in.Request.(*smithyhttp.Request)
 		if !ok {
 			// Return an error if the request type is unexpected.
@@ -80,10 +78,10 @@ var dropAcceptEncodingHeader = middleware.FinalizeMiddlewareFunc(DropAcceptEncod
 
 // restoreAcceptEncodingHeader is a middleware function that restores the Accept-Encoding header to the request.
 // This is done after the request is signed to maintain compatibility with certain S3-like storage providers.
-//
-//nolint:lll
 var restoreAcceptEncodingHeader = middleware.FinalizeMiddlewareFunc(RestoreAcceptEncodingMiddlewareID,
-	func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (out middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
+	func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (
+		out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
+	) {
 		req, ok := in.Request.(*smithyhttp.Request)
 		if !ok {
 			// Return an error if the request type is unexpected.

--- a/pkg/storage/s3/storage.go
+++ b/pkg/storage/s3/storage.go
@@ -185,6 +185,7 @@ func (s *StorageProvider) Upload(_ context.Context, _ string) (models.SpecConfig
 	return models.SpecConfig{}, fmt.Errorf("not implemented")
 }
 
+//nolint:gocyclo
 func (s *StorageProvider) explodeKey(
 	ctx context.Context, client *s3helper.ClientWrapper, storageSpec s3helper.SourceSpec) ([]s3ObjectSummary, error) {
 	if storageSpec.Key != "" && !strings.HasSuffix(storageSpec.Key, "*") && !strings.HasSuffix(storageSpec.Key, "/") {


### PR DESCRIPTION
Fixes a few accumulated linter errors that can make merging problematic unless you skip verification.

As we've got nearly 20 counts of gocyclo (high cyclomatic complexity), and 20+ funlen (long  functions) we might consider taking some time to address them.  I also run a default revive (another linter) against the codebase, and it suggest there are some changes we could make.

```
❯ revive ./... | wc -l
    2690
```