### PR TITLE
More gracefully handle bad tool output

### DIFF
--- a/pkg/compute/capacity/system/gpu/amd.go
+++ b/pkg/compute/capacity/system/gpu/amd.go
@@ -55,7 +55,7 @@ func parseRocmSMIOutput(output io.Reader) (models.Resources, error) {
 	return models.Resources{GPU: uint64(len(gpus)), GPUs: gpus}, nil
 }
 
-func NewAMDGPUProvider() capacity.Provider {
+func NewAMDGPUProvider() *capacity.ToolBasedProvider {
 	return &capacity.ToolBasedProvider{
 		Command:  rocmCommand,
 		Provides: "AMD GPUs",

--- a/pkg/compute/capacity/system/gpu/nvidia.go
+++ b/pkg/compute/capacity/system/gpu/nvidia.go
@@ -18,7 +18,7 @@ const (
 	nvidiaCLIFormatArg = "--format=csv,noheader,nounits"
 )
 
-func NewNvidiaGPUProvider() capacity.Provider {
+func NewNvidiaGPUProvider() *capacity.ToolBasedProvider {
 	return &capacity.ToolBasedProvider{
 		Command:  nvidiaCLI,
 		Provides: "Nvidia GPUs",


### PR DESCRIPTION
It turns out that `rocm-smi` will print non-JSON output but still return a zero error code in the case of an error – naughty! This has prompted us to be more uniform with how we handle tool errors – any error generated by a GPU detector tool will be ignored, rather than errors that they explicitly flag. This will allow the node to come online with zero GPUs in this case, and the reason for this will be in the log.