### PR TITLE
Update docker executor for oom

### DIFF
--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -510,3 +510,15 @@ func (s *ExecutorTestSuite) TestDockerStreamsSlowTask() {
 	require.Equal(s.T(), df.Size, 6)
 	require.Equal(s.T(), df.Tag, logger.StdoutStreamTag)
 }
+
+func (s *ExecutorTestSuite) TestDockerOOM() {
+	task := mock.TaskBuilder().
+		Engine(
+			dockermodels.NewDockerEngineBuilder("ubuntu").
+				WithEntrypoint("tail", "/dev/zero").
+				Build()).BuildOrDie()
+
+	result, err := s.runJob(task, uuid.New().String())
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "Memory limit exceeded", result.ErrorMsg)
+}

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -520,5 +520,5 @@ func (s *ExecutorTestSuite) TestDockerOOM() {
 
 	result, err := s.runJob(task, uuid.New().String())
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), "Memory limit exceeded", result.ErrorMsg)
+	require.Equal(s.T(), "memory limit exceeded", result.ErrorMsg)
 }

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -520,5 +520,5 @@ func (s *ExecutorTestSuite) TestDockerOOM() {
 
 	result, err := s.runJob(task, uuid.New().String())
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), "memory limit exceeded", result.ErrorMsg)
+	require.Contains(s.T(), result.ErrorMsg, "memory limit exceeded")
 }

--- a/pkg/executor/docker/handler.go
+++ b/pkg/executor/docker/handler.go
@@ -50,6 +50,7 @@ type executionHandler struct {
 	result *models.RunCommandResult
 }
 
+//nolint:funlen
 func (h *executionHandler) run(ctx context.Context) {
 	h.running.Store(true)
 	defer func() {
@@ -111,10 +112,10 @@ func (h *executionHandler) run(ctx context.Context) {
 			return
 		}
 		if containerJSON.ContainerJSONBase.State.OOMKilled {
-			containerError = errors.New("memory limit exceeded")
+			containerError = errors.New(`memory limit exceeded. Please refer to https://docs.bacalhau.org/getting-started/resources/#docker-executor for more information`) //nolint:lll
 			h.result = &models.RunCommandResult{
 				ExitCode: int(containerExitStatusCode),
-				ErrorMsg: fmt.Sprintf(containerError.Error()),
+				ErrorMsg: containerError.Error(),
 			}
 			return
 		}


### PR DESCRIPTION
When a docker container exceeds memory limits (OOM status = true) An informative error message will be relayed to the user.

Have also implemented a test that will trigger OOM errors. NB: The test currently uses the error message as a signal for an error occurring, so if the message is changed, the test may need to be updated as well


Fixes issues #249 #248
