### PR TITLE
Show error message when nodes don't support Docker

### DIFF
--- a/cmd/cli/serve/timeout_test.go
+++ b/cmd/cli/serve/timeout_test.go
@@ -46,7 +46,7 @@ func (s *ServeSuite) TestNoTimeoutSetOrApplied() {
 		)
 
 		s.Run(name, func() {
-			args := []string{}
+			args := []string{"--node-type", "requester,compute"}
 			if tc.configuredMax != nil {
 				args = append(args, "--max-job-execution-timeout", tc.configuredMax.String())
 			}

--- a/pkg/orchestrator/interfaces.go
+++ b/pkg/orchestrator/interfaces.go
@@ -91,7 +91,6 @@ type Planner interface {
 // NodeDiscoverer discovers nodes in the network that are suitable to execute a job.
 type NodeDiscoverer interface {
 	ListNodes(ctx context.Context) ([]models.NodeInfo, error)
-	FindNodes(ctx context.Context, job models.Job) ([]models.NodeInfo, error)
 }
 
 // NodeRanker ranks nodes based on their suitability to execute a job.

--- a/pkg/orchestrator/selection/discovery/chained.go
+++ b/pkg/orchestrator/selection/discovery/chained.go
@@ -27,12 +27,6 @@ func (c *Chain) Add(discoverer ...orchestrator.NodeDiscoverer) {
 	c.discoverers = append(c.discoverers, discoverer...)
 }
 
-func (c *Chain) FindNodes(ctx context.Context, job models.Job) ([]models.NodeInfo, error) {
-	return c.chainDiscovery(ctx, "FindNodes", func(r orchestrator.NodeDiscoverer) ([]models.NodeInfo, error) {
-		return r.FindNodes(ctx, job)
-	})
-}
-
 func (c *Chain) ListNodes(ctx context.Context) ([]models.NodeInfo, error) {
 	return c.chainDiscovery(ctx, "ListNodes", func(r orchestrator.NodeDiscoverer) ([]models.NodeInfo, error) {
 		return r.ListNodes(ctx)

--- a/pkg/orchestrator/selection/discovery/chained_test.go
+++ b/pkg/orchestrator/selection/discovery/chained_test.go
@@ -34,21 +34,21 @@ func TestChainedSuite(t *testing.T) {
 	suite.Run(t, new(ChainedSuite))
 }
 
-func (s *ChainedSuite) TestFindNodes() {
+func (s *ChainedSuite) TestListNodes() {
 	s.chain.Add(NewFixedDiscoverer(s.peerID1))
 	s.chain.Add(NewFixedDiscoverer(s.peerID2))
 	s.chain.Add(NewFixedDiscoverer(s.peerID3))
 
-	peerIDs, err := s.chain.FindNodes(context.Background(), models.Job{})
+	peerIDs, err := s.chain.ListNodes(context.Background())
 	s.NoError(err)
 	s.ElementsMatch([]models.NodeInfo{s.peerID1, s.peerID2, s.peerID3}, peerIDs)
 }
 
-func (s *ChainedSuite) TestFindNodes_Overlap() {
+func (s *ChainedSuite) TestListNodes_Overlap() {
 	s.chain.Add(NewFixedDiscoverer(s.peerID1, s.peerID2))
 	s.chain.Add(NewFixedDiscoverer(s.peerID2, s.peerID3))
 
-	peerIDs, err := s.chain.FindNodes(context.Background(), models.Job{})
+	peerIDs, err := s.chain.ListNodes(context.Background())
 	s.NoError(err)
 	s.ElementsMatch([]models.NodeInfo{s.peerID1, s.peerID2, s.peerID3}, peerIDs)
 }
@@ -57,7 +57,7 @@ func (s *ChainedSuite) TestHandle_Error() {
 	s.chain.Add(NewFixedDiscoverer(s.peerID1, s.peerID2))
 	s.chain.Add(newBadDiscoverer())
 	s.chain.Add(NewFixedDiscoverer(s.peerID3))
-	_, err := s.chain.FindNodes(context.Background(), models.Job{})
+	_, err := s.chain.ListNodes(context.Background())
 	s.Error(err)
 }
 
@@ -67,7 +67,7 @@ func (s *ChainedSuite) TestHandle_IgnoreError() {
 	s.chain.Add(newBadDiscoverer())
 	s.chain.Add(NewFixedDiscoverer(s.peerID3))
 
-	peerIDs, err := s.chain.FindNodes(context.Background(), models.Job{})
+	peerIDs, err := s.chain.ListNodes(context.Background())
 	s.NoError(err)
 	s.ElementsMatch([]models.NodeInfo{s.peerID1, s.peerID2, s.peerID3}, peerIDs)
 }
@@ -77,10 +77,6 @@ type badDiscoverer struct{}
 
 func newBadDiscoverer() *badDiscoverer {
 	return &badDiscoverer{}
-}
-
-func (b *badDiscoverer) FindNodes(context.Context, models.Job) ([]models.NodeInfo, error) {
-	return nil, errors.New("bad discoverer")
 }
 
 func (b *badDiscoverer) ListNodes(context.Context) ([]models.NodeInfo, error) {

--- a/pkg/orchestrator/selection/discovery/store.go
+++ b/pkg/orchestrator/selection/discovery/store.go
@@ -22,12 +22,6 @@ func NewStoreNodeDiscoverer(params StoreNodeDiscovererParams) *StoreNodeDiscover
 	}
 }
 
-// FindNodes returns the nodes that support the job's execution engine, and have enough TOTAL capacity to run the job.
-func (d *StoreNodeDiscoverer) FindNodes(ctx context.Context, job models.Job) ([]models.NodeInfo, error) {
-	// filter nodes that support the job's engine
-	return d.store.ListForEngine(ctx, job.Task().Engine.Type)
-}
-
 // ListNodes implements orchestrator.NodeDiscoverer
 func (d *StoreNodeDiscoverer) ListNodes(ctx context.Context) ([]models.NodeInfo, error) {
 	return d.store.List(ctx)

--- a/pkg/orchestrator/selection/discovery/store_test.go
+++ b/pkg/orchestrator/selection/discovery/store_test.go
@@ -34,30 +34,29 @@ func TestStoreNodeDiscovererSuite(t *testing.T) {
 	suite.Run(t, new(StoreNodeDiscovererSuite))
 }
 
-func (s *StoreNodeDiscovererSuite) TestFindNodes() {
+func (s *StoreNodeDiscovererSuite) TestListNodes() {
 	ctx := context.Background()
 	nodeInfo1 := generateNodeInfo("node1", models.EngineDocker)
-	nodeInfo2 := generateNodeInfo("node2", models.EngineDocker, models.EngineWasm)
 	s.NoError(s.store.Add(ctx, nodeInfo1))
-	s.NoError(s.store.Add(ctx, nodeInfo2))
 
 	// both nodes are returned when asked for docker nodes
 	job := mock.Job()
 	job.Task().Engine.Type = models.EngineDocker
 
-	peerIDs, err := s.discoverer.FindNodes(context.Background(), *job)
+	peerIDs, err := s.discoverer.ListNodes(context.Background())
+	s.NoError(err)
+	s.ElementsMatch([]models.NodeInfo{nodeInfo1}, peerIDs)
+
+	nodeInfo2 := generateNodeInfo("node2", models.EngineDocker, models.EngineWasm)
+	s.NoError(s.store.Add(ctx, nodeInfo2))
+	// only node2 is returned when asked for noop nodes
+	peerIDs, err = s.discoverer.ListNodes(context.Background())
 	s.NoError(err)
 	s.ElementsMatch([]models.NodeInfo{nodeInfo1, nodeInfo2}, peerIDs)
-
-	// only node2 is returned when asked for noop nodes
-	job2 := mock.Job()
-	peerIDs, err = s.discoverer.FindNodes(context.Background(), *job2)
-	s.NoError(err)
-	s.Empty(peerIDs)
 }
 
-func (s *StoreNodeDiscovererSuite) TestFindNodes_Empty() {
-	peerIDs, err := s.discoverer.FindNodes(context.Background(), *mock.Job())
+func (s *StoreNodeDiscovererSuite) TestListNodes_Empty() {
+	peerIDs, err := s.discoverer.ListNodes(context.Background())
 	s.NoError(err)
 	s.Empty(peerIDs)
 }

--- a/pkg/orchestrator/selection/ranking/features.go
+++ b/pkg/orchestrator/selection/ranking/features.go
@@ -74,7 +74,8 @@ func (s *featureNodeRanker) rankNode(ctx context.Context, node models.NodeInfo, 
 
 		if !found {
 			// Target wasn't found – we can end early as we won't use this node.
-			return orchestrator.RankUnsuitable, fmt.Sprintf("does not support %s, only %s", requiredKey, providedKeys)
+			availableKeys := strings.Join(providedKeys, ", ")
+			return orchestrator.RankUnsuitable, fmt.Sprintf("does not support %s, only %s", requiredKey, availableKeys)
 		}
 	}
 

--- a/pkg/orchestrator/selection/selector/node_selector.go
+++ b/pkg/orchestrator/selection/selector/node_selector.go
@@ -62,7 +62,7 @@ func (n NodeSelector) TopMatchingNodes(ctx context.Context, job *models.Job, des
 }
 
 func (n NodeSelector) rankAndFilterNodes(ctx context.Context, job *models.Job) (selected, rejected []orchestrator.NodeRank, err error) {
-	nodeIDs, err := n.nodeDiscoverer.FindNodes(ctx, *job)
+	nodeIDs, err := n.nodeDiscoverer.ListNodes(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/routing/inmemory/inmemory_test.go
+++ b/pkg/routing/inmemory/inmemory_test.go
@@ -119,24 +119,6 @@ func (s *InMemoryNodeInfoStoreSuite) Test_List() {
 	s.ElementsMatch([]models.NodeInfo{nodeInfo0, nodeInfo1}, allNodeInfos)
 }
 
-func (s *InMemoryNodeInfoStoreSuite) Test_ListForEngine() {
-	ctx := context.Background()
-	nodeInfo0 := generateNodeInfo(s.T(), nodeIDs[0], models.EngineDocker)
-	nodeInfo1 := generateNodeInfo(s.T(), nodeIDs[1], models.EngineWasm)
-	nodeInfo2 := generateNodeInfo(s.T(), nodeIDs[2], models.EngineDocker, models.EngineWasm)
-	s.NoError(s.store.Add(ctx, nodeInfo0))
-	s.NoError(s.store.Add(ctx, nodeInfo1))
-	s.NoError(s.store.Add(ctx, nodeInfo2))
-
-	dockerNodes, err := s.store.ListForEngine(ctx, models.EngineDocker)
-	s.NoError(err)
-	s.ElementsMatch([]models.NodeInfo{nodeInfo0, nodeInfo2}, dockerNodes)
-
-	wasmNodes, err := s.store.ListForEngine(ctx, models.EngineWasm)
-	s.NoError(err)
-	s.ElementsMatch([]models.NodeInfo{nodeInfo1, nodeInfo2}, wasmNodes)
-}
-
 func (s *InMemoryNodeInfoStoreSuite) Test_Delete() {
 	ctx := context.Background()
 	nodeInfo0 := generateNodeInfo(s.T(), nodeIDs[0], models.EngineDocker)
@@ -146,23 +128,15 @@ func (s *InMemoryNodeInfoStoreSuite) Test_Delete() {
 
 	// delete first node
 	s.NoError(s.store.Delete(ctx, nodeInfo0.ID()))
-	dockerNodes, err := s.store.ListForEngine(ctx, models.EngineDocker)
+	nodes, err := s.store.List(ctx)
 	s.NoError(err)
-	s.ElementsMatch([]models.NodeInfo{nodeInfo1}, dockerNodes)
-
-	wasmNodes, err := s.store.ListForEngine(ctx, models.EngineWasm)
-	s.NoError(err)
-	s.ElementsMatch([]models.NodeInfo{nodeInfo1}, wasmNodes)
+	s.ElementsMatch([]models.NodeInfo{nodeInfo1}, nodes)
 
 	// delete second node
 	s.NoError(s.store.Delete(ctx, nodeInfo1.ID()))
-	dockerNodes, err = s.store.ListForEngine(ctx, models.EngineDocker)
+	nodes, err = s.store.List(ctx)
 	s.NoError(err)
-	s.Empty(dockerNodes)
-
-	wasmNodes, err = s.store.ListForEngine(ctx, models.EngineWasm)
-	s.NoError(err)
-	s.Empty(wasmNodes)
+	s.Empty(nodes)
 }
 
 func (s *InMemoryNodeInfoStoreSuite) Test_Replace() {
@@ -182,15 +156,6 @@ func (s *InMemoryNodeInfoStoreSuite) Test_Replace() {
 	allNodeInfos, err := s.store.List(ctx)
 	s.NoError(err)
 	s.ElementsMatch([]models.NodeInfo{nodeInfo1}, allNodeInfos)
-
-	// test ListForEngine
-	dockerNodes, err := s.store.ListForEngine(ctx, models.EngineDocker)
-	s.NoError(err)
-	s.Empty(dockerNodes)
-
-	wasmNodes, err := s.store.ListForEngine(ctx, models.EngineWasm)
-	s.NoError(err)
-	s.ElementsMatch([]models.NodeInfo{nodeInfo1}, wasmNodes)
 }
 
 func (s *InMemoryNodeInfoStoreSuite) Test_Eviction() {

--- a/pkg/routing/types.go
+++ b/pkg/routing/types.go
@@ -18,8 +18,6 @@ type NodeInfoStore interface {
 	GetByPrefix(ctx context.Context, prefix string) (models.NodeInfo, error)
 	// List returns a list of nodes
 	List(ctx context.Context) ([]models.NodeInfo, error)
-	// ListForEngine returns a list of nodes that support the given engine.
-	ListForEngine(ctx context.Context, engine string) ([]models.NodeInfo, error)
 	// Delete deletes a node info from the repo.
 	Delete(ctx context.Context, nodeID string) error
 }

--- a/pkg/test/devstack/disabled_feature_test.go
+++ b/pkg/test/devstack/disabled_feature_test.go
@@ -26,8 +26,8 @@ func disabledTestSpec(t testing.TB) scenario.Scenario {
 	return scenario.Scenario{
 		Stack: &scenario.StackConfig{
 			DevStackOptions: &devstack.DevStackOptions{
-				NumberOfRequesterOnlyNodes: 1,
-				NumberOfComputeOnlyNodes:   1,
+				NumberOfHybridNodes:      1,
+				NumberOfComputeOnlyNodes: 1,
 			},
 		},
 		Spec: scenario.WasmHelloWorld(t).Spec,

--- a/pkg/test/devstack/target_all_test.go
+++ b/pkg/test/devstack/target_all_test.go
@@ -50,9 +50,7 @@ func (suite *TargetAllSuite) TestCanTargetZeroNodes() {
 func (suite *TargetAllSuite) TestCanTargetSingleNode() {
 	testCase := scenario.Scenario{
 		Stack: &scenario.StackConfig{DevStackOptions: &devstack.DevStackOptions{
-			NumberOfHybridNodes:        0,
-			NumberOfRequesterOnlyNodes: 1,
-			NumberOfComputeOnlyNodes:   1,
+			NumberOfHybridNodes: 1,
 		}},
 		Spec:          testutils.MakeSpecWithOpts(suite.T()),
 		Deal:          model.Deal{TargetingMode: model.TargetAll},
@@ -71,9 +69,8 @@ func (suite *TargetAllSuite) TestCanTargetSingleNode() {
 func (suite *TargetAllSuite) TestCanTargetMultipleNodes() {
 	testCase := scenario.Scenario{
 		Stack: &scenario.StackConfig{DevStackOptions: &devstack.DevStackOptions{
-			NumberOfHybridNodes:        0,
-			NumberOfRequesterOnlyNodes: 1,
-			NumberOfComputeOnlyNodes:   5,
+			NumberOfHybridNodes:      1,
+			NumberOfComputeOnlyNodes: 4,
 		}},
 		Spec:          testutils.MakeSpecWithOpts(suite.T()),
 		Deal:          model.Deal{TargetingMode: model.TargetAll},
@@ -95,9 +92,8 @@ func (suite *TargetAllSuite) TestPartialFailure() {
 	testCase := scenario.Scenario{
 		Stack: &scenario.StackConfig{
 			DevStackOptions: &devstack.DevStackOptions{
-				NumberOfHybridNodes:        0,
-				NumberOfRequesterOnlyNodes: 1,
-				NumberOfComputeOnlyNodes:   2,
+				NumberOfHybridNodes:      1,
+				NumberOfComputeOnlyNodes: 1,
 			},
 			ExecutorConfig: noop.ExecutorConfig{
 				ExternalHooks: noop.ExecutorConfigExternalHooks{


### PR DESCRIPTION
This commit allows the CLI to show a node ranking error message when nodes don't have the available engine installed.

We do this by removing the FindNodes method previously used for node discovery. This used to pre-filter the returned nodes to remove any that did not support the engine, but this meant that they wouldn't even appear to the ranking system and wouldn't appear on the CLI either. This was only here as a performance optimisation, but it's premature (ranking will still take milliseconds even with a 10,000 node cluster).

Now, we just list all nodes and filter them using the engine ranking strategy instead. In fact, this strategy has been present for months and is even enabled, it just never did anything because it was never passed any nodes to filter out. It works just fine, and provides users with a helpful error messgae, as below:

    % bacalhau docker run ubuntu date
    Using default tag: latest. Please specify a tag/digest for better reproducibility.
    Job successfully submitted. Job ID: 270ad777-1279-48f1-bc51-c7aa900a90e8
    Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

            Communicating with the network  ................  done ✅  0.0s
               Creating job for submission  ................  err  ❌  0.5s

    Error submitting job: not enough nodes to run job. requested: 1, available: 0.
            Node QmT5mqWF: does not support docker, only wasm

Resolves #3141. 