### PR TITLE
cleanup: Rename NewIPFSPublishers 

### DIFF
--- a/pkg/node/factories.go
+++ b/pkg/node/factories.go
@@ -118,7 +118,7 @@ func NewStandardPublishersFactory() PublishersFactory {
 		func(
 			ctx context.Context,
 			nodeConfig NodeConfig) (publisher.PublisherProvider, error) {
-			pr, err := publisher_util.NewIPFSPublishers(
+			pr, err := publisher_util.NewPublisherProvider(
 				ctx,
 				nodeConfig.CleanupManager,
 				nodeConfig.IPFSClient,

--- a/pkg/publisher/util/utils.go
+++ b/pkg/publisher/util/utils.go
@@ -18,13 +18,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
-/* TODO(forrest): Fix me(!):
-- method has wrong name, this make S3 publisher, and noop, in addition to IPFS
-Issue: https://github.com/bacalhau-project/bacalhau/issues/2555
-
-*/
-
-func NewIPFSPublishers(
+func NewPublisherProvider(
 	ctx context.Context,
 	cm *system.CleanupManager,
 	cl ipfsClient.Client,


### PR DESCRIPTION
NewIPFSPublishers creates different publishers, not just IPFS base ones,  and returns a PublisherProvider.

Renamed to NewPublisherProvider

Closes #2555 