### PR TITLE
feat: implement server/client version notify middleware

### DIFF
--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -26,13 +26,11 @@ func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 
 	bv := version.Get()
 	headers := map[string][]string{
-		apimodels.HTTPHeaderClientMajorVersion: {bv.Major},
-		apimodels.HTTPHeaderClientMinorVersion: {bv.Minor},
-		apimodels.HTTPHeaderClientGitVersion:   {bv.GitVersion},
-		apimodels.HTTPHeaderClientGitCommit:    {bv.GitCommit},
-		apimodels.HTTPHeaderClientBuildDate:    {bv.BuildDate.UTC().String()},
-		apimodels.HTTPHeaderClientBuildOS:      {bv.GOOS},
-		apimodels.HTTPHeaderClientArch:         {bv.GOARCH},
+		apimodels.HTTPHeaderBacalhauGitVersion: {bv.GitVersion},
+		apimodels.HTTPHeaderBacalhauGitCommit:  {bv.GitCommit},
+		apimodels.HTTPHeaderBacalhauBuildDate:  {bv.BuildDate.UTC().String()},
+		apimodels.HTTPHeaderBacalhauBuildOS:    {bv.GOOS},
+		apimodels.HTTPHeaderBacalhauArch:       {bv.GOARCH},
 	}
 	return clientv2.New(clientv2.Options{
 		Context: ctx,

--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/version"
 )
 
 func GetAPIClient(ctx context.Context) *client.APIClient {
@@ -22,6 +24,16 @@ func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 		scheme = "https"
 	}
 
+	bv := version.Get()
+	headers := map[string][]string{
+		apimodels.HTTPHeaderClientMajorVersion: {bv.Major},
+		apimodels.HTTPHeaderClientMinorVersion: {bv.Minor},
+		apimodels.HTTPHeaderClientGitVersion:   {bv.GitVersion},
+		apimodels.HTTPHeaderClientGitCommit:    {bv.GitCommit},
+		apimodels.HTTPHeaderClientBuildDate:    {bv.BuildDate.UTC().String()},
+		apimodels.HTTPHeaderClientBuildOS:      {bv.GOOS},
+		apimodels.HTTPHeaderClientArch:         {bv.GOARCH},
+	}
 	return clientv2.New(clientv2.Options{
 		Context: ctx,
 		Address: fmt.Sprintf("%s://%s:%d", scheme, config.ClientAPIHost(), config.ClientAPIPort()),
@@ -29,5 +41,6 @@ func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 		clientv2.WithCACertificate(tlsConfig.CACert),
 		clientv2.WithInsecureTLS(tlsConfig.Insecure),
 		clientv2.WithTLS(tlsConfig.UseTLS),
+		clientv2.WithHeaders(headers),
 	)
 }

--- a/pkg/models/buildversion.go
+++ b/pkg/models/buildversion.go
@@ -8,6 +8,7 @@ import (
 type BuildVersionInfo struct {
 	Major      string    `json:"Major,omitempty" example:"0"`
 	Minor      string    `json:"Minor,omitempty" example:"3"`
+	Patch      string    `json:"Patch,omitempty" example:"12"`
 	GitVersion string    `json:"GitVersion" example:"v0.3.12"`
 	GitCommit  string    `json:"GitCommit" example:"d612b63108f2b5ce1ab2b9e02444eb1dac1d922d"`
 	BuildDate  time.Time `json:"BuildDate" example:"2022-11-16T14:03:31Z"`

--- a/pkg/models/buildversion.go
+++ b/pkg/models/buildversion.go
@@ -8,7 +8,6 @@ import (
 type BuildVersionInfo struct {
 	Major      string    `json:"Major,omitempty" example:"0"`
 	Minor      string    `json:"Minor,omitempty" example:"3"`
-	Patch      string    `json:"Patch,omitempty" example:"12"`
 	GitVersion string    `json:"GitVersion" example:"v0.3.12"`
 	GitCommit  string    `json:"GitCommit" example:"d612b63108f2b5ce1ab2b9e02444eb1dac1d922d"`
 	BuildDate  time.Time `json:"BuildDate" example:"2022-11-16T14:03:31Z"`

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/authz"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/agent"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/shared"
 
@@ -196,6 +197,7 @@ func NewNode(
 		"/api/v1/requester/logs",
 	}...)
 
+	serverVersion := version.Get()
 	// public http api server
 	serverParams := publicapi.ServerParams{
 		Router:     echo.New(),
@@ -204,6 +206,13 @@ func NewNode(
 		HostID:     config.Host.ID().String(),
 		Config:     config.APIServerConfig,
 		Authorizer: authz.AlwaysAllow,
+		Headers: map[string]string{
+			apimodels.HTTPHeaderBacalhauGitVersion: serverVersion.GitVersion,
+			apimodels.HTTPHeaderBacalhauGitCommit:  serverVersion.GitCommit,
+			apimodels.HTTPHeaderBacalhauBuildDate:  serverVersion.BuildDate.UTC().String(),
+			apimodels.HTTPHeaderBacalhauBuildOS:    serverVersion.GOOS,
+			apimodels.HTTPHeaderBacalhauArch:       serverVersion.GOARCH,
+		},
 	}
 
 	// Only allow autocert for requester nodes

--- a/pkg/publicapi/apimodels/constants.go
+++ b/pkg/publicapi/apimodels/constants.go
@@ -14,12 +14,14 @@ const (
 	// HTTPHeaderAppID is the header used to pass the application ID to the server.
 	HTTPHeaderAppID = "X-Bacalhau-App-ID"
 
-	HTTPHeaderClientMajorVersion = "X-Bacalhau-Client-Major-Version"
-	HTTPHeaderClientMinorVersion = "X-Bacalhau-Client-Minor-Version"
-	HTTPHeaderClientPatchVersion = "X-Bacalhau-Client-Patch-Version"
-	HTTPHeaderClientGitVersion   = "X-Bacalhau-Git-Version"
-	HTTPHeaderClientGitCommit    = "X-Bacalhau-Client-Git-Commit"
-	HTTPHeaderClientBuildDate    = "X-Bacalhau-Client-Build-Date"
-	HTTPHeaderClientBuildOS      = "X-Bacalhau-Client-Build-OS"
-	HTTPHeaderClientArch         = "X-Bacalhau-Client-Arch"
+	// HTTPHeaderBacalhauGitVersion is the header used to pass the agent version, eg v1.2.3
+	HTTPHeaderBacalhauGitVersion = "X-Bacalhau-Git-Version"
+	// HTTPHeaderBacalhauGitCommit is the header used to pass the agent git commit
+	HTTPHeaderBacalhauGitCommit = "X-Bacalhau-Git-Commit"
+	// HTTPHeaderBacalhauBuildDate is the header used to pass the agent build date in UTC
+	HTTPHeaderBacalhauBuildDate = "X-Bacalhau-Build-Date"
+	// HTTPHeaderBacalhauBuildOS is the header used to pass the agent operating system
+	HTTPHeaderBacalhauBuildOS = "X-Bacalhau-Build-OS"
+	// HTTPHeaderBacalhauArch is the header used to pass the agent architecture
+	HTTPHeaderBacalhauArch = "X-Bacalhau-Arch"
 )

--- a/pkg/publicapi/apimodels/constants.go
+++ b/pkg/publicapi/apimodels/constants.go
@@ -13,4 +13,13 @@ const (
 
 	// HTTPHeaderAppID is the header used to pass the application ID to the server.
 	HTTPHeaderAppID = "X-Bacalhau-App-ID"
+
+	HTTPHeaderClientMajorVersion = "X-Bacalhau-Client-Major-Version"
+	HTTPHeaderClientMinorVersion = "X-Bacalhau-Client-Minor-Version"
+	HTTPHeaderClientPatchVersion = "X-Bacalhau-Client-Patch-Version"
+	HTTPHeaderClientGitVersion   = "X-Bacalhau-Git-Version"
+	HTTPHeaderClientGitCommit    = "X-Bacalhau-Client-Git-Commit"
+	HTTPHeaderClientBuildDate    = "X-Bacalhau-Client-Build-Date"
+	HTTPHeaderClientBuildOS      = "X-Bacalhau-Client-Build-OS"
+	HTTPHeaderClientArch         = "X-Bacalhau-Client-Arch"
 )

--- a/pkg/publicapi/client/v2/client.go
+++ b/pkg/publicapi/client/v2/client.go
@@ -21,7 +21,6 @@ func New(options Options, optFns ...OptionFn) *Client {
 	}
 
 	resolveHTTPClient(&options)
-
 	return &Client{
 		httpClient: options.HTTPClient,
 		options:    options,

--- a/pkg/publicapi/endpoint/orchestrator/job.go
+++ b/pkg/publicapi/endpoint/orchestrator/job.go
@@ -4,14 +4,15 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/labstack/echo/v4"
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"github.com/labstack/echo/v4"
-	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 func (e *Endpoint) putJob(c echo.Context) error {

--- a/pkg/publicapi/middleware/logger.go
+++ b/pkg/publicapi/middleware/logger.go
@@ -21,8 +21,8 @@ func RequestLogger(logger zerolog.Logger, logLevel zerolog.Level) echo.Middlewar
 		LogReferer:      true,
 		LogUserAgent:    true,
 		LogRequestID:    true,
-		LogHeaders: []string{apimodels.HTTPHeaderClientGitVersion, apimodels.HTTPHeaderClientBuildOS,
-			apimodels.HTTPHeaderClientArch},
+		LogHeaders: []string{apimodels.HTTPHeaderBacalhauGitVersion, apimodels.HTTPHeaderBacalhauBuildOS,
+			apimodels.HTTPHeaderBacalhauArch},
 		LogValuesFunc: func(c echo.Context, v echomiddelware.RequestLoggerValues) error {
 			if v.Status >= http.StatusInternalServerError && logLevel < zerolog.ErrorLevel {
 				logLevel = zerolog.ErrorLevel

--- a/pkg/publicapi/middleware/logger.go
+++ b/pkg/publicapi/middleware/logger.go
@@ -3,10 +3,11 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/labstack/echo/v4"
 	echomiddelware "github.com/labstack/echo/v4/middleware"
 	"github.com/rs/zerolog"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 )
 
 func RequestLogger(logger zerolog.Logger, logLevel zerolog.Level) echo.MiddlewareFunc {
@@ -20,6 +21,8 @@ func RequestLogger(logger zerolog.Logger, logLevel zerolog.Level) echo.Middlewar
 		LogReferer:      true,
 		LogUserAgent:    true,
 		LogRequestID:    true,
+		LogHeaders: []string{apimodels.HTTPHeaderClientGitVersion, apimodels.HTTPHeaderClientBuildOS,
+			apimodels.HTTPHeaderClientArch},
 		LogValuesFunc: func(c echo.Context, v echomiddelware.RequestLoggerValues) error {
 			if v.Status >= http.StatusInternalServerError && logLevel < zerolog.ErrorLevel {
 				logLevel = zerolog.ErrorLevel
@@ -27,7 +30,7 @@ func RequestLogger(logger zerolog.Logger, logLevel zerolog.Level) echo.Middlewar
 				logLevel = zerolog.WarnLevel
 			}
 
-			logger.WithLevel(logLevel).
+			event := logger.WithLevel(logLevel).
 				Str("RequestID", v.RequestID).
 				Str("Method", v.Method).
 				Str("URI", v.URI).
@@ -38,8 +41,13 @@ func RequestLogger(logger zerolog.Logger, logLevel zerolog.Level) echo.Middlewar
 				Str("Referer", v.Referer).
 				Str("UserAgent", v.UserAgent).
 				Str("ClientID", c.Response().Header().Get(apimodels.HTTPHeaderClientID)).
-				Str("JobID", c.Response().Header().Get(apimodels.HTTPHeaderJobID)).
-				Send()
+				Str("JobID", c.Response().Header().Get(apimodels.HTTPHeaderJobID))
+
+			for header, values := range v.Headers {
+				event.Strs(header, values)
+			}
+
+			event.Send()
 			return nil
 		},
 	})

--- a/pkg/publicapi/middleware/server_headers.go
+++ b/pkg/publicapi/middleware/server_headers.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+// ServerHeader middleware adds HTTP Headers `headers` to response
+func ServerHeader(headers map[string]string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			for key, header := range headers {
+				c.Response().Header().Set(key, header)
+			}
+			return next(c)
+		}
+	}
+}

--- a/pkg/publicapi/middleware/version.go
+++ b/pkg/publicapi/middleware/version.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver"
 	"github.com/labstack/echo/v4"
 	echomiddelware "github.com/labstack/echo/v4/middleware"
@@ -9,58 +11,72 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 )
 
-func VersionNotifyLogger(logger *zerolog.Logger, serverVersion *semver.Version) echo.MiddlewareFunc {
+type Notification struct {
+	RequestID     string
+	ClientID      string
+	ServerVersion string
+
+	ClientVersion string
+	Message       string
+}
+
+func VersionNotifyLogger(logger *zerolog.Logger, serverVersion semver.Version) echo.MiddlewareFunc {
 	return echomiddelware.RequestLoggerWithConfig(echomiddelware.RequestLoggerConfig{
-		LogHeaders: []string{
-			apimodels.HTTPHeaderClientMajorVersion,
-			apimodels.HTTPHeaderClientMinorVersion,
-			apimodels.HTTPHeaderClientPatchVersion,
-			apimodels.HTTPHeaderClientGitVersion,
-		},
+		// instructs logger to extract given list of headers from request.
+		LogHeaders: []string{apimodels.HTTPHeaderBacalhauGitVersion},
 		LogValuesFunc: func(c echo.Context, v echomiddelware.RequestLoggerValues) error {
-			event := logger.WithLevel(zerolog.WarnLevel).
-				Str("RequestID", v.RequestID).
-				Str("ClientID", c.Response().Header().Get(apimodels.HTTPHeaderClientID))
 
-			notify := false
-			cVersion := v.Headers[apimodels.HTTPHeaderClientGitVersion]
-			if len(cVersion) == 1 {
-				notify = true
-				clientVersion, err := semver.NewVersion(cVersion[0])
-				if err != nil {
-					event.Msgf("received request with invalid client version: %s", cVersion[0])
-				} else {
-					diff := serverVersion.Compare(clientVersion)
-					switch diff {
-					case 0:
-						// versions are the same, don't notify
-						notify = false
-					case 1:
-						event.
-							Str("ServerVersion", serverVersion.String()).
-							Str("ClientVersion", clientVersion.String()).
-							Msgf("received request from outdated client")
-					case -1:
-						event.
-							Str("ServerVersion", serverVersion.String()).
-							Str("ClientVersion", clientVersion.String()).
-							Msgf("received request from newer client")
-					}
+			notif := Notification{
+				RequestID:     v.RequestID,
+				ClientID:      c.Response().Header().Get(apimodels.HTTPHeaderClientID),
+				ServerVersion: serverVersion.String(),
+			}
+
+			defer func() {
+				if notif.Message != "" {
+					logger.WithLevel(zerolog.WarnLevel).
+						Str("ClientID", notif.ClientID).
+						Str("RequestID", notif.RequestID).
+						Str("ClientVersion", notif.ClientVersion).
+						Str("ServerVersion", notif.ServerVersion).
+						Msg(notif.Message)
 				}
-			} else if len(cVersion) == 0 {
-				notify = true
-				event.Msg("received request from unversioned client")
-			} else {
-				notify = true
-				event.
-					Str("ServerVersion", serverVersion.String()).
-					Strs("ClientVersions", cVersion).
-					Msgf("receieved request from client with multipule versions")
+			}()
+
+			cVersion := v.Headers[apimodels.HTTPHeaderBacalhauGitVersion]
+			if len(cVersion) == 0 {
+				// version header is empty, cannot parse it
+				notif.Message = "received request from client without version"
+				return nil
+			}
+			if len(cVersion) > 1 {
+				// version header contained multiple fields
+				notif.Message = fmt.Sprintf("received request from client with multiple versions: %s", cVersion)
+				return nil
 			}
 
-			if notify {
-				event.Send()
+			// there is a single version header, attempt to parse it.
+			clientVersion, err := semver.NewVersion(cVersion[0])
+			if err != nil {
+				// cannot parse client version, should notify
+				notif.Message = fmt.Sprintf("received request with invalid client version: %s", cVersion[0])
+				return nil
 			}
+			// extract parsed client version for comparison
+			notif.ClientVersion = clientVersion.String()
+
+			diff := serverVersion.Compare(clientVersion)
+			switch diff {
+			case 1:
+				// client version is less than server version
+				notif.Message = "received request from outdated client"
+			case -1:
+				// server version is less than client version
+				notif.Message = "received request from newer client"
+			case 0:
+				// versions are the same, don't notify
+			}
+
 			return nil
 		},
 	})

--- a/pkg/publicapi/middleware/version.go
+++ b/pkg/publicapi/middleware/version.go
@@ -25,7 +25,6 @@ func VersionNotifyLogger(logger *zerolog.Logger, serverVersion semver.Version) e
 		// instructs logger to extract given list of headers from request.
 		LogHeaders: []string{apimodels.HTTPHeaderBacalhauGitVersion},
 		LogValuesFunc: func(c echo.Context, v echomiddelware.RequestLoggerValues) error {
-
 			notif := Notification{
 				RequestID:     v.RequestID,
 				ClientID:      c.Response().Header().Get(apimodels.HTTPHeaderClientID),

--- a/pkg/publicapi/middleware/version.go
+++ b/pkg/publicapi/middleware/version.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/labstack/echo/v4"
+	echomiddelware "github.com/labstack/echo/v4/middleware"
+	"github.com/rs/zerolog"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+)
+
+func VersionNotifyLogger(logger *zerolog.Logger, serverVersion *semver.Version) echo.MiddlewareFunc {
+	return echomiddelware.RequestLoggerWithConfig(echomiddelware.RequestLoggerConfig{
+		LogHeaders: []string{
+			apimodels.HTTPHeaderClientMajorVersion,
+			apimodels.HTTPHeaderClientMinorVersion,
+			apimodels.HTTPHeaderClientPatchVersion,
+			apimodels.HTTPHeaderClientGitVersion,
+		},
+		LogValuesFunc: func(c echo.Context, v echomiddelware.RequestLoggerValues) error {
+			event := logger.WithLevel(zerolog.WarnLevel).
+				Str("RequestID", v.RequestID).
+				Str("ClientID", c.Response().Header().Get(apimodels.HTTPHeaderClientID))
+
+			notify := false
+			cVersion := v.Headers[apimodels.HTTPHeaderClientGitVersion]
+			if len(cVersion) == 1 {
+				notify = true
+				clientVersion, err := semver.NewVersion(cVersion[0])
+				if err != nil {
+					event.Msgf("received request with invalid client version: %s", cVersion[0])
+				} else {
+					diff := serverVersion.Compare(clientVersion)
+					switch diff {
+					case 0:
+						// versions are the same, don't notify
+						notify = false
+					case 1:
+						event.
+							Str("ServerVersion", serverVersion.String()).
+							Str("ClientVersion", clientVersion.String()).
+							Msgf("received request from outdated client")
+					case -1:
+						event.
+							Str("ServerVersion", serverVersion.String()).
+							Str("ClientVersion", clientVersion.String()).
+							Msgf("received request from newer client")
+					}
+				}
+			} else if len(cVersion) == 0 {
+				notify = true
+				event.Msg("received request from unversioned client")
+			} else {
+				notify = true
+				event.
+					Str("ServerVersion", serverVersion.String()).
+					Strs("ClientVersions", cVersion).
+					Msgf("receieved request from client with multipule versions")
+			}
+
+			if notify {
+				event.Send()
+			}
+			return nil
+		},
+	})
+}

--- a/pkg/publicapi/middleware/version_test.go
+++ b/pkg/publicapi/middleware/version_test.go
@@ -1,0 +1,117 @@
+//go:build unit || !integration
+
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+)
+
+type VersionNotifyTestSuite struct {
+	suite.Suite
+	logger zerolog.Logger
+	buf    *bytes.Buffer
+}
+
+func (suite *VersionNotifyTestSuite) SetupTest() {
+	suite.buf = &bytes.Buffer{}
+	suite.logger = zerolog.New(suite.buf)
+}
+
+func TestLogVersionNotifyTestSute(t *testing.T) {
+	suite.Run(t, new(VersionNotifyTestSuite))
+}
+
+func (suite *VersionNotifyTestSuite) TestLogVersionNotify() {
+	for _, tc := range []struct {
+		name                  string
+		clientVersion         []string
+		serverVersion         *semver.Version
+		expectedMessage       string
+		expectedClientVersion string
+	}{
+		{
+			name:            "same version: no notification",
+			serverVersion:   semver.MustParse("v1.2.3"),
+			clientVersion:   []string{semver.MustParse("v1.2.3").String()},
+			expectedMessage: "",
+		},
+		{
+			name:            "no version: notify",
+			serverVersion:   semver.MustParse("v1.2.3"),
+			clientVersion:   []string{},
+			expectedMessage: "received request from client without version",
+		},
+		{
+			name:            "multiple versions: notify",
+			serverVersion:   semver.MustParse("v1.2.3"),
+			clientVersion:   []string{"v1.0.0", "v1.1.0"},
+			expectedMessage: "received request from client with multiple versions",
+		},
+		{
+			name:                  "different major: client outdated notify",
+			serverVersion:         semver.MustParse("v1.2.3"),
+			clientVersion:         []string{semver.MustParse("v1.2.2").String()},
+			expectedMessage:       "received request from outdated client",
+			expectedClientVersion: semver.MustParse("v1.2.2").String(),
+		},
+		{
+			name:                  "different major: client newer notify",
+			serverVersion:         semver.MustParse("v1.2.3"),
+			clientVersion:         []string{semver.MustParse("v1.2.4").String()},
+			expectedMessage:       "received request from newer client",
+			expectedClientVersion: semver.MustParse("v1.2.4").String(),
+		},
+		{
+			name:            "invalid client version: notify",
+			serverVersion:   semver.MustParse("v1.2.3"),
+			clientVersion:   []string{"invalid version string"},
+			expectedMessage: "received request with invalid client version:",
+		},
+	} {
+		suite.Run(tc.name, func() {
+			ctx := context.Background()
+
+			suite.buf.Reset()
+
+			router := echo.New()
+			router.Use(VersionNotifyLogger(&suite.logger, *tc.serverVersion))
+			router.GET("/test", func(e echo.Context) error {
+				return nil
+			})
+
+			req, _ := http.NewRequestWithContext(ctx, "GET", "/test", nil)
+			for _, h := range tc.clientVersion {
+				req.Header.Add(apimodels.HTTPHeaderBacalhauGitVersion, h)
+			}
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			if suite.buf.Len() == 0 {
+				suite.Equalf("", tc.expectedMessage, "unexpected notification")
+			} else {
+				notif := suite.parseMessage(suite.buf.String())
+				suite.Contains(notif.Message, tc.expectedMessage)
+				suite.Equal(tc.expectedClientVersion, notif.ClientVersion)
+			}
+		})
+	}
+}
+
+func (suite *VersionNotifyTestSuite) parseMessage(msg string) Notification {
+	var out Notification
+	suite.Require().NoError(json.Unmarshal([]byte(msg), &out))
+	return out
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,6 @@ func Get() *models.BuildVersionInfo {
 	versionInfo := &models.BuildVersionInfo{
 		Major:      strconv.FormatInt(s.Major(), 10), //nolint:gomnd // base10, magic number appropriate
 		Minor:      strconv.FormatInt(s.Minor(), 10), //nolint:gomnd // base10, magic number appropriate
-		Patch:      strconv.FormatInt(s.Patch(), 10), //nolint:gomnd // base10, magic number appropriate
 		GitVersion: GITVERSION,
 		GitCommit:  revision,
 		BuildDate:  revisionTime,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,8 +13,9 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/rs/zerolog/log"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
 )
 
 const DevelopmentGitVersion = "v0.0.0-xxxxxxx"
@@ -44,6 +45,7 @@ func Get() *models.BuildVersionInfo {
 	versionInfo := &models.BuildVersionInfo{
 		Major:      strconv.FormatInt(s.Major(), 10), //nolint:gomnd // base10, magic number appropriate
 		Minor:      strconv.FormatInt(s.Minor(), 10), //nolint:gomnd // base10, magic number appropriate
+		Patch:      strconv.FormatInt(s.Patch(), 10), //nolint:gomnd // base10, magic number appropriate
 		GitVersion: GITVERSION,
 		GitCommit:  revision,
 		BuildDate:  revisionTime,


### PR DESCRIPTION
# What
This PR modifies the client and server to include the following version related headers in their https requests/reponses:
```
	// HTTPHeaderBacalhauGitVersion is the header used to pass the agent version, eg v1.2.3
	HTTPHeaderBacalhauGitVersion = "X-Bacalhau-Git-Version"
	// HTTPHeaderBacalhauGitCommit is the header used to pass the agent git commit
	HTTPHeaderBacalhauGitCommit = "X-Bacalhau-Git-Commit"
	// HTTPHeaderBacalhauBuildDate is the header used to pass the agent build date in UTC
	HTTPHeaderBacalhauBuildDate = "X-Bacalhau-Build-Date"
	// HTTPHeaderBacalhauBuildOS is the header used to pass the agent operating system
	HTTPHeaderBacalhauBuildOS = "X-Bacalhau-Build-OS"
	// HTTPHeaderBacalhauArch is the header used to pass the agent architecture
	HTTPHeaderBacalhauArch = "X-Bacalhau-Arch"
```
Further it adds a notification middleware to notify it of requests from clients on versions differing from it.

- closes https://github.com/bacalhau-project/expanso-planning/issues/237
- closes https://github.com/bacalhau-project/expanso-planning/issues/236
- closes https://github.com/bacalhau-project/expanso-planning/issues/238