### PR TITLE
Shunt GPU tooling error messages to DEBUG

### DIFF
--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -1,11 +1,8 @@
 package serve
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -14,7 +11,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
-	system_capacity "github.com/bacalhau-project/bacalhau/pkg/compute/capacity/system"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	bac_libp2p "github.com/bacalhau-project/bacalhau/pkg/libp2p"
@@ -234,8 +230,6 @@ func serve(cmd *cobra.Command) error {
 
 	allowedListLocalPaths := getAllowListedLocalPathsConfig()
 
-	// TODO (forrest): [ux] in the future we should make this configurable to users.
-	autoLabel := true
 	// Create node config from cmd arguments
 	nodeConfig := node.NodeConfig{
 		CleanupManager:        cm,
@@ -248,7 +242,7 @@ func serve(cmd *cobra.Command) error {
 		RequesterNodeConfig:   requesterConfig,
 		IsComputeNode:         isComputeNode,
 		IsRequesterNode:       isRequesterNode,
-		Labels:                getNodeLabels(autoLabel),
+		Labels:                config.GetStringMapString(types.NodeLabels),
 		AllowListedLocalPaths: allowedListLocalPaths,
 		FsRepo:                fsRepo,
 		NodeInfoStoreTTL:      nodeInfoStoreTTL,
@@ -437,53 +431,4 @@ func pickP2pAddress(addresses []multiaddr.Multiaddr) multiaddr.Multiaddr {
 	})
 
 	return addresses[0]
-}
-
-func AutoOutputLabels() map[string]string {
-	m := make(map[string]string)
-	// Get the operating system name
-	os := runtime.GOOS
-	m["Operating-System"] = os
-	m["git-lfs"] = "False"
-	if checkGitLFS() {
-		m["git-lfs"] = "True"
-	}
-	arch := runtime.GOARCH
-	m["Architecture"] = arch
-
-	provider := system_capacity.NewPhysicalCapacityProvider()
-	resources, err := provider.GetAvailableCapacity(context.Background())
-	if err == nil {
-		// Print the GPU names
-		for i, gpu := range resources.GPUs {
-			// Model label e.g. GPU-0: Tesla-T1
-			key := fmt.Sprintf("GPU-%d", i)
-			name := strings.Replace(gpu.Name, " ", "-", -1) // Replace spaces with dashes
-			m[key] = name
-
-			// Memory label e.g. GPU-0-Memory: 15360-MiB
-			key = fmt.Sprintf("GPU-%d-Memory", i)
-			memory := strings.Replace(fmt.Sprintf("%d MiB", gpu.Memory), " ", "-", -1) // Replace spaces with dashes
-			m[key] = memory
-		}
-	}
-	// Get list of installed packages (Only works for linux, make it work for every platform)
-	// files, err := ioutil.ReadDir("/var/lib/dpkg/info")
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// var packageList []string
-	// for _, file := range files {
-	// 	if !file.IsDir() && filepath.Ext(file.FlagName()) == ".list" {
-
-	// 		packageList = append(packageList, file.FlagName()[:len(file.FlagName())-5])
-	// 	}
-	// }
-	// m["Installed-Packages"] = strings.Join(packageList, ",")
-	return m
-}
-
-func checkGitLFS() bool {
-	_, err := exec.LookPath("git-lfs")
-	return err == nil
 }

--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -177,23 +177,6 @@ func SetupIPFSClient(ctx context.Context, cm *system.CleanupManager, ipfsCfg typ
 	return client, nil
 }
 
-func getNodeLabels(autoLabel bool) map[string]string {
-	labelConfig := config.GetStringMapString(types.NodeLabels)
-	labelMap := make(map[string]string)
-	if autoLabel {
-		AutoLabels := AutoOutputLabels()
-		for key, value := range AutoLabels {
-			labelMap[key] = value
-		}
-	}
-
-	for key, value := range labelConfig {
-		labelMap[key] = value
-	}
-
-	return labelMap
-}
-
 func getDisabledFeatures() (node.FeatureConfig, error) {
 	var featureConfig node.FeatureConfig
 	if err := config.ForKey(types.NodeDisabledFeatures, &featureConfig); err != nil {

--- a/pkg/compute/capacity/labels.go
+++ b/pkg/compute/capacity/labels.go
@@ -1,0 +1,34 @@
+package capacity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+)
+
+type gpuLabelsProvider struct {
+	resources models.Resources
+}
+
+func NewGPULabelsProvider(totalCapacity models.Resources) models.LabelsProvider {
+	return gpuLabelsProvider{resources: totalCapacity}
+}
+
+// GetLabels implements models.LabelsProvider.
+func (p gpuLabelsProvider) GetLabels(ctx context.Context) map[string]string {
+	labels := make(map[string]string, len(p.resources.GPUs)*2)
+	for i, gpu := range p.resources.GPUs {
+		// Model label e.g. GPU-0: Tesla-T1
+		key := fmt.Sprintf("GPU-%d", i)
+		name := strings.Replace(gpu.Name, " ", "-", -1) // Replace spaces with dashes
+		labels[key] = name
+
+		// Memory label e.g. GPU-0-Memory: 15360-MiB
+		key = fmt.Sprintf("GPU-%d-Memory", i)
+		memory := strings.Replace(fmt.Sprintf("%d MiB", gpu.Memory), " ", "-", -1) // Replace spaces with dashes
+		labels[key] = memory
+	}
+	return labels
+}

--- a/pkg/compute/capacity/system/provider.go
+++ b/pkg/compute/capacity/system/provider.go
@@ -66,9 +66,10 @@ func (p *PhysicalCapacityProvider) GetTotalCapacity(ctx context.Context) (models
 			// smi can't communicate with the drivers, etc. instead we provide a
 			// warning, show the args to the command we tried and its response.
 			// motivation: https://expanso.atlassian.net/browse/GDAY-90
-			log.Ctx(ctx).Warn().Err(err).Msgf(
-				"Cannot inspect %s so they will not be used",
+			log.Ctx(ctx).Debug().Msgf(
+				"Cannot inspect %s so they will not be used: %s",
 				strings.Join(gpuProvider.ResourceTypes(), " or "),
+				err.Error(),
 			)
 			continue
 		}

--- a/pkg/models/node_info.go
+++ b/pkg/models/node_info.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"golang.org/x/exp/maps"
 )
 
 type NodeType int
@@ -43,6 +44,27 @@ type NodeInfoProvider interface {
 
 type ComputeNodeInfoProvider interface {
 	GetComputeInfo(ctx context.Context) ComputeNodeInfo
+}
+
+type LabelsProvider interface {
+	GetLabels(ctx context.Context) map[string]string
+}
+
+type mergeProvider struct {
+	providers []LabelsProvider
+}
+
+// GetLabels implements LabelsProvider.
+func (p mergeProvider) GetLabels(ctx context.Context) map[string]string {
+	labels := make(map[string]string)
+	for _, provider := range p.providers {
+		maps.Copy(labels, provider.GetLabels(ctx))
+	}
+	return labels
+}
+
+func MergeLabelsInOrder(providers ...LabelsProvider) LabelsProvider {
+	return mergeProvider{providers: providers}
 }
 
 type NodeInfo struct {

--- a/pkg/node/labels.go
+++ b/pkg/node/labels.go
@@ -1,0 +1,28 @@
+package node
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+)
+
+type RuntimeLabelsProvider struct{}
+
+// GetLabels implements models.LabelsProvider.
+func (*RuntimeLabelsProvider) GetLabels(context.Context) map[string]string {
+	return map[string]string{
+		"Operating-System": runtime.GOOS,
+		"Architecture":     runtime.GOARCH,
+	}
+}
+
+var _ models.LabelsProvider = (*RuntimeLabelsProvider)(nil)
+
+type ConfigLabelsProvider struct {
+	staticLabels map[string]string
+}
+
+func (p *ConfigLabelsProvider) GetLabels(context.Context) map[string]string {
+	return p.staticLabels
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -161,18 +161,6 @@ func NewNode(
 		return nil, err
 	}
 
-	// node info provider
-	basicHost, ok := config.Host.(*basichost.BasicHost)
-	if !ok {
-		return nil, fmt.Errorf("host is not a basic host")
-	}
-	nodeInfoProvider := routing.NewNodeInfoProvider(routing.NodeInfoProviderParams{
-		Host:            basicHost,
-		IdentityService: basicHost.IDService(),
-		Labels:          config.Labels,
-		BacalhauVersion: *version.Get(),
-	})
-
 	// node info publisher
 	nodeInfoPublisherInterval := config.NodeInfoPublisherInterval
 	if nodeInfoPublisherInterval.IsZero() {
@@ -221,20 +209,11 @@ func NewNode(
 		return nil, err
 	}
 
-	shared.NewEndpoint(shared.EndpointParams{
-		Router:           apiServer.Router,
-		NodeID:           config.Host.ID().String(),
-		PeerStore:        config.Host.Peerstore(),
-		NodeInfoProvider: nodeInfoProvider,
-	})
-
-	agent.NewEndpoint(agent.EndpointParams{
-		Router:           apiServer.Router,
-		NodeInfoProvider: nodeInfoProvider,
-	})
-
 	var requesterNode *Requester
 	var computeNode *Compute
+
+	var computeInfoProvider models.ComputeNodeInfoProvider
+	var labelsProvider models.LabelsProvider = &ConfigLabelsProvider{staticLabels: config.Labels}
 
 	// setup requester node
 	if config.IsRequesterNode {
@@ -272,8 +251,38 @@ func NewNode(
 		if err != nil {
 			return nil, err
 		}
-		nodeInfoProvider.RegisterComputeInfoProvider(computeNode.computeInfoProvider)
+
+		computeInfoProvider = computeNode.computeInfoProvider
+		labelsProvider = models.MergeLabelsInOrder(
+			computeNode.autoLabelsProvider,
+			labelsProvider,
+		)
 	}
+
+	// node info provider
+	basicHost, ok := config.Host.(*basichost.BasicHost)
+	if !ok {
+		return nil, fmt.Errorf("host is not a basic host")
+	}
+	nodeInfoProvider := routing.NewNodeInfoProvider(routing.NodeInfoProviderParams{
+		Host:                basicHost,
+		IdentityService:     basicHost.IDService(),
+		LabelsProvider:      labelsProvider,
+		ComputeInfoProvider: computeInfoProvider,
+		BacalhauVersion:     *version.Get(),
+	})
+
+	shared.NewEndpoint(shared.EndpointParams{
+		Router:           apiServer.Router,
+		NodeID:           config.Host.ID().String(),
+		PeerStore:        config.Host.Peerstore(),
+		NodeInfoProvider: nodeInfoProvider,
+	})
+
+	agent.NewEndpoint(agent.EndpointParams{
+		Router:           apiServer.Router,
+		NodeInfoProvider: nodeInfoProvider,
+	})
 
 	// NB(forrest): this must be done last to avoid eager publishing before nodes are constructed
 	// TODO(forrest) [fixme] we should fix this to make it less racy in testing

--- a/pkg/routing/node_info_provider.go
+++ b/pkg/routing/node_info_provider.go
@@ -12,7 +12,7 @@ import (
 type NodeInfoProviderParams struct {
 	Host                host.Host
 	IdentityService     identify.IDService
-	Labels              map[string]string
+	LabelsProvider      models.LabelsProvider
 	ComputeInfoProvider models.ComputeNodeInfoProvider
 	BacalhauVersion     models.BuildVersionInfo
 }
@@ -20,7 +20,7 @@ type NodeInfoProviderParams struct {
 type NodeInfoProvider struct {
 	h                   host.Host
 	identityService     identify.IDService
-	labels              map[string]string
+	labelsProvider      models.LabelsProvider
 	computeInfoProvider models.ComputeNodeInfoProvider
 	bacalhauVersion     models.BuildVersionInfo
 }
@@ -29,15 +29,10 @@ func NewNodeInfoProvider(params NodeInfoProviderParams) *NodeInfoProvider {
 	return &NodeInfoProvider{
 		h:                   params.Host,
 		identityService:     params.IdentityService,
-		labels:              params.Labels,
+		labelsProvider:      params.LabelsProvider,
 		computeInfoProvider: params.ComputeInfoProvider,
 		bacalhauVersion:     params.BacalhauVersion,
 	}
-}
-
-// RegisterComputeInfoProvider registers a compute info provider with the node info provider.
-func (n *NodeInfoProvider) RegisterComputeInfoProvider(provider models.ComputeNodeInfoProvider) {
-	n.computeInfoProvider = provider
 }
 
 func (n *NodeInfoProvider) GetNodeInfo(ctx context.Context) models.NodeInfo {
@@ -47,7 +42,7 @@ func (n *NodeInfoProvider) GetNodeInfo(ctx context.Context) models.NodeInfo {
 			ID:    n.h.ID(),
 			Addrs: n.identityService.OwnObservedAddrs(),
 		},
-		Labels:   n.labels,
+		Labels:   n.labelsProvider.GetLabels(ctx),
 		NodeType: models.NodeTypeRequester,
 	}
 	if n.computeInfoProvider != nil {

--- a/pkg/storage/repo/labels.go
+++ b/pkg/storage/repo/labels.go
@@ -1,0 +1,21 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+)
+
+type labelsProvider struct{}
+
+func NewLabelsProvider() models.LabelsProvider {
+	return labelsProvider{}
+}
+
+// GetLabels implements models.LabelsProvider.
+func (labelsProvider) GetLabels(ctx context.Context) map[string]string {
+	return map[string]string{
+		"git-lfs": fmt.Sprint(checkGitLFS() != nil),
+	}
+}


### PR DESCRIPTION
Also clean up some tech debt around labels – make it part of the node setup proper, which paves the way for labels to be regenerated on every publish in the future.

Resolves #3082.