### PR TITLE
Update the duckdb executor image to put binary in path

### DIFF
--- a/docker/custom-job-images/duckdb/Dockerfile
+++ b/docker/custom-job-images/duckdb/Dockerfile
@@ -8,8 +8,7 @@ RUN if [ $TARGETPLATFORM = 'linux/arm64' ]; then \
     else \
     wget -O /tmp/ddb.zip "https://github.com/duckdb/duckdb/releases/download/v0.9.2/duckdb_cli-linux-amd64.zip"; \
     fi
-RUN unzip /tmp/ddb.zip 
-
+RUN unzip /tmp/ddb.zip -d /usr/local/bin
 
 LABEL org.opencontainers.image.source https://github.com/bacalhau-project/bacalhau-images
 LABEL org.opencontainers.image.title "Bacalhau custom jobtype - Duckdb"

--- a/docker/custom-job-images/duckdb/Makefile
+++ b/docker/custom-job-images/duckdb/Makefile
@@ -1,6 +1,6 @@
 MACHINE = $(shell uname -m)
 USERNAME ?= bacalhauproject
-VERSION ?= 0.1
+VERSION ?= 0.2
 
 ifeq ($(MACHINE),x86_64)
     MACHINE := amd64

--- a/pkg/translation/translators/duckdb.go
+++ b/pkg/translation/translators/duckdb.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/util"
 )
 
-const DuckDBImage = "bacalhauproject/exec-duckdb:0.1"
+const DuckDBImage = "bacalhauproject/exec-duckdb:0.2"
 
 type DuckDBTranslator struct{}
 


### PR DESCRIPTION
Fixes #3171 by putting the downloaded binary into /usr/local/bin