### PR TITLE
Enable experimental job translation

### DIFF
--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -76,4 +76,5 @@ bacalhau serve \
   --peer "${CONNECT_PEER}" \
   --private-internal-ipfs=false \
   --web-ui "${BACALHAU_NODE_WEBUI}" \
-  --labels owner=bacalhau
+  --labels owner=bacalhau \
+  --requester-job-translation-enabled


### PR DESCRIPTION
Enables the job translation (python + duckdb) for deployment. Not yet documented for use but will give us an opportunity to test more.