### PR TITLE
bug-ish: demonstrate issue with http payload

### DIFF
--- a/cmd/cli/agent/alive.go
+++ b/cmd/cli/agent/alive.go
@@ -3,10 +3,11 @@ package agent
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
-	"github.com/spf13/cobra"
 )
 
 // AliveOptions is a struct to support alive command
@@ -36,7 +37,7 @@ func NewAliveCmd() *cobra.Command {
 // Run executes alive command
 func (o *AliveOptions) runAlive(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	response, err := util.GetAPIClientV2(ctx).Agent().Alive()
+	response, err := util.GetAPIClientV2().Agent().Alive(ctx)
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("could not get server alive: %w", err), 1)
 	}

--- a/cmd/cli/agent/node.go
+++ b/cmd/cli/agent/node.go
@@ -3,11 +3,12 @@ package agent
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"github.com/spf13/cobra"
 )
 
 // NodeOptions is a struct to support node command
@@ -37,7 +38,7 @@ func NewNodeCmd() *cobra.Command {
 // Run executes node command
 func (o *NodeOptions) runNode(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	response, err := util.GetAPIClientV2(ctx).Agent().Node(&apimodels.GetAgentNodeRequest{})
+	response, err := util.GetAPIClientV2().Agent().Node(ctx, &apimodels.GetAgentNodeRequest{})
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("could not get server node: %w", err), 1)
 	}

--- a/cmd/cli/agent/version.go
+++ b/cmd/cli/agent/version.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
-	"github.com/spf13/cobra"
 )
 
 // VersionOptions is a struct to support version command
@@ -37,7 +38,7 @@ func NewVersionCmd() *cobra.Command {
 // Run executes version command
 func (oV *VersionOptions) runVersion(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	serverVersionResponse, err := util.GetAPIClientV2(ctx).Agent().Version()
+	serverVersionResponse, err := util.GetAPIClientV2().Agent().Version(ctx)
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("could not get server version: %w", err), 1)
 	}

--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	shellescape "gopkg.in/alessio/shellescape.v1"
+	"gopkg.in/alessio/shellescape.v1"
 	"k8s.io/kubectl/pkg/util/i18n"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
@@ -100,8 +100,8 @@ func exec(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, options *E
 		return fmt.Errorf("%s: %w", userstrings.JobSpecBad, err)
 	}
 
-	client := util.GetAPIClientV2(cmd.Context())
-	resp, err := client.Jobs().Put(&apimodels.PutJobRequest{
+	client := util.GetAPIClientV2()
+	resp, err := client.Jobs().Put(cmd.Context(), &apimodels.PutJobRequest{
 		Job: job,
 	})
 	if err != nil {

--- a/cmd/cli/job/describe.go
+++ b/cmd/cli/job/describe.go
@@ -3,13 +3,14 @@ package job
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/i18n"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
-	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 var (
@@ -58,7 +59,7 @@ func NewDescribeCmd() *cobra.Command {
 func (o *DescribeOptions) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	jobID := args[0]
-	response, err := util.GetAPIClientV2(ctx).Jobs().Get(&apimodels.GetJobRequest{
+	response, err := util.GetAPIClientV2().Jobs().Get(ctx, &apimodels.GetJobRequest{
 		JobID: jobID,
 	})
 	if err != nil {

--- a/cmd/cli/job/executions.go
+++ b/cmd/cli/job/executions.go
@@ -5,6 +5,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/i18n"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
@@ -12,10 +17,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
-	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 var executionsOrderByFields = []string{"modify_time", "create_time", "id", "state"}
@@ -104,7 +105,7 @@ var executionColumns = []output.TableColumn[*models.Execution]{
 func (o *ExecutionOptions) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	jobID := args[0]
-	response, err := util.GetAPIClientV2(ctx).Jobs().Executions(&apimodels.ListJobExecutionsRequest{
+	response, err := util.GetAPIClientV2().Jobs().Executions(ctx, &apimodels.ListJobExecutionsRequest{
 		JobID: jobID,
 		BaseListRequest: apimodels.BaseListRequest{
 			Limit:     o.Limit,

--- a/cmd/cli/job/history.go
+++ b/cmd/cli/job/history.go
@@ -5,6 +5,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/i18n"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
@@ -12,10 +17,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
-	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 var (
@@ -125,7 +126,7 @@ var historyColumns = []output.TableColumn[*models.JobHistory]{
 func (o *HistoryOptions) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	jobID := args[0]
-	response, err := util.GetAPIClientV2(ctx).Jobs().History(&apimodels.ListJobHistoryRequest{
+	response, err := util.GetAPIClientV2().Jobs().History(ctx, &apimodels.ListJobHistoryRequest{
 		JobID:       jobID,
 		EventType:   o.EventType,
 		ExecutionID: o.ExecutionID,

--- a/cmd/cli/job/list.go
+++ b/cmd/cli/job/list.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubectl/pkg/util/i18n"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
@@ -12,11 +18,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
-	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 var orderByFields = []string{"id", "created_at"}
@@ -123,7 +124,7 @@ func (o *ListOptions) run(cmd *cobra.Command, _ []string) {
 			util.Fatal(cmd, fmt.Errorf("could not parse labels: %w", err), 1)
 		}
 	}
-	response, err := util.GetAPIClientV2(ctx).Jobs().List(&apimodels.ListJobsRequest{
+	response, err := util.GetAPIClientV2().Jobs().List(ctx, &apimodels.ListJobsRequest{
 		Labels: labelRequirements,
 		BaseListRequest: apimodels.BaseListRequest{
 			Limit:     o.Limit,

--- a/cmd/cli/job/run.go
+++ b/cmd/cli/job/run.go
@@ -154,6 +154,14 @@ func (o *RunOptions) run(cmd *cobra.Command, args []string) {
 	client := util.GetAPIClientV2()
 	resp, err := client.Jobs().Put(ctx, &apimodels.PutJobRequest{
 		Job: j,
+		BasePutRequest: apimodels.BasePutRequest{
+			BaseRequest: apimodels.BaseRequest{
+				Namespace: "TheNamespace",
+				Headers: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
 	})
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("failed request: %w", err), 1)

--- a/cmd/cli/job/run.go
+++ b/cmd/cli/job/run.go
@@ -6,13 +6,14 @@ import (
 	"io"
 	"os"
 
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/i18n"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/template"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/i18n"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
@@ -150,8 +151,8 @@ func (o *RunOptions) run(cmd *cobra.Command, args []string) {
 	}
 
 	// Submit the job
-	client := util.GetAPIClientV2(ctx)
-	resp, err := client.Jobs().Put(&apimodels.PutJobRequest{
+	client := util.GetAPIClientV2()
+	resp, err := client.Jobs().Put(ctx, &apimodels.PutJobRequest{
 		Job: j,
 	})
 	if err != nil {

--- a/cmd/cli/job/stop.go
+++ b/cmd/cli/job/stop.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/i18n"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/printer"
@@ -108,12 +109,12 @@ func (o *StopOptions) run(cmd *cobra.Command, cmdArgs []string) error {
 
 	// Let the user know we are initiating the request
 	spinner.NextStep(connectingMessage)
-	apiClient := util.GetAPIClientV2(ctx)
+	apiClient := util.GetAPIClientV2()
 
 	// Fetch the job information so we can check whether the task is already
 	// terminal or not. We will not send requests if it is.
 	spinner.NextStep(gettingJobMessage)
-	response, err := apiClient.Jobs().Get(&apimodels.GetJobRequest{
+	response, err := apiClient.Jobs().Get(ctx, &apimodels.GetJobRequest{
 		JobID: requestedJobID,
 	})
 	if err != nil {
@@ -134,7 +135,7 @@ func (o *StopOptions) run(cmd *cobra.Command, cmdArgs []string) error {
 	// requester to decide if we are allowed to do that or not.
 	spinner.NextStep(stoppingJobMessage)
 
-	stopResponse, err := apiClient.Jobs().Stop(&apimodels.StopJobRequest{
+	stopResponse, err := apiClient.Jobs().Stop(ctx, &apimodels.StopJobRequest{
 		JobID:  requestedJobID,
 		Reason: "Stopped at user request",
 	})

--- a/cmd/cli/node/describe.go
+++ b/cmd/cli/node/describe.go
@@ -3,11 +3,12 @@ package node
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"github.com/spf13/cobra"
 )
 
 // DescribeOptions is a struct to support node command
@@ -38,7 +39,7 @@ func NewDescribeCmd() *cobra.Command {
 func (o *DescribeOptions) runDescribe(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	nodeID := args[0]
-	response, err := util.GetAPIClientV2(ctx).Nodes().Get(&apimodels.GetNodeRequest{
+	response, err := util.GetAPIClientV2().Nodes().Get(ctx, &apimodels.GetNodeRequest{
 		NodeID: nodeID,
 	})
 	if err != nil {

--- a/cmd/cli/node/list.go
+++ b/cmd/cli/node/list.go
@@ -3,13 +3,14 @@ package node
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 var defaultColumnGroups = []string{"labels", "capacity"}
@@ -62,7 +63,7 @@ func (o *ListOptions) run(cmd *cobra.Command, _ []string) {
 			util.Fatal(cmd, fmt.Errorf("could not parse labels: %w", err), 1)
 		}
 	}
-	response, err := util.GetAPIClientV2(ctx).Nodes().List(&apimodels.ListNodesRequest{
+	response, err := util.GetAPIClientV2().Nodes().List(ctx, &apimodels.ListNodesRequest{
 		Labels: labelRequirements,
 		BaseListRequest: apimodels.BaseListRequest{
 			Limit:     o.Limit,

--- a/cmd/cli/serve/serve_test.go
+++ b/cmd/cli/serve/serve_test.go
@@ -189,9 +189,7 @@ func (s *ServeSuite) TestCanSubmitJob() {
 	docker.MustHaveDocker(s.T())
 	port, _ := s.serve("--node-type", "requester", "--node-type", "compute")
 	client := client.NewAPIClient(client.NoTLS, "localhost", port)
-	clientV2 := clientv2.New(clientv2.Config{
-		Address: fmt.Sprintf("http://127.0.0.1:%d", port),
-	})
+	clientV2 := clientv2.New(fmt.Sprintf("http://127.0.0.1:%d", port))
 	s.Require().NoError(apitest.WaitForAlive(s.ctx, clientV2))
 
 	job, err := model.NewJobWithSaneProductionDefaults()

--- a/cmd/cli/serve/serve_test.go
+++ b/cmd/cli/serve/serve_test.go
@@ -189,7 +189,7 @@ func (s *ServeSuite) TestCanSubmitJob() {
 	docker.MustHaveDocker(s.T())
 	port, _ := s.serve("--node-type", "requester", "--node-type", "compute")
 	client := client.NewAPIClient(client.NoTLS, "localhost", port)
-	clientV2 := clientv2.New(clientv2.Options{
+	clientV2 := clientv2.New(clientv2.Config{
 		Address: fmt.Sprintf("http://127.0.0.1:%d", port),
 	})
 	s.Require().NoError(apitest.WaitForAlive(s.ctx, clientV2))

--- a/cmd/cli/serve/timeout_test.go
+++ b/cmd/cli/serve/timeout_test.go
@@ -55,9 +55,7 @@ func (s *ServeSuite) TestNoTimeoutSetOrApplied() {
 			s.Require().NoError(err)
 
 			client := client.NewAPIClient(client.NoTLS, "localhost", port)
-			clientV2 := clientv2.New(clientv2.Config{
-				Address: fmt.Sprintf("http://127.0.0.1:%d", port),
-			})
+			clientV2 := clientv2.New(fmt.Sprintf("http://127.0.0.1:%d", port))
 			s.Require().NoError(apitest.WaitForAlive(s.ctx, clientV2))
 
 			testJob := model.NewJob()

--- a/cmd/cli/serve/timeout_test.go
+++ b/cmd/cli/serve/timeout_test.go
@@ -55,7 +55,7 @@ func (s *ServeSuite) TestNoTimeoutSetOrApplied() {
 			s.Require().NoError(err)
 
 			client := client.NewAPIClient(client.NoTLS, "localhost", port)
-			clientV2 := clientv2.New(clientv2.Options{
+			clientV2 := clientv2.New(clientv2.Config{
 				Address: fmt.Sprintf("http://127.0.0.1:%d", port),
 			})
 			s.Require().NoError(apitest.WaitForAlive(s.ctx, clientV2))

--- a/cmd/testing/base.go
+++ b/cmd/testing/base.go
@@ -62,7 +62,7 @@ func (s *BaseSuite) SetupTest() {
 	s.Host = s.Node.APIServer.Address
 	s.Port = s.Node.APIServer.Port
 	s.Client = client.NewAPIClient(client.NoTLS, s.Host, s.Port)
-	s.ClientV2 = clientv2.New(clientv2.Options{
+	s.ClientV2 = clientv2.New(clientv2.Config{
 		Address: fmt.Sprintf("http://%s:%d", s.Host, s.Port),
 	})
 }

--- a/cmd/testing/base.go
+++ b/cmd/testing/base.go
@@ -62,9 +62,7 @@ func (s *BaseSuite) SetupTest() {
 	s.Host = s.Node.APIServer.Address
 	s.Port = s.Node.APIServer.Port
 	s.Client = client.NewAPIClient(client.NoTLS, s.Host, s.Port)
-	s.ClientV2 = clientv2.New(clientv2.Config{
-		Address: fmt.Sprintf("http://%s:%d", s.Host, s.Port),
-	})
+	s.ClientV2 = clientv2.New(fmt.Sprintf("http://%s:%d", s.Host, s.Port))
 }
 
 // After each test

--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -49,5 +49,5 @@ func GetAPIClientV2() *clientv2.Client {
 		}))
 	}
 
-	return clientv2.New(clientv2.Config{Address: base}, opts...)
+	return clientv2.New(base, opts...)
 }

--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -3,12 +3,13 @@ package util
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/bacalhau-project/bacalhau/pkg/version"
-	"github.com/rs/zerolog/log"
 )
 
 func GetAPIClient(ctx context.Context) *client.APIClient {
@@ -48,5 +49,5 @@ func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 		}))
 	}
 
-	return clientv2.New(clientv2.Options{Context: ctx, Address: base}, opts...)
+	return clientv2.New(clientv2.Config{Context: ctx, Address: base}, opts...)
 }

--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -17,7 +17,7 @@ func GetAPIClient(ctx context.Context) *client.APIClient {
 	return client.NewAPIClient(legacyTLS, config.ClientAPIHost(), config.ClientAPIPort())
 }
 
-func GetAPIClientV2(ctx context.Context) *clientv2.Client {
+func GetAPIClientV2() *clientv2.Client {
 	base := config.ClientAPIBase()
 	tlsConfig := config.ClientTLSConfig()
 
@@ -39,7 +39,7 @@ func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 
 	token, err := ReadToken(base)
 	if err != nil {
-		log.Ctx(ctx).Warn().Err(err).Msg("Failed to read access tokens – API calls will be without authorization")
+		log.Warn().Err(err).Msg("Failed to read access tokens – API calls will be without authorization")
 	}
 
 	if token != "" {
@@ -49,5 +49,5 @@ func GetAPIClientV2(ctx context.Context) *clientv2.Client {
 		}))
 	}
 
-	return clientv2.New(clientv2.Config{Context: ctx, Address: base}, opts...)
+	return clientv2.New(clientv2.Config{Address: base}, opts...)
 }

--- a/cmd/util/auth/auth.go
+++ b/cmd/util/auth/auth.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/choose"
 	"github.com/bacalhau-project/bacalhau/pkg/authn"
 	"github.com/bacalhau-project/bacalhau/pkg/authn/challenge"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"github.com/samber/lo"
-	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 )
 
 type responder = func(request *json.RawMessage) (response []byte, err error)
@@ -25,8 +26,8 @@ func RunAuthenticationFlow(cmd *cobra.Command) (string, error) {
 		authn.MethodTypeAsk:       askResponder(cmd),
 	}
 
-	client := util.GetAPIClientV2(cmd.Context())
-	methods, err := client.Auth().Methods(&apimodels.ListAuthnMethodsRequest{})
+	client := util.GetAPIClientV2()
+	methods, err := client.Auth().Methods(cmd.Context(), &apimodels.ListAuthnMethodsRequest{})
 	if err != nil {
 		return "", err
 	}
@@ -61,7 +62,7 @@ func RunAuthenticationFlow(cmd *cobra.Command) (string, error) {
 			return "", err
 		}
 
-		authnResponse, err := client.Auth().Authenticate(&apimodels.AuthnRequest{
+		authnResponse, err := client.Auth().Authenticate(cmd.Context(), &apimodels.AuthnRequest{
 			Name:       chosenMethodName,
 			MethodData: response,
 		})

--- a/cmd/util/download.go
+++ b/cmd/util/download.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
-	"github.com/spf13/cobra"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/pkg/downloader"
@@ -24,7 +25,7 @@ func DownloadResultsHandler(
 ) error {
 	cmd.PrintErrf("Fetching results of job '%s'...\n", jobID)
 	cm := GetCleanupManager(ctx)
-	response, err := GetAPIClientV2(ctx).Jobs().Results(&apimodels.ListJobResultsRequest{
+	response, err := GetAPIClientV2().Jobs().Results(ctx, &apimodels.ListJobResultsRequest{
 		JobID: jobID,
 	})
 	if err != nil {

--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
@@ -17,9 +21,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
 const PrintoutCanceledButRunningNormally string = "printout canceled but running normally"
@@ -77,7 +78,7 @@ func PrintJobExecution(
 	}
 
 	if runtimeSettings.PrintNodeDetails || jobErr != nil {
-		executions, err := client.Jobs().Executions(&apimodels.ListJobExecutionsRequest{
+		executions, err := client.Jobs().Executions(ctx, &apimodels.ListJobExecutionsRequest{
 			JobID: jobID,
 		})
 		if err != nil {
@@ -113,7 +114,7 @@ func followLogs(cmd *cobra.Command, jobID string, client *clientv2.Client) error
 	// Wait until the job has actually been accepted and started, otherwise this will fail waiting for
 	// the execution to appear.
 	for i := 0; i < 10; i++ {
-		resp, err := client.Jobs().Get(&apimodels.GetJobRequest{
+		resp, err := client.Jobs().Get(cmd.Context(), &apimodels.GetJobRequest{
 			JobID: jobID,
 		})
 		if err != nil {
@@ -221,7 +222,7 @@ To cancel the job, run:
 
 	var lastEventState models.JobStateType
 	for !cmdShuttingDown {
-		resp, err := client.Jobs().Get(&apimodels.GetJobRequest{
+		resp, err := client.Jobs().Get(ctx, &apimodels.GetJobRequest{
 			JobID: jobID,
 		})
 		if err != nil {

--- a/ops/aws/canary/lambda/pkg/scenarios/submitAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitAndGet.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/downloader"
 	"github.com/bacalhau-project/bacalhau/pkg/downloader/util"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/rs/zerolog/log"
 )
 
 func SubmitAndGet(ctx context.Context) error {
@@ -35,7 +36,7 @@ func SubmitAndGet(ctx context.Context) error {
 		return err
 	}
 
-	results, err := getClientV2().Jobs().Results(&apimodels.ListJobResultsRequest{
+	results, err := getClientV2().Jobs().Results(ctx, &apimodels.ListJobResultsRequest{
 		JobID: submittedJob.Metadata.ID,
 	})
 	if err != nil {

--- a/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/submitDockerIPFSJobAndGet.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/downloader"
 	"github.com/bacalhau-project/bacalhau/pkg/downloader/util"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/rs/zerolog/log"
 )
 
 // This test submits a job that uses the Docker executor with an IPFS input.
@@ -45,7 +46,7 @@ func SubmitDockerIPFSJobAndGet(ctx context.Context) error {
 		return fmt.Errorf("waiting until completed: %s", err)
 	}
 
-	results, err := getClientV2().Jobs().Results(&apimodels.ListJobResultsRequest{
+	results, err := getClientV2().Jobs().Results(ctx, &apimodels.ListJobResultsRequest{
 		JobID: submittedJob.Metadata.ID,
 	})
 	if err != nil {

--- a/ops/aws/canary/lambda/pkg/scenarios/utils.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/utils.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/cmd/util/parse"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
@@ -15,7 +17,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
-	"github.com/rs/zerolog/log"
 )
 
 const defaultEchoMessage = "hello λ!"
@@ -148,7 +149,7 @@ func getClient() *client.APIClient {
 
 func getClientV2() *clientv2.Client {
 	host, port := getClientHostAndPort()
-	return clientv2.New(clientv2.Options{
+	return clientv2.New(clientv2.Config{
 		Address: fmt.Sprintf("http://%s:%d", host, port),
 	})
 }

--- a/ops/aws/canary/lambda/pkg/scenarios/utils.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/utils.go
@@ -149,9 +149,7 @@ func getClient() *client.APIClient {
 
 func getClientV2() *clientv2.Client {
 	host, port := getClientHostAndPort()
-	return clientv2.New(clientv2.Config{
-		Address: fmt.Sprintf("http://%s:%d", host, port),
-	})
+	return clientv2.New(fmt.Sprintf("http://%s:%d", host, port))
 }
 
 func getNodeSelectors() ([]model.LabelSelectorRequirement, error) {

--- a/pkg/publicapi/apimodels/base_requests.go
+++ b/pkg/publicapi/apimodels/base_requests.go
@@ -1,7 +1,6 @@
 package apimodels
 
 import (
-	"context"
 	"strconv"
 )
 
@@ -9,7 +8,6 @@ import (
 type BaseRequest struct {
 	Namespace string            `query:"namespace"`
 	Headers   map[string]string `query:"-"`
-	Context   context.Context   `query:"-"`
 
 	// A good place to define other fields that are common to all requests,
 	// such as auth tokens
@@ -21,9 +19,6 @@ func (o *BaseRequest) ToHTTPRequest() *HTTPRequest {
 
 	if o.Namespace != "" {
 		r.Params.Set("namespace", o.Namespace)
-	}
-	if o.Context != nil {
-		r.Ctx = o.Context
 	}
 
 	for k, v := range o.Headers {

--- a/pkg/publicapi/client/v2/client.go
+++ b/pkg/publicapi/client/v2/client.go
@@ -10,18 +10,24 @@ import (
 )
 
 type Client struct {
+	address string
+
 	httpClient *http.Client
 	config     Config
 }
 
 // New creates a new client.
-func New(cfg Config, optFns ...OptionFn) *Client {
+func New(address string, optFns ...OptionFn) *Client {
+	// define default filed on the config by setting them here, then
+	// modify with options to override.
+	var cfg Config
 	for _, optFn := range optFns {
 		optFn(&cfg)
 	}
 
 	resolveHTTPClient(&cfg)
 	return &Client{
+		address:    address,
 		httpClient: cfg.HTTPClient,
 		config:     cfg,
 	}
@@ -178,7 +184,10 @@ func (c *Client) toHTTP(ctx context.Context, method, endpoint string, r *apimode
 
 // generate URL for a given endpoint
 func (c *Client) url(endpoint string) (*url.URL, error) {
-	base, _ := url.Parse(c.config.Address)
+	base, err := url.Parse(c.address)
+	if err != nil {
+		return nil, err
+	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err

--- a/pkg/publicapi/client/v2/client.go
+++ b/pkg/publicapi/client/v2/client.go
@@ -11,19 +11,19 @@ import (
 
 type Client struct {
 	httpClient *http.Client
-	options    Options
+	config     Config
 }
 
 // New creates a new client.
-func New(options Options, optFns ...OptionFn) *Client {
+func New(cfg Config, optFns ...OptionFn) *Client {
 	for _, optFn := range optFns {
-		optFn(&options)
+		optFn(&cfg)
 	}
 
-	resolveHTTPClient(&options)
+	resolveHTTPClient(&cfg)
 	return &Client{
-		httpClient: options.HTTPClient,
-		options:    options,
+		httpClient: cfg.HTTPClient,
+		config:     cfg,
 	}
 }
 
@@ -118,8 +118,8 @@ func (c *Client) toHTTP(method, endpoint string, r *apimodels.HTTPRequest) (*htt
 	}
 
 	// build parameters
-	if c.options.Namespace != "" && r.Params.Get("namespace") == "" {
-		r.Params.Add("namespace", c.options.Namespace)
+	if c.config.Namespace != "" && r.Params.Get("namespace") == "" {
+		r.Params.Add("namespace", c.config.Namespace)
 	}
 	// Add in the query parameters, if any
 	for key, values := range u.Query() {
@@ -152,17 +152,17 @@ func (c *Client) toHTTP(method, endpoint string, r *apimodels.HTTPRequest) (*htt
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	if c.options.AppID != "" {
-		req.Header.Set(apimodels.HTTPHeaderAppID, c.options.AppID)
-		req.Header.Add("User-Agent", c.options.AppID)
+	if c.config.AppID != "" {
+		req.Header.Set(apimodels.HTTPHeaderAppID, c.config.AppID)
+		req.Header.Add("User-Agent", c.config.AppID)
 	}
 
 	// Optionally configure HTTP authorization
-	if c.options.HTTPAuth != nil {
-		req.Header.Set("Authorization", c.options.HTTPAuth.String())
+	if c.config.HTTPAuth != nil {
+		req.Header.Set("Authorization", c.config.HTTPAuth.String())
 	}
 
-	for key, values := range c.options.Headers {
+	for key, values := range c.config.Headers {
 		for _, value := range values {
 			req.Header.Add(key, value)
 		}
@@ -187,7 +187,7 @@ func (c *Client) requestContext(r *apimodels.HTTPRequest) context.Context {
 
 // generate URL for a given endpoint
 func (c *Client) url(endpoint string) (*url.URL, error) {
-	base, _ := url.Parse(c.options.Address)
+	base, _ := url.Parse(c.config.Address)
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err

--- a/pkg/publicapi/client/v2/client_agent.go
+++ b/pkg/publicapi/client/v2/client_agent.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 )
 
@@ -14,22 +16,22 @@ func (c *Client) Agent() *Agent {
 }
 
 // Alive is used to check if the agent is alive.
-func (c *Agent) Alive() (*apimodels.IsAliveResponse, error) {
+func (c *Agent) Alive(ctx context.Context) (*apimodels.IsAliveResponse, error) {
 	var res apimodels.IsAliveResponse
-	err := c.client.get("/api/v1/agent/alive", &apimodels.BaseGetRequest{}, &res)
+	err := c.client.get(ctx, "/api/v1/agent/alive", &apimodels.BaseGetRequest{}, &res)
 	return &res, err
 }
 
 // Version is used to get the agent version.
-func (c *Agent) Version() (*apimodels.GetVersionResponse, error) {
+func (c *Agent) Version(ctx context.Context) (*apimodels.GetVersionResponse, error) {
 	var res apimodels.GetVersionResponse
-	err := c.client.get("/api/v1/agent/version", &apimodels.BaseGetRequest{}, &res)
+	err := c.client.get(ctx, "/api/v1/agent/version", &apimodels.BaseGetRequest{}, &res)
 	return &res, err
 }
 
 // Node is used to get the agent node info.
-func (c *Agent) Node(req *apimodels.GetAgentNodeRequest) (*apimodels.GetAgentNodeResponse, error) {
+func (c *Agent) Node(ctx context.Context, req *apimodels.GetAgentNodeRequest) (*apimodels.GetAgentNodeResponse, error) {
 	var res apimodels.GetAgentNodeResponse
-	err := c.client.get("/api/v1/agent/node", req, &res)
+	err := c.client.get(ctx, "/api/v1/agent/node", req, &res)
 	return &res, err
 }

--- a/pkg/publicapi/client/v2/client_auth.go
+++ b/pkg/publicapi/client/v2/client_auth.go
@@ -1,6 +1,10 @@
 package client
 
-import "github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+)
 
 const authBase = "/api/v1/auth"
 
@@ -12,14 +16,15 @@ func (c *Client) Auth() *Auth {
 	return &Auth{client: c}
 }
 
-func (auth *Auth) Methods(r *apimodels.ListAuthnMethodsRequest) (*apimodels.ListAuthnMethodsResponse, error) {
+func (auth *Auth) Methods(ctx context.Context, r *apimodels.ListAuthnMethodsRequest) (*apimodels.
+	ListAuthnMethodsResponse, error) {
 	var resp apimodels.ListAuthnMethodsResponse
-	err := auth.client.list(authBase, r, &resp)
+	err := auth.client.list(ctx, authBase, r, &resp)
 	return &resp, err
 }
 
-func (auth *Auth) Authenticate(r *apimodels.AuthnRequest) (*apimodels.AuthnResponse, error) {
+func (auth *Auth) Authenticate(ctx context.Context, r *apimodels.AuthnRequest) (*apimodels.AuthnResponse, error) {
 	var resp apimodels.AuthnResponse
-	err := auth.client.post(authBase+"/"+r.Name, r, &resp)
+	err := auth.client.post(ctx, authBase+"/"+r.Name, r, &resp)
 	return &resp, err
 }

--- a/pkg/publicapi/client/v2/client_jobs.go
+++ b/pkg/publicapi/client/v2/client_jobs.go
@@ -1,6 +1,10 @@
 package client
 
-import "github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+)
 
 const jobsPath = "/api/v1/orchestrator/jobs"
 
@@ -14,63 +18,64 @@ func (c *Client) Jobs() *Jobs {
 }
 
 // Put is used to submit a new job to the cluster, or update an existing job with matching ID.
-func (j *Jobs) Put(r *apimodels.PutJobRequest) (*apimodels.PutJobResponse, error) {
+func (j *Jobs) Put(ctx context.Context, r *apimodels.PutJobRequest) (*apimodels.PutJobResponse, error) {
 	var resp apimodels.PutJobResponse
-	if err := j.client.put(jobsPath, r, &resp); err != nil {
+	if err := j.client.put(ctx, jobsPath, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // Get is used to get a job by ID.
-func (j *Jobs) Get(r *apimodels.GetJobRequest) (*apimodels.GetJobResponse, error) {
+func (j *Jobs) Get(ctx context.Context, r *apimodels.GetJobRequest) (*apimodels.GetJobResponse, error) {
 	var resp apimodels.GetJobResponse
-	if err := j.client.get(jobsPath+"/"+r.JobID, r, &resp); err != nil {
+	if err := j.client.get(ctx, jobsPath+"/"+r.JobID, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // List is used to list all jobs in the cluster.
-func (j *Jobs) List(r *apimodels.ListJobsRequest) (*apimodels.ListJobsResponse, error) {
+func (j *Jobs) List(ctx context.Context, r *apimodels.ListJobsRequest) (*apimodels.ListJobsResponse, error) {
 	var resp apimodels.ListJobsResponse
-	if err := j.client.list(jobsPath, r, &resp); err != nil {
+	if err := j.client.list(ctx, jobsPath, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // History returns history events for a job.
-func (j *Jobs) History(r *apimodels.ListJobHistoryRequest) (*apimodels.ListJobHistoryResponse, error) {
+func (j *Jobs) History(ctx context.Context, r *apimodels.ListJobHistoryRequest) (*apimodels.ListJobHistoryResponse, error) {
 	var resp apimodels.ListJobHistoryResponse
-	if err := j.client.list(jobsPath+"/"+r.JobID+"/history", r, &resp); err != nil {
+	if err := j.client.list(ctx, jobsPath+"/"+r.JobID+"/history", r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // Executions returns executions for a job.
-func (j *Jobs) Executions(r *apimodels.ListJobExecutionsRequest) (*apimodels.ListJobExecutionsResponse, error) {
+func (j *Jobs) Executions(ctx context.Context, r *apimodels.ListJobExecutionsRequest) (*apimodels.ListJobExecutionsResponse,
+	error) {
 	var resp apimodels.ListJobExecutionsResponse
-	if err := j.client.list(jobsPath+"/"+r.JobID+"/executions", r, &resp); err != nil {
+	if err := j.client.list(ctx, jobsPath+"/"+r.JobID+"/executions", r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // Results returns results for a job.
-func (j *Jobs) Results(r *apimodels.ListJobResultsRequest) (*apimodels.ListJobResultsResponse, error) {
+func (j *Jobs) Results(ctx context.Context, r *apimodels.ListJobResultsRequest) (*apimodels.ListJobResultsResponse, error) {
 	var resp apimodels.ListJobResultsResponse
-	if err := j.client.list(jobsPath+"/"+r.JobID+"/results", r, &resp); err != nil {
+	if err := j.client.list(ctx, jobsPath+"/"+r.JobID+"/results", r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // Stop is used to stop a job by ID.
-func (j *Jobs) Stop(r *apimodels.StopJobRequest) (*apimodels.StopJobResponse, error) {
+func (j *Jobs) Stop(ctx context.Context, r *apimodels.StopJobRequest) (*apimodels.StopJobResponse, error) {
 	var resp apimodels.StopJobResponse
-	if err := j.client.delete(jobsPath+"/"+r.JobID, r, &resp); err != nil {
+	if err := j.client.delete(ctx, jobsPath+"/"+r.JobID, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/pkg/publicapi/client/v2/client_nodes.go
+++ b/pkg/publicapi/client/v2/client_nodes.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 )
 
@@ -16,18 +18,18 @@ func (c *Client) Nodes() *Nodes {
 }
 
 // Get is used to get a node by ID.
-func (c *Nodes) Get(r *apimodels.GetNodeRequest) (*apimodels.GetNodeResponse, error) {
+func (c *Nodes) Get(ctx context.Context, r *apimodels.GetNodeRequest) (*apimodels.GetNodeResponse, error) {
 	var resp apimodels.GetNodeResponse
-	if err := c.client.get(nodesPath+"/"+r.NodeID, r, &resp); err != nil {
+	if err := c.client.get(ctx, nodesPath+"/"+r.NodeID, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // List is used to list all nodes in the cluster.
-func (c *Nodes) List(r *apimodels.ListNodesRequest) (*apimodels.ListNodesResponse, error) {
+func (c *Nodes) List(ctx context.Context, r *apimodels.ListNodesRequest) (*apimodels.ListNodesResponse, error) {
 	var resp apimodels.ListNodesResponse
-	if err := c.client.list(nodesPath, r, &resp); err != nil {
+	if err := c.client.list(ctx, nodesPath, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/pkg/publicapi/client/v2/options.go
+++ b/pkg/publicapi/client/v2/options.go
@@ -10,14 +10,15 @@ import (
 	"os"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 )
 
-type Options struct {
+type Config struct {
 	// Address is the address of the node's public REST API.
 	Address string
 
@@ -58,11 +59,11 @@ type TLSConfig struct {
 }
 
 // OptionFn is a function that can be used to configure the client.
-type OptionFn func(*Options)
+type OptionFn func(*Config)
 
 // UseTLS denotes whether to use TLS or not
 func WithTLS(active bool) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.TLS.UseTLS = active
 	}
 }
@@ -71,42 +72,42 @@ func WithTLS(active bool) OptionFn {
 // that it is possible to use TLS without the insecure flag
 // when the server uses a self-signed certificate
 func WithCACertificate(cacert string) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.TLS.CACert = cacert
 	}
 }
 
 // Insecure activates TLS but does not verify any certificate
 func WithInsecureTLS(insecure bool) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.TLS.Insecure = insecure
 	}
 }
 
 // WithAddress sets the address of the node's public REST API.
 func WithAddress(address string) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.Address = address
 	}
 }
 
 // WithNamespace sets the default namespace to use for all requests.
 func WithNamespace(namespace string) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.Namespace = namespace
 	}
 }
 
 // WithAppID sets the optional application specific identifier appended to the User-Agent header.
 func WithAppID(appID string) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.AppID = appID
 	}
 }
 
 // WithContext sets the default context to use for requests.
 func WithContext(ctx context.Context) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.Context = ctx
 	}
 }
@@ -114,33 +115,33 @@ func WithContext(ctx context.Context) OptionFn {
 // WithHTTPClient sets the client to use. Default will be used if not provided.
 // If set, other configuration options will be ignored, such as Timeout
 func WithHTTPClient(client *http.Client) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.HTTPClient = client
 	}
 }
 
 // WithHTTPAuth sets the auth info to use for http access.
 func WithHTTPAuth(credential *apimodels.HTTPCredential) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.HTTPAuth = credential
 	}
 }
 
 // WithTimeout sets the timeout for requests.
 func WithTimeout(timeout time.Duration) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.Timeout = timeout
 	}
 }
 
 // WithHeaders sets the headers to add to all requests.
 func WithHeaders(headers http.Header) OptionFn {
-	return func(o *Options) {
+	return func(o *Config) {
 		o.Headers = headers
 	}
 }
 
-func resolveHTTPClient(config *Options) {
+func resolveHTTPClient(config *Config) {
 	if config.HTTPClient != nil {
 		return
 	}
@@ -148,7 +149,7 @@ func resolveHTTPClient(config *Options) {
 }
 
 // getTLSTransport builds a http.Transport from the TLS options
-func getTLSTransport(config *Options) *http.Transport {
+func getTLSTransport(config *Config) *http.Transport {
 	tr := &http.Transport{}
 
 	if !config.TLS.UseTLS {
@@ -180,7 +181,7 @@ func getTLSTransport(config *Options) *http.Transport {
 }
 
 // defaultHTTPClient is the default client to use if none is provided.
-func defaultHTTPClient(config *Options) *http.Client {
+func defaultHTTPClient(config *Config) *http.Client {
 	tr := getTLSTransport(config)
 
 	return &http.Client{

--- a/pkg/publicapi/client/v2/options.go
+++ b/pkg/publicapi/client/v2/options.go
@@ -18,9 +18,6 @@ import (
 )
 
 type Config struct {
-	// Address is the address of the node's public REST API.
-	Address string
-
 	// Namespace is the default namespace to use for all requests.
 	Namespace string
 
@@ -77,13 +74,6 @@ func WithCACertificate(cacert string) OptionFn {
 func WithInsecureTLS(insecure bool) OptionFn {
 	return func(o *Config) {
 		o.TLS.Insecure = insecure
-	}
-}
-
-// WithAddress sets the address of the node's public REST API.
-func WithAddress(address string) OptionFn {
-	return func(o *Config) {
-		o.Address = address
 	}
 }
 

--- a/pkg/publicapi/client/v2/options.go
+++ b/pkg/publicapi/client/v2/options.go
@@ -2,7 +2,6 @@
 package client
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -27,9 +26,6 @@ type Config struct {
 
 	// The optional application specific identifier appended to the User-Agent header.
 	AppID string
-
-	// Context is the default context to use for requests.
-	Context context.Context
 
 	// HTTPClient is the client to use. Default will be used if not provided.
 	// If set, other configuration options will be ignored, such as Timeout
@@ -102,13 +98,6 @@ func WithNamespace(namespace string) OptionFn {
 func WithAppID(appID string) OptionFn {
 	return func(o *Config) {
 		o.AppID = appID
-	}
-}
-
-// WithContext sets the default context to use for requests.
-func WithContext(ctx context.Context) OptionFn {
-	return func(o *Config) {
-		o.Context = ctx
 	}
 }
 

--- a/pkg/publicapi/client/v2/util.go
+++ b/pkg/publicapi/client/v2/util.go
@@ -13,6 +13,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 )
@@ -31,6 +32,7 @@ func encodeBody(obj interface{}) (io.Reader, error) {
 	if err := enc.Encode(obj); err != nil {
 		return nil, err
 	}
+	fmt.Println("Encoded HTTP Body: ", buf.String())
 	return buf, nil
 }
 

--- a/pkg/publicapi/endpoint/orchestrator/job.go
+++ b/pkg/publicapi/endpoint/orchestrator/job.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -37,6 +38,22 @@ func (e *Endpoint) putJob(c echo.Context) error {
 	if err := c.Validate(&args); err != nil {
 		return err
 	}
+	if len(args.Headers) == 0 {
+		log.Info().Msg("HTTP Payload did not contain header")
+	} else {
+		log.Info().Msgf("HTTP Payload contains header values header: %s", args.Headers)
+	}
+	if args.Namespace != "" {
+		log.Info().Msgf("HTTP Payload contains namespace: %s", args.Namespace)
+	} else {
+		log.Info().Msg("HTTP Payload did not contain namespace")
+	}
+	if len(c.Request().Header) == 0 {
+		log.Info().Msg("HTTP Request did not contain header")
+	} else {
+		log.Info().Msgf("HTTP Request contains headers: %s", c.Request().Header)
+	}
+
 	resp, err := e.orchestrator.SubmitJob(ctx, &orchestrator.SubmitJobRequest{
 		Job: args.Job,
 	})

--- a/pkg/publicapi/test/agent_test.go
+++ b/pkg/publicapi/test/agent_test.go
@@ -6,21 +6,24 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/version"
-	"github.com/stretchr/testify/require"
 )
 
 func (s *ServerSuite) TestAlive() {
-	resp, err := s.client.Agent().Alive()
+	ctx := context.Background()
+	resp, err := s.client.Agent().Alive(ctx)
 	s.Require().NoError(err)
 	s.Require().Equal("OK", resp.Status)
 	s.Require().True(resp.IsReady())
 }
 
 func (s *ServerSuite) TestAgentVersion() {
-	resp, err := s.client.Agent().Version()
+	ctx := context.Background()
+	resp, err := s.client.Agent().Version(ctx)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(resp)
 	s.Require().NotNil(resp.BuildVersionInfo)
@@ -29,7 +32,8 @@ func (s *ServerSuite) TestAgentVersion() {
 }
 
 func (s *ServerSuite) TestAgentNode() {
-	resp, err := s.client.Agent().Node(&apimodels.GetAgentNodeRequest{})
+	ctx := context.Background()
+	resp, err := s.client.Agent().Node(ctx, &apimodels.GetAgentNodeRequest{})
 	s.Require().NoError(err)
 	s.Require().NotEmpty(resp)
 	s.Require().NotNil(resp.NodeInfo)
@@ -41,7 +45,8 @@ func (s *ServerSuite) TestAgentNode() {
 }
 
 func (s *ServerSuite) TestAgentNodeCompute() {
-	resp, err := s.computeClient.Agent().Node(&apimodels.GetAgentNodeRequest{})
+	ctx := context.Background()
+	resp, err := s.computeClient.Agent().Node(ctx, &apimodels.GetAgentNodeRequest{})
 	s.Require().NoError(err)
 	s.Require().NotEmpty(resp)
 	s.Require().NotNil(resp.NodeInfo)

--- a/pkg/publicapi/test/node_test.go
+++ b/pkg/publicapi/test/node_test.go
@@ -4,13 +4,17 @@ package test
 
 import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+
+	"context"
+
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
 func (s *ServerSuite) TestNodeList() {
-	resp, err := s.client.Nodes().List(&apimodels.ListNodesRequest{})
+	ctx := context.Background()
+	resp, err := s.client.Nodes().List(ctx, &apimodels.ListNodesRequest{})
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), resp)
 	require.NotEmpty(s.T(), resp.Nodes)
@@ -18,12 +22,13 @@ func (s *ServerSuite) TestNodeList() {
 }
 
 func (s *ServerSuite) TestNodeListLabels() {
+	ctx := context.Background()
 	req1, err := labels.NewRequirement("name", selection.Equals, []string{"node-1"})
 	require.NoError(s.T(), err)
 	req2, err := labels.NewRequirement("env", selection.Equals, []string{"devstack"})
 	require.NoError(s.T(), err)
 
-	resp, err := s.client.Nodes().List(&apimodels.ListNodesRequest{
+	resp, err := s.client.Nodes().List(ctx, &apimodels.ListNodesRequest{
 		Labels: []labels.Requirement{*req1, *req2},
 	})
 	require.NoError(s.T(), err)

--- a/pkg/publicapi/test/setup_test.go
+++ b/pkg/publicapi/test/setup_test.go
@@ -40,14 +40,10 @@ func (s *ServerSuite) SetupSuite() {
 	)
 
 	s.requesterNode = stack.Nodes[0]
-	s.client = client.New(client.Config{
-		Address: s.requesterNode.APIServer.GetURI().String(),
-	})
+	s.client = client.New(s.requesterNode.APIServer.GetURI().String())
 
 	s.computeNode = stack.Nodes[1]
-	s.computeClient = client.New(client.Config{
-		Address: s.computeNode.APIServer.GetURI().String(),
-	})
+	s.computeClient = client.New(s.computeNode.APIServer.GetURI().String())
 
 	s.Require().NoError(WaitForAlive(ctx, s.client))
 	s.Require().NoError(WaitForAlive(ctx, s.computeClient))

--- a/pkg/publicapi/test/setup_test.go
+++ b/pkg/publicapi/test/setup_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/node"
@@ -13,7 +15,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
 	"github.com/bacalhau-project/bacalhau/pkg/test/teststack"
-	"github.com/stretchr/testify/suite"
 )
 
 type ServerSuite struct {
@@ -39,12 +40,12 @@ func (s *ServerSuite) SetupSuite() {
 	)
 
 	s.requesterNode = stack.Nodes[0]
-	s.client = client.New(client.Options{
+	s.client = client.New(client.Config{
 		Address: s.requesterNode.APIServer.GetURI().String(),
 	})
 
 	s.computeNode = stack.Nodes[1]
-	s.computeClient = client.New(client.Options{
+	s.computeClient = client.New(client.Config{
 		Address: s.computeNode.APIServer.GetURI().String(),
 	})
 

--- a/pkg/publicapi/test/tools.go
+++ b/pkg/publicapi/test/tools.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
-	"github.com/rs/zerolog/log"
 )
 
 const TimeToWaitForServerReply = 10 * time.Second
@@ -38,7 +39,7 @@ func WaitFor(ctx context.Context, c *client.Client, condition func(context.Conte
 // WaitForAlive waits for the server to be alive
 func WaitForAlive(ctx context.Context, c *client.Client) error {
 	return WaitFor(ctx, c, func(ctx context.Context, apiClient *client.Client) bool {
-		res, err := apiClient.Agent().Alive()
+		res, err := apiClient.Agent().Alive(ctx)
 		if err != nil {
 			log.Warn().Err(err).Msg("failed to check if server is alive")
 			return false
@@ -50,7 +51,7 @@ func WaitForAlive(ctx context.Context, c *client.Client) error {
 // WaitForNodes waits for the server to be alive and for the node to discover itself
 func WaitForNodes(ctx context.Context, c *client.Client) error {
 	return WaitFor(ctx, c, func(ctx context.Context, apiClient *client.Client) bool {
-		res, err := apiClient.Nodes().List(&apimodels.ListNodesRequest{})
+		res, err := apiClient.Nodes().List(ctx, &apimodels.ListNodesRequest{})
 		if err != nil {
 			log.Warn().Err(err).Msg("failed to list nodes. retrying...")
 			return false

--- a/pkg/publicapi/test/util_test.go
+++ b/pkg/publicapi/test/util_test.go
@@ -87,9 +87,7 @@ func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.No
 	err = n.Start(ctx)
 	require.NoError(t, err)
 
-	apiClient := client.New(client.Config{
-		Address: n.APIServer.GetURI().String(),
-	})
+	apiClient := client.New(n.APIServer.GetURI().String())
 	require.NoError(t, WaitForNodes(ctx, apiClient))
 	return n, apiClient
 }

--- a/pkg/publicapi/test/util_test.go
+++ b/pkg/publicapi/test/util_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
@@ -86,7 +87,7 @@ func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.No
 	err = n.Start(ctx)
 	require.NoError(t, err)
 
-	apiClient := client.New(client.Options{
+	apiClient := client.New(client.Config{
 		Address: n.APIServer.GetURI().String(),
 	})
 	require.NoError(t, WaitForNodes(ctx, apiClient))

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -152,9 +152,7 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) string {
 
 	apiServer := stack.Nodes[0].APIServer
 	apiClient := client.NewAPIClient(client.NoTLS, apiServer.Address, apiServer.Port)
-	apiClientV2 := clientv2.New(clientv2.Config{
-		Address: fmt.Sprintf("http://%s:%d", apiServer.Address, apiServer.Port),
-	})
+	apiClientV2 := clientv2.New(fmt.Sprintf("http://%s:%d", apiServer.Address, apiServer.Port))
 
 	submittedJob, submitError := apiClient.Submit(s.Ctx, j)
 	if scenario.SubmitChecker == nil {

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -153,7 +153,6 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) string {
 	apiServer := stack.Nodes[0].APIServer
 	apiClient := client.NewAPIClient(client.NoTLS, apiServer.Address, apiServer.Port)
 	apiClientV2 := clientv2.New(clientv2.Config{
-		Context: s.Ctx,
 		Address: fmt.Sprintf("http://%s:%d", apiServer.Address, apiServer.Port),
 	})
 
@@ -177,7 +176,7 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) string {
 	// Check outputs
 	if scenario.ResultsChecker != nil {
 		s.T().Log("Checking output")
-		results, err := apiClientV2.Jobs().Results(&apimodels.ListJobResultsRequest{
+		results, err := apiClientV2.Jobs().Results(s.Ctx, &apimodels.ListJobResultsRequest{
 			JobID: submittedJob.Metadata.ID,
 		})
 		s.Require().NoError(err)

--- a/pkg/test/scenario/suite.go
+++ b/pkg/test/scenario/suite.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
@@ -151,7 +152,7 @@ func (s *ScenarioRunner) RunScenario(scenario Scenario) string {
 
 	apiServer := stack.Nodes[0].APIServer
 	apiClient := client.NewAPIClient(client.NoTLS, apiServer.Address, apiServer.Port)
-	apiClientV2 := clientv2.New(clientv2.Options{
+	apiClientV2 := clientv2.New(clientv2.Config{
 		Context: s.Ctx,
 		Address: fmt.Sprintf("http://%s:%d", apiServer.Address, apiServer.Port),
 	})

--- a/pkg/test/utils/utils.go
+++ b/pkg/test/utils/utils.go
@@ -6,12 +6,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
-	"github.com/stretchr/testify/require"
 
 	"github.com/bacalhau-project/bacalhau/pkg/job"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -23,7 +24,7 @@ func GetJobFromTestOutput(ctx context.Context, t *testing.T, c *clientv2.Client,
 	uuidRegex := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 	require.Regexp(t, uuidRegex, jobID, "Job ID should be a UUID")
 
-	j, err := c.Jobs().Get(&apimodels.GetJobRequest{
+	j, err := c.Jobs().Get(ctx, &apimodels.GetJobRequest{
 		JobID: jobID,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
### What
Demonstrate the issue mentioned in https://github.com/bacalhau-project/bacalhau/issues/3217

To summarize: we are including HTTP headers and URL Params in the body all HTTP requests that contain one. This introduces ambiguity in how (we) developers access data from requests in server code. If you run this code and issues a `job run` command it will print the entire request as a curl command, in that output you can see all the data we are including in the body.

To reproduce
1. `bacalhau serve --node-type=compute,requester`
2. `bacalhau --api-host=0.0.0.0 job run <some-job-file.yaml>`
3. Observe the encoded body in client terminal, e.g.
```
Encoded HTTP Body:  {"Namespace":"TheNamespace","Headers":{"foo":"bar"},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["cat /inputs/foo_data.txt \u003e /outputs/foo_data.txt"]}},"Publisher":{"Type":""},"InputSources":[{"Source":{"Type":"urlDownload","Params":{"url":"https://gist.githubusercontent.com/enricorotundo/990f0ad01a50d08dfb580e4ad404870e/raw/aa6934257351a0da93f1e740c72f27128590cebc/foo_data.txt"}},"Alias":"","Target":"/inputs"}],"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}
```

<details>
<summary>Click to toggle contents of detailed breakdown</summary>
### Demonstration

The example header values I am using are `"foo":"bar"`. I have made a small change [here](https://github.com/bacalhau-project/bacalhau/pull/3319/files#diff-c4ce9033451a83dadeb581da73ccfe01775552c07b7d5e67727c8df9c74b5e94R155-R164) to include them when submitting a job.
 
## Issues with Headers
1 Curl with HTTP Headers in body and header field:
```bash
curl -X PUT 'http://0.0.0.0:1234/api/v1/orchestrator/jobs?namespace=TheNamespace' \
-H 'Foo: bar' \
-H 'Accept-Encoding: gzip' \
-H 'Content-Type: application/json' \
--data-binary '{"Namespace":"TheNamespace","Headers":{"foo":"bar"},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["-c","echo \"Hello Bacalhau !!!!!!!!!!!!!!! this is a test\""]}},"Publisher":{"Type":"ipfs"},"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}'
```
Log messages:
```
16:09:57.772 | INF pkg/publicapi/endpoint/orchestrator/job.go:44 > HTTP Payload contains header values header: map[foo:bar]
16:09:57.773 | INF pkg/publicapi/endpoint/orchestrator/job.go:47 > HTTP Payload contains namespace: TheNamespace
16:09:57.773 | INF pkg/publicapi/endpoint/orchestrator/job.go:54 > HTTP Request contains headers: map[Accept:[*/*] Accept-Encoding:[gzip] Content-Length:[590] Content-Type:[application/json] Foo:[bar] User-Agent:[curl/7.81.0]]
```

4. Curl without headers in payload:
```bash
curl -X PUT 'http://0.0.0.0:1234/api/v1/orchestrator/jobs?namespace=TheNamespace' \
                                                           -H 'Foo: bar' \
                                                           -H 'Accept-Encoding: gzip' \
                                                           -H 'Content-Type: application/json' \
                                                           --data-binary '{"Namespace":"TheNamespace","Headers":{},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["-c","echo \"Hello Bacalhau !!!!!!!!!!!!!!! this is a test\""]}},"Publisher":{"Type":"ipfs"},"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}'
```
Log Messages:
```
16:08:49.114 | INF pkg/publicapi/endpoint/orchestrator/job.go:42 > HTTP Payload did not contain header
16:08:49.114 | INF pkg/publicapi/endpoint/orchestrator/job.go:47 > HTTP Payload contains namespace: TheNamespace
16:08:49.114 | INF pkg/publicapi/endpoint/orchestrator/job.go:54 > HTTP Request contains headers: map[Accept:[*/*] Accept-Encoding:[gzip] Content-Length:[579] Content-Type:[application/json] Foo:[bar] User-Agent:[curl/7.81.0]]
```

5. Curl without headers in header field
```
curl -X PUT 'http://0.0.0.0:1234/api/v1/orchestrator/jobs?namespace=TheNamespace' \
                                                           -H 'Accept-Encoding: gzip' \
                                                           -H 'Content-Type: application/json' \
                                                           --data-binary '{"Namespace":"TheNamespace","Headers":{"foo":"bar"},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["-c","echo \"Hello Bacalhau !!!!!!!!!!!!!!! this is a test\""]}},"Publisher":{"Type":"ipfs"},"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}'
```
Log Messages:
```
16:10:45.469 | INF pkg/publicapi/endpoint/orchestrator/job.go:44 > HTTP Payload contains header values header: map[foo:bar]
16:10:45.469 | INF pkg/publicapi/endpoint/orchestrator/job.go:47 > HTTP Payload contains namespace: TheNamespace
16:10:45.469 | INF pkg/publicapi/endpoint/orchestrator/job.go:54 > HTTP Request contains headers: map[Accept:[*/*] Accept-Encoding:[gzip] Content-Length:[590] Content-Type:[application/json] User-Agent:[curl/7.81.0]]
```

## Issues with URL Params:
And the example namespace filed I am using is `TheNamespace`, or  `AAAA` and `BBBB` to demonstrate difference in behavior.

1. Curl No Namespace in Payload:
```
curl -X PUT 'http://0.0.0.0:1234/api/v1/orchestrator/jobs?namespace=TheNamespace' \
                                                           -H 'Accept-Encoding: gzip' \
                                                           -H 'Content-Type: application/json' \
                                                           --data-binary '{"Namespace":"","Headers":{"foo":"bar"},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["-c","echo \"Hello Bacalhau !!!!!!!!!!!!!!! this is a test\""]}},"Publisher":{"Type":"ipfs"},"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}'
```
Logs:
```
16:12:52.654 | INF pkg/publicapi/endpoint/orchestrator/job.go:44 > HTTP Payload contains header values header: map[foo:bar]
16:12:52.654 | INF pkg/publicapi/endpoint/orchestrator/job.go:49 > HTTP Payload did not contain namespace
16:12:52.654 | INF pkg/publicapi/endpoint/orchestrator/job.go:54 > HTTP Request contains headers: map[Accept:[*/*] Accept-Encoding:[gzip] Content-Length:[578] Content-Type:[application/json] User-Agent:[curl/7.81.0]]
```

2. Curl No URL Params:
```
curl -X PUT 'http://0.0.0.0:1234/api/v1/orchestrator/jobs' \
                                                           -H 'Accept-Encoding: gzip' \
                                                           -H 'Content-Type: application/json' \
                                                           --data-binary '{"Namespace":"TheNamespace","Headers":{"foo":"bar"},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["-c","echo \"Hello Bacalhau !!!!!!!!!!!!!!! this is a test\""]}},"Publisher":{"Type":"ipfs"},"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}'
```
Logs:
```
16:14:11.158 | INF pkg/publicapi/endpoint/orchestrator/job.go:44 > HTTP Payload contains header values header: map[foo:bar]
16:14:11.158 | INF pkg/publicapi/endpoint/orchestrator/job.go:47 > HTTP Payload contains namespace: TheNamespace
16:14:11.158 | INF pkg/publicapi/endpoint/orchestrator/job.go:54 > HTTP Request contains headers: map[Accept:[*/*] Accept-Encoding:[gzip] Content-Length:[590] Content-Type:[application/json] User-Agent:[curl/7.81.0]]
```

3. Curl with different namespace in payload and URL:
```
curl -X PUT 'http://0.0.0.0:1234/api/v1/orchestrator/jobs?namespace=BBBB' \
                                                           -H 'Accept-Encoding: gzip' \
                                                           -H 'Content-Type: application/json' \
                                                           --data-binary '{"Namespace":"AAAAAA","Headers":{"foo":"bar"},"IdempotencyToken":"","Job":{"ID":"","Name":"A Simple Docker Job","Namespace":"default","Type":"batch","Priority":0,"Count":1,"Constraints":[],"Meta":{},"Labels":{},"Tasks":[{"Name":"My main task","Engine":{"Type":"docker","Params":{"Entrypoint":["/bin/bash"],"Image":"ubuntu:latest","Parameters":["-c","echo \"Hello Bacalhau !!!!!!!!!!!!!!! this is a test\""]}},"Publisher":{"Type":"ipfs"},"Resources":{},"Network":{"Type":"None"},"Timeouts":{}}],"State":{"StateType":"Undefined"},"Version":0,"Revision":0,"CreateTime":0,"ModifyTime":0}}'
```
Logs:
```
16:15:23.841 | INF pkg/publicapi/endpoint/orchestrator/job.go:44 > HTTP Payload contains header values header: map[foo:bar]
16:15:23.841 | INF pkg/publicapi/endpoint/orchestrator/job.go:47 > HTTP Payload contains namespace: AAAAAA
16:15:23.842 | INF pkg/publicapi/endpoint/orchestrator/job.go:54 > HTTP Request contains headers: map[Accept:[*/*] Accept-Encoding:[gzip] Content-Length:[584] Content-Type:[application/json] User-Agent:[curl/7.81.0]]
```
</details>