### PR TITLE
Refactor how we configure TLS in devstack

### DIFF
--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -224,6 +224,11 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 	} else {
 		options = append(options, devstack.WithDependencyInjector(node.NewStandardNodeDependencyInjector()))
 	}
+
+	// Get any certificate settings for devstack and use them if we have a certificate (possibly self-signed).
+	cert, key := config.GetRequesterCertificateSettings()
+	options = append(options, devstack.WithSelfSignedCertificate(cert, key))
+
 	stack, err := devstack.Setup(ctx, cm, fsRepo, options...)
 	if err != nil {
 		return err

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -234,15 +234,11 @@ func Setup(
 			NodeInfoStoreTTL:          stackConfig.NodeInfoStoreTTL,
 		}
 
-		if isRequesterNode {
-			// If we are setting up the requester node, then we should set the TLS
-			// settings needed for AutoCert.
-			nodeConfig.RequesterAutoCert = config.ServerAutoCertDomain()
-			nodeConfig.RequesterAutoCertCache = config.GetAutoCertCachePath()
-
-			cert, key := config.GetRequesterCertificateSettings()
-			nodeConfig.RequesterTLSCertificateFile = cert
-			nodeConfig.RequesterTLSKeyFile = key
+		if isRequesterNode && stackConfig.TLS.Certificate != "" && stackConfig.TLS.Key != "" {
+			// Does not make a lot of sense to use autotls with devstack, but we might want
+			// to use a self-signed certificate for testing purposes.
+			nodeConfig.RequesterTLSCertificateFile = stackConfig.TLS.Certificate
+			nodeConfig.RequesterTLSKeyFile = stackConfig.TLS.Key
 		}
 
 		// allow overriding configs of some nodes

--- a/pkg/devstack/option.go
+++ b/pkg/devstack/option.go
@@ -48,6 +48,11 @@ func defaultDevStackConfig() (*DevStackConfig, error) {
 	}, nil
 }
 
+type DevstackTLSSettings struct {
+	Certificate string
+	Key         string
+}
+
 type DevStackConfig struct {
 	ComputeConfig          node.ComputeConfig
 	RequesterConfig        node.RequesterConfig
@@ -69,6 +74,7 @@ type DevStackConfig struct {
 	NodeInfoPublisherInterval  routing.NodeInfoPublisherIntervalConfig
 	ExecutorPlugins            bool // when true pluggable executors will be used.
 	NodeInfoStoreTTL           time.Duration
+	TLS                        DevstackTLSSettings
 }
 
 func (o *DevStackConfig) MarshalZerologObject(e *zerolog.Event) {
@@ -211,5 +217,14 @@ func WithNodeInfoPublisherInterval(interval routing.NodeInfoPublisherIntervalCon
 func WithExecutorPlugins(enabled bool) ConfigOption {
 	return func(cfg *DevStackConfig) {
 		cfg.ExecutorPlugins = enabled
+	}
+}
+
+func WithSelfSignedCertificate(cert string, key string) ConfigOption {
+	return func(cfg *DevStackConfig) {
+		cfg.TLS = DevstackTLSSettings{
+			Certificate: cert,
+			Key:         key,
+		}
 	}
 }


### PR DESCRIPTION
To make it easier to test, we switch to using option functions which allow us to specify them at test time if necessary, or in the CLI based on the CLI parameters.

Closes #3258 