### PR TITLE
Removes mypy from airflow plugin

### DIFF
--- a/integration/airflow/bacalhau_airflow/__init__.py
+++ b/integration/airflow/bacalhau_airflow/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for bacalhau-airflow."""
 
-__author__ = """Enrico Rotundo"""
-__email__ = "team@bacalhau.com"
+__author__ = """Bacalhau team"""
+__email__ = "team@bacalhau.org"
 # __version__ = "0.0.3"

--- a/integration/airflow/tox.ini
+++ b/integration/airflow/tox.ini
@@ -30,9 +30,7 @@ commands =
 [testenv:lint]
 allowlist_externals =
     flake8
-    mypy
 extras =
     test
 commands =
     flake8 bacalhau_airflow tests
-    mypy bacalhau_airflow tests


### PR DESCRIPTION
Running mypy manually is fine, running it via tox complains about missing packages. 

This is new and hasn't shown up before and is blocking other PRs from being merged.

Mypy is disabled as a linter as there are very few type hints here.