### PR TITLE
fix: correctly parse resource config

### DIFF
--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -190,7 +190,7 @@ func (s *ExecutorTestSuite) runJobGetStdout(spec *models.Task, executionID strin
 
 const (
 	CPU_LIMIT    = "100m"
-	MEMORY_LIMIT = "100mb"
+	MEMORY_LIMIT = "100MB"
 
 	CPU_LIMIT_UNITS    = 0.1
 	MEMORY_LIMIT_BYTES = 100 * 1024 * 1024

--- a/pkg/models/resource.go
+++ b/pkg/models/resource.go
@@ -29,15 +29,8 @@ func (r *ResourcesConfig) Normalize() {
 		return
 	}
 	sanitizeResourceString := func(s string) string {
-		// TODO(forrest) [bug] Mi and Mb mean different things:
-		// - 'i' generally denotes ebi e.g.  Mebibytes
-		// - 'b' is usually bit e.g. Megabit or in this context Megabyte
-		// 1 Megabyte ~= .96 Mebibyte so we are losing meaning in this conversion
-		// need to fix this.
-
-		// lower case, allow Mi, Gi to mean Mb, Gb, and remove spaces
+		// lower case and remove spaces
 		s = strings.ToLower(s)
-		s = strings.ReplaceAll(s, "i", "b")
 		s = strings.ReplaceAll(s, " ", "")
 		s = strings.ReplaceAll(s, "\n", "")
 		return s

--- a/pkg/models/resource.go
+++ b/pkg/models/resource.go
@@ -29,6 +29,12 @@ func (r *ResourcesConfig) Normalize() {
 		return
 	}
 	sanitizeResourceString := func(s string) string {
+		// TODO(forrest) [bug] Mi and Mb mean different things:
+		// - 'i' generally denotes ebi e.g.  Mebibytes
+		// - 'b' is usually bit e.g. Megabit or in this context Megabyte
+		// 1 Megabyte ~= .96 Mebibyte so we are losing meaning in this conversion
+		// need to fix this.
+
 		// lower case, allow Mi, Gi to mean Mb, Gb, and remove spaces
 		s = strings.ToLower(s)
 		s = strings.ReplaceAll(s, "i", "b")

--- a/pkg/models/resource.go
+++ b/pkg/models/resource.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/BTBurke/k8sresource"
-	"github.com/c2h5oh/datasize"
+	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
@@ -16,9 +16,9 @@ import (
 type ResourcesConfig struct {
 	// CPU https://github.com/BTBurke/k8sresource string
 	CPU string `json:"CPU,omitempty"`
-	// Memory github.com/c2h5oh/datasize string
+	// Memory github.com/dustin/go-humanize string
 	Memory string `json:"Memory,omitempty"`
-	// Memory github.com/c2h5oh/datasize string
+	// Memory github.com/dustin/go-humanize string
 	Disk string `json:"Disk,omitempty"`
 	GPU  string `json:"GPU,omitempty"`
 }
@@ -82,18 +82,18 @@ func (r *ResourcesConfig) ToResources() (*Resources, error) {
 		res.CPU = cpu.ToFloat64()
 	}
 	if r.Memory != "" {
-		mem, err := datasize.ParseString(r.Memory)
+		mem, err := humanize.ParseBytes(r.Memory)
 		if err != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("invalid memory value: %s", r.Memory))
 		}
-		res.Memory = mem.Bytes()
+		res.Memory = mem
 	}
 	if r.Disk != "" {
-		disk, err := datasize.ParseString(r.Disk)
+		disk, err := humanize.ParseBytes(r.Disk)
 		if err != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("invalid disk value: %s", r.Disk))
 		}
-		res.Disk = disk.Bytes()
+		res.Disk = disk
 	}
 	if r.GPU != "" {
 		gpu, err := strconv.ParseUint(r.GPU, 10, 64)
@@ -303,9 +303,9 @@ func (r *Resources) IsZero() bool {
 
 // return string representation of ResourceUsageData
 func (r *Resources) String() string {
-	mem := datasize.ByteSize(r.Memory)
-	disk := datasize.ByteSize(r.Disk)
-	return fmt.Sprintf("{CPU: %f, Memory: %s, Disk: %s, GPU: %d}", r.CPU, mem.HR(), disk.HR(), r.GPU)
+	mem := humanize.Bytes(r.Memory)
+	disk := humanize.Bytes(r.Disk)
+	return fmt.Sprintf("{CPU: %f, Memory: %s, Disk: %s, GPU: %d}", r.CPU, mem, disk, r.GPU)
 }
 
 // AllocatedResources is the set of resources to be used by an execution, which

--- a/pkg/models/resources_test.go
+++ b/pkg/models/resources_test.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceMemory(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp uint64
+	}{
+		{"42", 42},          // 42 Bytes
+		{"42MB", 42000000},  // 42 Megabytes
+		{"42MiB", 44040192}, // 42 Mebibyte
+		{"42mb", 42000000},  // 42 Megabytes
+		{"42mib", 44040192}, // 42 Mebibyte
+	}
+
+	for _, p := range tests {
+		cfg, err := NewResourcesConfigBuilder().Memory(p.in).Build()
+		require.NoError(t, err)
+		// TODO I think this is where the bug occurs
+		actual, err := cfg.ToResources()
+		require.NoError(t, err)
+
+		require.Equal(t, p.exp, actual.Memory)
+	}
+}

--- a/pkg/models/resources_test.go
+++ b/pkg/models/resources_test.go
@@ -23,7 +23,6 @@ func TestResourceBytes(t *testing.T) {
 	for _, p := range tests {
 		cfg, err := NewResourcesConfigBuilder().Memory(p.in).Disk(p.in).Build()
 		require.NoError(t, err)
-		// TODO I think this is where the bug occurs
 		actual, err := cfg.ToResources()
 		require.NoError(t, err)
 

--- a/pkg/models/resources_test.go
+++ b/pkg/models/resources_test.go
@@ -1,3 +1,5 @@
+//go:build unit || !integration
+
 package models
 
 import (
@@ -6,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResourceMemory(t *testing.T) {
+func TestResourceBytes(t *testing.T) {
 	tests := []struct {
 		in  string
 		exp uint64
@@ -19,12 +21,13 @@ func TestResourceMemory(t *testing.T) {
 	}
 
 	for _, p := range tests {
-		cfg, err := NewResourcesConfigBuilder().Memory(p.in).Build()
+		cfg, err := NewResourcesConfigBuilder().Memory(p.in).Disk(p.in).Build()
 		require.NoError(t, err)
 		// TODO I think this is where the bug occurs
 		actual, err := cfg.ToResources()
 		require.NoError(t, err)
 
 		require.Equal(t, p.exp, actual.Memory)
+		require.Equal(t, p.exp, actual.Disk)
 	}
 }


### PR DESCRIPTION
This change modifies `models.ResourceConfig` to use `go-humanize` instead of `datasize` for more accurate parsing of human-readable strings into bytes. `go-humanize` can parse mebibyte strings and megabytes strings (ditto that for the rest of the SI units). Also updated the 'String' method of 'ResourceConfig' to reflect these changes.

I noticed this issue when `bacalhau config auto-resources` produced a config that failed to parse. The bacalhau config system uses `go-humanize` for parsing values, and had modified `model.ResourceConfig` to do the same. When https://github.com/bacalhau-project/bacalhau/pull/3061 landed it replaced usage of `model.ResourceConfig` with `models.ResourceConfig` which broke the behavior implemented in https://github.com/bacalhau-project/bacalhau/pull/3012. The change resolves this breakage.

Additionally, when making this change I noticed the `models.ResourceConfig.Normalize()` method erroneously converted Mebibytes (Mi/MiB) to Megabyte (MB) when parsing the string representation. The `datasize` package doesn't distinguish these types. The `model.ResourceConfig` implementation did not have this behavior. `go-humanize` does distinguish between these types. I have removed the incorrect behavior from `models.ResourceConfig.Normalize()` and update the test for it.
