### PR TITLE
Ensure commands using the Client APIs are cancellable

### DIFF
--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -15,6 +15,7 @@ func GetAPIClient(ctx context.Context) *client.APIClient {
 
 func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 	return clientv2.New(clientv2.Options{
+		Context: ctx,
 		Address: fmt.Sprintf("http://%s:%d", config.ClientAPIHost(), config.ClientAPIPort()),
 	})
 }

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -150,6 +150,7 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) (resultsDir string) {
 	apiServer := stack.Nodes[0].APIServer
 	apiClient := client.NewAPIClient(apiServer.Address, apiServer.Port)
 	apiClientV2 := clientv2.New(clientv2.Options{
+		Context: s.Ctx,
 		Address: fmt.Sprintf("http://%s:%d", apiServer.Address, apiServer.Port),
 	})
 	submittedJob, submitError := apiClient.Submit(s.Ctx, j)


### PR DESCRIPTION
Otherwise, sending a SIGINT using Ctrl+C does not have any effect, and we have to wait for the API call to time out.

Resolves #3046.