### PR TITLE
Fix GPU labels for nodes with multiple GPU vendors

### DIFF
--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -448,7 +448,7 @@ func AutoOutputLabels() map[string]string {
 		// Print the GPU names
 		for i, gpu := range resources.GPUs {
 			// Model label e.g. GPU-0: Tesla-T1
-			key := fmt.Sprintf("GPU-%d", gpu.Index)
+			key := fmt.Sprintf("GPU-%d", i)
 			name := strings.Replace(gpu.Name, " ", "-", -1) // Replace spaces with dashes
 			m[key] = name
 


### PR DESCRIPTION
The GPU index is self reported and not guaranteed to be unique across different GPU vendors. This was causing labels from different vendors to collide and override each other.