### PR TITLE
Only release Bacalhau artifacts from the workspace.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
           TAG="<< pipeline.git.tag >>"
           echo "TAG = ${TAG}"
           find dist/
-          gh release upload $TAG dist/*
+          gh release upload $TAG dist/bacalhau_$TAG_*
 
   release_python:
     executor: linux-amd64


### PR DESCRIPTION
It was picking up our webui build files which we don't want to release.