### PR TITLE
Ensures requests as json do not include headers

### DIFF
--- a/pkg/publicapi/apimodels/base_requests.go
+++ b/pkg/publicapi/apimodels/base_requests.go
@@ -7,7 +7,7 @@ import (
 // BaseRequest is the base request used for all requests
 type BaseRequest struct {
 	Namespace string            `query:"namespace"`
-	Headers   map[string]string `query:"-"`
+	Headers   map[string]string `query:"-" json:"-"`
 
 	// A good place to define other fields that are common to all requests,
 	// such as auth tokens

--- a/pkg/publicapi/apimodels/base_requests_test.go
+++ b/pkg/publicapi/apimodels/base_requests_test.go
@@ -38,5 +38,6 @@ func (s *BaseRequestTestCase) TestBaseRequest() {
 
 	// Should not contain any headers from the TestBaseRequest
 	s.Require().Empty(result.Headers, "headers were not excluded from json marshalling")
-
+	s.Require().Equal(initial.Namespace, result.Namespace, "namespace was not marshalled correctly")
+	s.Require().Equal(initial.IdempotencyToken, result.IdempotencyToken, "idempotency token was not marshalled correctly")
 }

--- a/pkg/publicapi/apimodels/base_requests_test.go
+++ b/pkg/publicapi/apimodels/base_requests_test.go
@@ -1,0 +1,42 @@
+//go:build unit || !integration
+
+package apimodels_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+	"github.com/stretchr/testify/suite"
+)
+
+type BaseRequestTestCase struct {
+	suite.Suite
+}
+
+func TestBaseRequestSuite(t *testing.T) {
+	suite.Run(t, new(BaseRequestTestCase))
+}
+
+func (s *BaseRequestTestCase) TestBaseRequest() {
+	initial := apimodels.BasePutRequest{
+		BaseRequest: apimodels.BaseRequest{
+			Namespace: "namespace",
+			Headers: map[string]string{
+				"test": "test",
+			},
+		},
+		IdempotencyToken: "1234",
+	}
+
+	b, err := json.Marshal(initial)
+	s.Require().NoError(err)
+
+	var result apimodels.BasePutRequest
+	err = json.Unmarshal(b, &result)
+	s.Require().NoError(err)
+
+	// Should not contain any headers from the TestBaseRequest
+	s.Require().Empty(result.Headers, "headers were not excluded from json marshalling")
+
+}


### PR DESCRIPTION
Currently the headers in the BaseRequest structure are excluded for query parameters, but as still included when encoded as json.  This commit changes that to exclude the headers in BaseRequest any time they are marshalled as json.

Fixes #3340 