### PR TITLE
Build and release on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,10 +634,15 @@ workflows:
     jobs:
     - build_swagger:
         name: build-swagger-spec
+        filters: &build_on_branch_and_tag_push
+          tags:
+            # only run on tags that look like release tags e.g. v0.1.2 or
+            # v0.1.3alpha19 (actually v0.1.3anything...)
+            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
     - build_python_packages:
         name: build-python-packages
-        requires:
-        - build-swagger-spec
+        requires: [build-swagger-spec]
+        filters: *build_on_branch_and_tag_push
     - release_python:
         name: release-python-packages
         requires:
@@ -645,21 +650,21 @@ workflows:
         - build-python-packages
         # This job will only run on tags (specifically starting with 'v.') and
         # will not run on branches
-        filters: &filters_release_only
+        filters: &build_on_release_only
           branches:
             ignore: /.*/ # don't run on any branches - only tags
-          tags:
-            # only run on tags that look like release tags e.g. v0.1.2 or
-            # v0.1.3alpha19 (actually v0.1.3anything...)
-            only: /^v([0-9]+).([0-9]+).([0-9]+).*$/
+          <<: *build_on_branch_and_tag_push
 
   build:
     jobs:
-    - build_webui
+    - build_webui:
+        filters: *build_on_branch_and_tag_push
     - build:
         requires: [build_webui]
+        filters: *build_on_branch_and_tag_push
     - docker:
         requires: [build]
+        filters: *build_on_branch_and_tag_push
     - release:
         requires: [build]
-        filters: *filters_release_only
+        filters: *build_on_release_only


### PR DESCRIPTION
It turns out the tag filtering system works opposite to the branch filtering: they don't run jobs on tags by default, only on tags that specifically select:

https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag