### PR TITLE
Remove building Bacalhau as part of Docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,14 @@ commands:
         - ~/.cache/go-build
         - ~/go/pkg/mod
 
+  install_python:
+    steps:
+    - run: sudo apt install python3.10 -y
+    - run: curl -sSL https://install.python-poetry.org | python3 -
+    - run: echo 'export PATH="/home/circleci/.local/bin:$PATH"' >> "$BASH_ENV"
+
 jobs:
-  build:
+  test:
     parallelism: 1
     environment:
       GOPROXY: https://proxy.golang.org
@@ -115,8 +121,6 @@ jobs:
       target_os:
         type: enum
         enum: ["linux", "darwin", "windows"]
-      run_tests:
-        type: boolean
       build_tags:
         type: string
         default: ""
@@ -124,7 +128,7 @@ jobs:
     - checkout
 
     - attach_workspace:
-        at: ~/repo
+        at: .
 
     - when:
         condition:
@@ -148,92 +152,69 @@ jobs:
           which go
 
     - run:
-        name: Build
-        command: make build-ci
+        name: "Setup BACALHAU_ENVIRONMENT environment variable"
+        command: echo 'export BACALHAU_ENVIRONMENT=test' >> "$BASH_ENV"
+    - run:
+        name: Test Go
+        environment:
+          LOG_LEVEL: debug
+          TEST_BUILD_TAGS: << parameters.build_tags >>
+          TEST_PARALLEL_PACKAGES: 4 # This is set to 4 as xlarge instances have at least 8 CPUs, and we want to leave some CPU for the Docker instances
+        command: |
+          export GOBIN=${HOME}/bin
+          export PATH=$GOBIN:$PATH
+          go install gotest.tools/gotestsum@v1.8.2
+          make test-and-report
+        no_output_timeout: 20m
 
-    - when:
-        condition:
-          equal: [true, << parameters.run_tests >>]
-        steps:
-        - run:
-            name: "Setup BACALHAU_ENVIRONMENT environment variable"
-            command: echo 'export BACALHAU_ENVIRONMENT=test' >> "$BASH_ENV"
-        - run:
-            name: Test Go
-            environment:
-              LOG_LEVEL: debug
-              TEST_BUILD_TAGS: << parameters.build_tags >>
-              TEST_PARALLEL_PACKAGES: 4 # This is set to 4 as xlarge instances have at least 8 CPUs, and we want to leave some CPU for the Docker instances
-            command: |
-              export GOBIN=${HOME}/bin
-              export PATH=$GOBIN:$PATH
-              go install gotest.tools/gotestsum@v1.8.2
-              make test-and-report
+    - store_test_results:
+        path: .
+    - persist_to_workspace:
+        root: coverage/
+        paths:
+        - "*.coverage"
 
-            no_output_timeout: 20m
-        - store_test_results:
-            path: .
-        - persist_to_workspace:
-            root: coverage/
-            paths:
-            - "*.coverage"
+  test-python-sdk:
+    parallelism: 1
+    executor: linux-amd64
+    steps:
+    - checkout
+    - install_python
+    - run:
+        working_directory: python
+        command: make setup test
 
-    - when:
-        condition:
-          and:
-          - equal: ["linux", << parameters.target_os >>]
-          - equal: ["amd64", << parameters.target_arch >>]
-          - equal: [true, << parameters.run_tests >>]
-        steps:
-        - run:
-            name: Test Python SDK
-            command: |
-              sudo apt install python3.10 -y
-              curl -sSL https://install.python-poetry.org | python3 -
-              cd python
-              # Unsetting locale because of https://github.com/python-poetry/poetry/issues/3412
-              env LANG= LANGUAGE= LC_ALL= /home/circleci/.local/bin/poetry lock --no-update --no-interaction
-              # Using '--no-ansi' because of https://github.com/python-poetry/poetry/issues/7184
-              env LANG= LANGUAGE= LC_ALL= /home/circleci/.local/bin/poetry install --no-root --no-interaction --no-ansi --with test
-              # Run tests
-              cd ..
-              make test-python
-        - run:
-            name: Test Python Airflow Provider
-            command: |
-              cd integration/airflow
-              pip3 install -r dev-requirements.txt
-              tox
-              cd ../..
-        - run:
-            name: Test Python Flyte plugin
-            command: |
-              cd integration/flyte
-              make setup
-              make test
-              cd ../..
-            # - run:
-            #     name: Upload results
-            #     command: |
-            #       export DEBIAN_FRONTEND=noninteractive
-            #       sudo apt install python3.10 -y
-            #       python3 -m pip install --upgrade pip
-            #       pip3 install gsutil
-            #       export SHA="<< pipeline.git.revision >>"
-            #       export DATETIME="$(date -u +"%FT%H%MZ")"
-            #       if [ "<<pipeline.git.tag>>" != "" ]; then
-            #         export TEST_RESULTS_FILENAME="<<pipeline.git.tag>>-$DATETIME-$SHA.xml"
-            #       else
-            #         export TEST_RESULTS_FILENAME="<<pipeline.git.branch>>-$DATETIME-$SHA.xml"
-            #       fi
-            #       # Credentials for project: bacalhau-cicd
-            #       # Account:
-            #       echo "$GOOGLE_CLOUD_STORAGE_BACALHAU_CICD_RW" | base64 --decode > ~/.boto
-            #       if [[ "${TEST_RESULTS_FILENAME}" == *"/"* ]]; then
-            #         mkdir -p $(dirname "${TEST_RESULTS_FILENAME}")
-            #       fi
-            #       mv unittests.xml "${TEST_RESULTS_FILENAME}"
-            #       gsutil cp "$TEST_RESULTS_FILENAME" "gs://$GCS_TEST_RESULTS_BUCKET"
+  test-python-airflow:
+    parallelism: 1
+    executor: linux-amd64
+    steps:
+      - checkout
+      - install_python
+      - run:
+          working_directory: integration/airflow
+          command: make setup test-all
+
+  test-python-flyte:
+    parallelism: 1
+    executor: linux-amd64
+    steps:
+      - checkout
+      - install_python
+      - run:
+          working_directory: integration/flyte
+          command: make setup test
+
+  build:
+    parallelism: 1
+    executor: linux-amd64
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - install_go:
+        executor: linux-amd64
 
     - run:
         name: Build tarball
@@ -241,18 +222,21 @@ jobs:
           echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
           echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
           export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
-          make build-bacalhau-tgz
+          # Prevent rebuilding web ui, we should have already attached it
+          find webui -exec touch -c '{}' +
+          GOOS=linux GOARCH=amd64 make build-bacalhau-tgz
+          GOOS=linux GOARCH=arm64 make build-bacalhau-tgz
+          GOOS=darwin GOARCH=amd64 make build-bacalhau-tgz
+          GOOS=darwin GOARCH=arm64 make build-bacalhau-tgz
+          GOOS=linux GOARCH=armv6 make build-bacalhau-tgz
+          GOOS=linux GOARCH=armv7 make build-bacalhau-tgz
+          GOOS=windows GOARCH=amd64 make build-bacalhau-tgz
 
-    - when:
-        condition:
-          not:
-            equal: ["integration", << parameters.build_tags >>]
-        steps:
-        - persist_to_workspace:
-            root: dist/
-            paths:
-            - "*.tar.gz"
-            - "*.sha256"
+    - persist_to_workspace:
+        root: dist/
+        paths:
+        - "*.tar.gz"
+        - "*.sha256"
 
     - store_artifacts:
         path: dist/
@@ -272,6 +256,7 @@ jobs:
           root: .
           paths:
             - "webui/build/*"
+            - "webui/node_modules/*"
 
   build_canary:
     parallelism: 1
@@ -511,16 +496,27 @@ jobs:
     executor: linux-amd64
     steps:
     - checkout
+    - attach_workspace:
+        at: dist/
     - run:
-        name: Login to GHCR
         command: |
-          echo $GHCR_PAT | docker login ghcr.io -u circleci --password-stdin
+          mkdir -p bin/linux/amd64 && tar -xvf dist/bacalhau_*_linux_amd64.tar.gz -C bin/linux/amd64
+          mkdir -p bin/linux/arm64 && tar -xvf dist/bacalhau_*_linux_arm64.tar.gz -C bin/linux/arm64
     - run:
-        name: Push application Docker image
         command: |
           docker context create buildx-build
           docker buildx create --use buildx-build
-          make push-bacalhau-image
+          make build-bacalhau-image
+    - when:
+        condition:
+          matches:
+            value: << pipeline.git.tag >>
+            pattern: "^v([0-9]+).([0-9]+).([0-9]+).*$"
+        steps:
+        - run:
+            name: Login to Github Container Registry
+            command: echo $GHCR_PAT | docker login ghcr.io -u circleci --password-stdin
+        - run: make push-bacalhau-image
 
   build_python_packages:
     executor: linux-amd64
@@ -613,215 +609,33 @@ workflows:
           tags:
             ignore: /.*/
 
-  # These workflow will run on all branches except 'main' and will not run on tags
-  test_linux_amd64:
+  test:
     jobs:
     - build_webui
-    - build:
+    - test:
         name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
         executor: << matrix.target_os >>-<< matrix.target_arch >>
         requires:
           - build_webui
         matrix:
           parameters:
-            target_os: ["linux"]
-            target_arch: ["amd64"]
-            run_tests: [true]
-            build_tags: ["unit", "integration"]
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-    - coverage:
-        name: Build coverage report
-        requires:
-        - build
-
-  test_linux_arm64:
-    jobs:
-    - build_webui
-    - build:
-        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        requires:
-          - build_webui
-        matrix:
-          parameters:
-            target_os: ["linux"]
-            target_arch: ["arm64"]
-            run_tests: [true]
-            build_tags: ["unit", "integration"]
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-
-  test_linux_armv6:
-    jobs:
-    - build_webui
-    - build:
-        name: test-linux-armv6
-        executor: linux-arm64
-        requires:
-          - build_webui
-        target_os: linux
-        target_arch: armv6
-        run_tests: false
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-
-  test_linux_armv7:
-    jobs:
-    - build_webui
-    - build:
-        name: test-linux-armv7
-        executor: linux-arm64
-        requires:
-          - build_webui
-        target_os: linux
-        target_arch: armv7
-        run_tests: false
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-
-  test_darwin_amd64:
-    jobs:
-    - build_webui
-    - build:
-        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        requires:
-          - build_webui
-        matrix:
-          parameters:
-            target_os: ["darwin"]
-            target_arch: ["amd64"]
-            run_tests: [true]
-            build_tags: ["unit", "integration"]
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-
-  test_darwin_arm64:
-    jobs:
-    - build_webui
-    - build:
-        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        requires:
-          - build_webui
-        matrix:
-          parameters:
-            target_os: ["darwin"]
-            target_arch: ["arm64"]
-            run_tests: [true]
-            build_tags: ["unit", "integration"]
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-
-  test_windows_amd64:
-    jobs:
-    - build_webui
-    - build:
-        name: test-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        requires:
-          - build_webui
-        matrix:
-          parameters:
-            target_os: ["windows"]
-            target_arch: ["amd64"]
-            run_tests: [true]
-            build_tags: ["unit", "integration"]
-        filters:
-          branches:
-            ignore: main
-          tags:
-            ignore: /.*/
-
-  main_only: # This workflow will only run on 'main' and will not run on tags
-    jobs:
-    - build_webui:
-        filters: &filters_main_only
-          branches: # this yaml anchor is setting these values to "filters_main_only"
-            only: main
-          tags:
-            ignore: /.*/
-    - build:
-        name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        requires:
-          - build_webui
-        matrix:
-          alias: build-generic
-          parameters:
-            target_os: ["linux", "darwin"]
+            target_os: ["linux", "darwin", "windows"]
             target_arch: ["amd64", "arm64"]
-            run_tests: [true]
             build_tags: ["unit", "integration"]
-        filters: *filters_main_only
-    - build:
-        name: build-<< matrix.target_os >>-<< matrix.target_arch >>-<< matrix.build_tags >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        matrix:
-          alias: build-windows
-          parameters:
-            target_os: ["windows"]
-            target_arch: ["amd64"]
-            run_tests: [true]
-            build_tags: ["unit", "integration"]
-        filters: *filters_main_only
-    - build:
-        name: build-linux-<< matrix.target_arch >>
-        executor: linux-arm64
-        target_os: linux
-        run_tests: false
-        matrix:
-          alias: build-arm
-          parameters:
-            target_arch: ["armv6", "armv7"]
-        filters: *filters_main_only
-        # - update_metadata:
-        #     name: Update metadata for main test runs
-        #     requires:
-        #     - build-linux-amd64-unit
-        #     METADATA_BUCKET: "bacalhau-global-storage"
-        #     METADATA_FILENAME: "LAST-TEST-RUNS-METADATA-OBJECT"
+          exclude:
+            - target_os: windows
+              target_arch: arm64
+              build_tags: unit
+            - target_os: windows
+              target_arch: arm64
+              build_tags: integration
+    - test-python-sdk
+    - test-python-airflow
+    - test-python-flyte
     - coverage:
         name: Build coverage report
         requires:
-        - build-generic
-        - build-windows
-        - build-arm
-
-  build_jsonschema: # Runs on new tags starting with 'v.'
-    jobs:
-    - build:
-        name: build-linux-amd64
-        executor: linux-amd64
-        target_os: linux
-        target_arch: amd64
-        run_tests: false
-        filters: &filters_tags_only
-          branches:
-            ignore: /.*/ # don't run on any branches - only tags
-          tags:
-            # only run on tags that look like release tags e.g. v0.1.2 or
-            # v0.1.3alpha19 (actually v0.1.3anything...)
-            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+        - test
 
   python:
     jobs:
@@ -836,45 +650,23 @@ workflows:
         requires:
         - build-swagger-spec
         - build-python-packages
-        filters: *filters_tags_only
-
-  tags_only: # This workflow will only run on tags (specifically starting with 'v.') and will not run on branches
-    jobs:
-    - build:
-        name: build-<< matrix.target_os >>-<< matrix.target_arch >>
-        executor: << matrix.target_os >>-<< matrix.target_arch >>
-        matrix:
-          alias: build-generic
-          parameters:
-            target_os: ["linux", "darwin", "windows"]
-            target_arch: ["amd64", "arm64"]
-            run_tests: [false]
-          exclude:
-          - target_os: windows
-            target_arch: arm64
-            run_tests: false
-        filters: *filters_tags_only
-    - build:
-        name: build-linux-<< matrix.target_arch >>
-        executor: linux-arm64
-        target_os: linux
-        run_tests: false
-        matrix:
-          alias: build-arm
-          parameters:
-            target_arch: ["armv6", "armv7"]
-        filters: *filters_tags_only
-    - release:
-        name: release-all-binaries
-        requires:
-        - build-generic
-        - build-arm
-        filters: *filters_tags_only
-    - docker:
-        filters:
+        # This job will only run on tags (specifically starting with 'v.') and
+        # will not run on branches
+        filters: &filters_release_only
           branches:
             ignore: /.*/ # don't run on any branches - only tags
           tags:
-            # only run on tags that STRICTLY look like release tags e.g. v0.1.2,
-            # NOT v0.1.3alpha19 (i.e. only build containers on real releases)
-            only: /^v([0-9]+).([0-9]+).([0-9]+)$/
+            # only run on tags that look like release tags e.g. v0.1.2 or
+            # v0.1.3alpha19 (actually v0.1.3anything...)
+            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+
+  build:
+    jobs:
+    - build_webui
+    - build:
+        requires: [build_webui]
+    - docker:
+        requires: [build]
+    - release:
+        requires: [build]
+        filters: *filters_release_only

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@
 **/*.swo
 **/*.out
 **/*.tfvars
-**/bin/**
 **/.vscode
 **/vendor/*
 **/stderr

--- a/docker/bacalhau-image/Dockerfile
+++ b/docker/bacalhau-image/Dockerfile
@@ -1,27 +1,12 @@
 # syntax=docker/dockerfile:1.4
-# Pinned to 1.20
-FROM cgr.dev/chainguard/go@sha256:8ed3fdc8f6375a3fd84b4b8b696a2366c3a639931aab492d6f92ca917e726ad6 as build
-
-# Release tag. Used to build the binary and tag the version.
-ARG TAG
-
-WORKDIR /work
-
-# only copy what we need to build the binary instead of
-# the whole repo and then filter using .dockerignore
-COPY pkg ./pkg
-COPY cmd ./cmd
-COPY testdata ./testdata
-COPY docs ./docs
-COPY go.mod .
-COPY main.go .
-COPY Makefile .
-RUN make modtidy
-RUN make build-bacalhau
-RUN find ./bin -name 'bacalhau' -exec mv -t ./bin {} +
-
 FROM cgr.dev/chainguard/nvidia-device-plugin
-COPY --from=build /work/bin/bacalhau /usr/local/bin/bacalhau
+
+# Automatically set by Docker to be the --platform flag
+ARG TARGETPLATFORM
+
+# Take advantage of the format for $TARGETPLATFORM being "OS/ARCH"
+# which matches our output directory structure in ./bin
+ADD bin/$TARGETPLATFORM/bacalhau /usr/local/bin/bacalhau
 ENV PATH="/usr/local/bin:/usr/bin"
 ENTRYPOINT ["bacalhau"]
 LABEL org.opencontainers.image.source https://github.com/bacalhau-project/bacalhau

--- a/integration/airflow/Makefile
+++ b/integration/airflow/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-build clean-pyc clean-test coverage dist docs help install lint lint/flake8 lint/black
+.PHONY: clean clean-build clean-pyc clean-test coverage dist docs help install lint lint/flake8 lint/black setup
 .DEFAULT_GOAL := help
 VERSION ?= $${PYPI_VERSION}
 
@@ -28,6 +28,11 @@ all: lint dist
 
 help:
 	@python3 -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+setup:
+	pip3 install -r dev-requirements.txt
+## workaround for https://github.com/bacalhau-project/bacalhau/issues/2683:
+	mkdir ~/.bacalhau
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 

--- a/integration/flyte/Makefile
+++ b/integration/flyte/Makefile
@@ -2,10 +2,12 @@
 install-piptools:
 	# pip 22.1 broke pip-tools: https://github.com/jazzband/pip-tools/issues/1617
 	python3 -m pip install -U pip-tools setuptools wheel "pip>=22.0.3,!=22.1"
-	
+
 .PHONY: setup
 setup: install-piptools ## Install requirements
 	python3 -m pip install -r dev-requirements.in
+## workaround for https://github.com/bacalhau-project/bacalhau/issues/2683:
+	mkdir ~/.bacalhau
 
 .PHONY: test
 test: ## Run tests

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,10 +1,17 @@
-POETRY := $(shell command -v poetry 2> /dev/null)
+POETRY ?= $(shell command -v poetry)
 VERSION ?= $${PYPI_VERSION}
 
 sources = bacalhau_sdk
 
-.`.PHONY: all
+.PHONY: all
 all: format lint pre-commit build
+
+.PHONY: setup
+setup:
+	$(POETRY) lock --no-update --no-interaction
+	$(POETRY) install --no-root --no-interaction --no-ansi --with test
+## workaround for https://github.com/bacalhau-project/bacalhau/issues/2683:
+	mkdir ~/.bacalhau
 
 .PHONY: test
 test: unittest coverage


### PR DESCRIPTION
This meant that our new Web UI build steps were not being picked up. This is not really necessary as we can just reuse the output that was created from our CI build step, rather than the rigmarole of trying to capture the right files and recreate the build process within the Dockerfile.

This change also means we can build the docker image on PRs as well, to check that it works.

There are some other refactors here – we now build and test as separate jobs so that we don't need to wait for tests to pass before pushing binaries to a release, and also generate all of our binaries from a single cross-compiling step (because we don't use CGO and hence can compile for all platforms from anywhere).

As a result of this refactor, the build time in CI is reduced from 17m to 14m... every little helps, I guess.