### PR TITLE
Speed up CI a little bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,6 @@ jobs:
         executor: << parameters.executor >>
 
     - run:
-        name: Init tools
-        command: |
-          make init
-          go version
-          which go
-
-    - run:
         name: "Setup BACALHAU_ENVIRONMENT environment variable"
         command: echo 'export BACALHAU_ENVIRONMENT=test' >> "$BASH_ENV"
     - run:

--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ COVER_FILE := coverage/${PACKAGE}_$(subst ${COMMA},_,${TEST_BUILD_TAGS}).coverag
 .PHONY: test-and-report
 test-and-report: unittests.xml ${COVER_FILE}
 
-${COVER_FILE} unittests.xml ${TEST_OUTPUT_FILE_PREFIX}_unit.json: ${BINARY_PATH} $(dir ${COVER_FILE})
+${COVER_FILE} unittests.xml ${TEST_OUTPUT_FILE_PREFIX}_unit.json &: ${CMD_FILES} ${PKG_FILES} $(dir ${COVER_FILE})
 	gotestsum \
 		--jsonfile ${TEST_OUTPUT_FILE_PREFIX}_unit.json \
 		--junitfile unittests.xml \


### PR DESCRIPTION
- We don't need to init tools for test or build anymore, because these jobs don't do anything with Python or Node anymore.
- We don't need to build the binary before running tests, which also saves installing the Node modules and building the Web UI.

Speeds up CI by about 2 minutes.