### PR TITLE
Run Web UI in deployed Bacalhau clusters.

### DIFF
--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -281,7 +281,9 @@ func serve(cmd *cobra.Command) error {
 	if startWebUI {
 		apiURL := standardNode.APIServer.GetURI().JoinPath("api", "v1")
 		go func() {
-			err := webui.ListenAndServe(ctx, apiURL.String())
+			// Specifically leave the host blank. The app will just use whatever
+			// host it is served on and replace the port and path.
+			err := webui.ListenAndServe(ctx, "", apiURL.Port(), apiURL.Path)
 			if err != nil {
 				cmd.PrintErrln(err)
 			}

--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -57,6 +57,7 @@ export BACALHAU_NODE_ID_0="${var.bacalhau_node_id_0}"
 export BACALHAU_NODE_ID_1="${var.instance_count > 1 ? var.bacalhau_node_id_1 : ""}"
 export BACALHAU_NODE_ID_2="${var.instance_count > 2 ? var.bacalhau_node_id_2 : ""}"
 export BACALHAU_NODE_TYPE="${var.bacalhau_node_type}"
+export BACALHAU_NODE_WEBUI="${strcontains(var.bacalhau_node_type, "requester") ? "true" : "false"}"
 export BACALHAU_NODE0_UNSAFE_ID="QmUqesBmpC7pSzqH86ZmZghtWkLwL6RRop3M1SrNbQN5QD"
 export BACALHAU_CONNECT_PEER="${var.bacalhau_connect_peer}"
 export GPU_NODE="${count.index >= var.instance_count - var.num_gpu_machines ? "true" : "false"}"
@@ -286,6 +287,7 @@ resource "google_compute_firewall" "bacalhau_ingress_firewall" {
   allow {
     protocol = "tcp"
     ports = [
+      "80",    // web ui
       "4001",  // ipfs swarm
       "1234",  // bacalhau API
       "1235",  // bacalhau swarm

--- a/ops/terraform/remote_files/scripts/install-node.sh
+++ b/ops/terraform/remote_files/scripts/install-node.sh
@@ -90,9 +90,10 @@ function install-ipfs() {
   wget "https://dist.ipfs.tech/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_linux-amd64.tar.gz"
   tar -xvzf "go-ipfs_${IPFS_VERSION}_linux-amd64.tar.gz"
   # TODO should reset PWD to home dir after each function call
-  cd go-ipfs
+  pushd go-ipfs
   sudo bash install.sh
   ipfs --version
+  popd
 }
 
 function install-bacalhau() {
@@ -116,11 +117,13 @@ function install-bacalhau-from-release() {
 
 function install-bacalhau-from-source() {
   echo "Installing Bacalhau from branch ${BACALHAU_BRANCH}"
-  sudo apt-get -y install --no-install-recommends jq
-  git clone --depth 1 --branch ${BACALHAU_BRANCH} https://github.com/bacalhau-project/bacalhau.git
-  cd bacalhau
-  GO111MODULE=on CGO_ENABLED=0 go build -gcflags '-N -l' -trimpath -o ./bacalhau
-  sudo mv ./bacalhau /usr/local/bin/bacalhau
+  sudo apt-get -y install --no-install-recommends jq nodejs npm make
+  git clone --branch ${BACALHAU_BRANCH} https://github.com/bacalhau-project/bacalhau.git
+  pushd bacalhau
+  pushd webui && npm install && popd
+  make build-bacalhau
+  sudo mv ./bin/*/bacalhau /usr/local/bin/bacalhau
+  popd
 }
 
 function install-otel-collector() {
@@ -367,7 +370,7 @@ function install-secrets() {
   fi
   if [[ -n "${SECRETS_DOCKER_PASSWORD}" ]]; then
     export DOCKER_PASSWORD="${SECRETS_DOCKER_PASSWORD}"
-  fi  
+  fi
 
   # write the secrets to persistent disk
   sudo tee /data/secrets.sh > /dev/null <<EOG

--- a/ops/terraform/remote_files/scripts/install-node.sh
+++ b/ops/terraform/remote_files/scripts/install-node.sh
@@ -404,11 +404,11 @@ function start-services() {
   sudo systemctl enable bacalhau
   sudo systemctl enable otel
   sudo systemctl enable promtail
+  sudo service openresty reload
   sudo systemctl start ipfs
   sudo systemctl start bacalhau
   sudo systemctl start otel
   sudo systemctl start promtail
-  sudo service openresty reload
 }
 
 function install() {

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -75,4 +75,5 @@ bacalhau serve \
   --api-port 1234 \
   --peer "${CONNECT_PEER}" \
   --private-internal-ipfs=false \
+  --web-ui "${BACALHAU_NODE_WEBUI}" \
   --labels owner=bacalhau

--- a/webui/public/index.html
+++ b/webui/public/index.html
@@ -6,7 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Bacalhau dashboard" />
-    <link rel="api-base" href="{{ .BaseURL }}" />
+    <link rel="api-host" href="{{ .Host }}" />
+    <link rel="api-port" href="{{ .Port }}" />
+    <link rel="api-base" href="{{ .Base }}" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/webui/src/services/bacalhau.ts
+++ b/webui/src/services/bacalhau.ts
@@ -46,6 +46,7 @@ class BacalhauAPI {
 
 }
 
-const defaultBaseURL = "http://bootstrap.production.bacalahu.org/api/v1"
-const declaredBaseURL = document.querySelector("link[rel=api-base]")?.getAttribute("href");
-export const bacalhauAPI = new BacalhauAPI(declaredBaseURL || defaultBaseURL);
+const host = document.querySelector("link[rel=api-host]")?.getAttribute("href") || document.location.host;
+const port = document.querySelector("link[rel=api-port]")?.getAttribute("href") || "1234";
+const base = document.querySelector("link[rel=api-base]")?.getAttribute("href") || "api/v1";
+export const bacalhauAPI = new BacalhauAPI(`${document.location.protocol}//${host}:${port}/${base}`);

--- a/webui/webui.go
+++ b/webui/webui.go
@@ -20,7 +20,7 @@ var buildFiles embed.FS
 // Return the index page for the web app with the passed API URL used. The app
 // running on each client will attempt to connect to the API URL to retrieve job
 // and node information.
-func IndexPage(apiURL string) ([]byte, error) {
+func IndexPage(host, port, base string) ([]byte, error) {
 	rawIndex, err := buildFiles.ReadFile("build/index.html")
 	if err != nil {
 		return nil, err
@@ -32,12 +32,12 @@ func IndexPage(apiURL string) ([]byte, error) {
 	}
 
 	var output bytes.Buffer
-	err = indexTemplate.Execute(&output, struct{ BaseURL string }{apiURL})
+	err = indexTemplate.Execute(&output, struct{ Host, Port, Base string }{host, port, base})
 	return output.Bytes(), err
 }
 
-func ListenAndServe(ctx context.Context, baseURL string) error {
-	indexPage, err := IndexPage(baseURL)
+func ListenAndServe(ctx context.Context, host, port, base string) error {
+	indexPage, err := IndexPage(host, port, base)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Spin up the web ui if this is a requester node.
- Expose port 80.