### PR TITLE
Make logs wait for execution to be running

### DIFF
--- a/pkg/compute/logstream/server.go
+++ b/pkg/compute/logstream/server.go
@@ -87,7 +87,7 @@ func (s *LogStreamServer) Handle(stream network.Stream) {
 
 	reader, err := e.GetOutputStream(s.ctx, localExecutionState.Execution.ID, request.WithHistory, request.Follow)
 	if err != nil {
-		log.Ctx(s.ctx).Error().Msgf("failed to get output streams from job: %s", localExecutionState.Execution.JobID)
+		log.Ctx(s.ctx).Error().Err(err).Str("JobID", localExecutionState.Execution.JobID).Msgf("failed to get output streams from job")
 		_ = stream.Reset()
 		return
 	}

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -37,6 +37,9 @@ const (
 	labelExecutorName = "bacalhau-executor"
 	labelJobName      = "bacalhau-jobID"
 	labelExecutionID  = "bacalhau-executionID"
+
+	outputStreamCheckTickTime = 100 * time.Millisecond
+	outputStreamCheckTimeout  = 5 * time.Second
 )
 
 type Executor struct {
@@ -246,7 +249,7 @@ func (e *Executor) GetOutputStream(ctx context.Context, executionID string, with
 		// Check the handlers every 100ms and send it down the
 		// channel if we find it. If we don't find it after 5 seconds
 		// then we'll be told on the exit channel
-		ticker := time.NewTicker(100 * time.Millisecond)
+		ticker := time.NewTicker(outputStreamCheckTickTime)
 		defer ticker.Stop()
 
 		for {
@@ -269,7 +272,7 @@ func (e *Executor) GetOutputStream(ctx context.Context, executionID string, with
 	select {
 	case handler := <-chHandler:
 		return handler.outputStream(ctx, withHistory, follow)
-	case <-time.After(5 * time.Second):
+	case <-time.After(outputStreamCheckTimeout):
 		chExit <- struct{}{}
 	}
 

--- a/pkg/executor/docker/executor.go
+++ b/pkg/executor/docker/executor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -235,11 +236,44 @@ func (e *Executor) Cancel(ctx context.Context, executionID string) error {
 // and whether to keep the stream open for new logs, respectively.
 // It returns an error if the execution is not found.
 func (e *Executor) GetOutputStream(ctx context.Context, executionID string, withHistory bool, follow bool) (io.ReadCloser, error) {
-	handler, found := e.handlers.Get(executionID)
-	if !found {
-		return nil, fmt.Errorf("getting outputs for execution (%s): %w", executionID, executor.ErrNotFound)
+	// It's possible we've recorded the execution as running, but have not yet added the handler to
+	// the handler map because we're still waiting for the container to start. We will try and wait
+	// for a few seconds to see if the handler is added to the map.
+	chHandler := make(chan *executionHandler)
+	chExit := make(chan struct{})
+
+	go func(ch chan *executionHandler, exit chan struct{}) {
+		// Check the handlers every 100ms and send it down the
+		// channel if we find it. If we don't find it after 5 seconds
+		// then we'll be told on the exit channel
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				h, found := e.handlers.Get(executionID)
+				if found {
+					ch <- h
+					return
+				}
+			case <-exit:
+				ticker.Stop()
+				return
+			}
+		}
+	}(chHandler, chExit)
+
+	// Either we'll find a handler for the execution (which might have finished starting)
+	// or we'll timeout and return an error.
+	select {
+	case handler := <-chHandler:
+		return handler.outputStream(ctx, withHistory, follow)
+	case <-time.After(5 * time.Second):
+		chExit <- struct{}{}
 	}
-	return handler.outputStream(ctx, withHistory, found)
+
+	return nil, fmt.Errorf("getting outputs for execution (%s): %w", executionID, executor.ErrNotFound)
 }
 
 // Run initiates and waits for the completion of an execution in one call.

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -479,10 +479,9 @@ func (s *ExecutorTestSuite) TestDockerStreamsAlreadyComplete() {
 		_, _ = s.runJobWithContext(ctx, task, id)
 		done <- true
 	}()
-
+	<-done
 	reader, err := s.executor.GetOutputStream(ctx, id, true, true)
 
-	<-done
 	require.Nil(s.T(), reader)
 	require.Error(s.T(), err)
 }

--- a/pkg/publicapi/endpoint/requester/endpoints_logs.go
+++ b/pkg/publicapi/endpoint/requester/endpoints_logs.go
@@ -124,7 +124,12 @@ func (s *Endpoint) logs(c echo.Context) error {
 			break
 		}
 		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msgf("Stream read failure. May be reset?: %s", err)
+			log.Ctx(ctx).
+				Error().
+				Err(err).
+				Str("Job", payload.JobID).
+				Str("Execution", payload.ExecutionID).
+				Msgf("Stream read failure. May be reset?: %s", err)
 			break
 		}
 


### PR DESCRIPTION
Currently when using the logs (docker run -f) it's possible that the log request gets to the compute node before the execution is running (this was highlighted when adding -f to the exec command).  There is a gap between when the execution is marked as running and when the docker container is actually started and running the code.  During this gap we previously did a single check to find the docker.executionHandler for the execution and then gave up.  

The new version now checks every 100ms until either we find the handler, or the goroutine is timed out (5s). Code is sleep-free. 