### PR TITLE
Improve pagination and filtering of job list command.

### DIFF
--- a/cmd/cli/job/list.go
+++ b/cmd/cli/job/list.go
@@ -140,4 +140,9 @@ func (o *ListOptions) run(cmd *cobra.Command, _ []string) {
 	if err = output.Output(cmd, listColumns, o.OutputOptions, response.Jobs); err != nil {
 		util.Fatal(cmd, fmt.Errorf("failed to output: %w", err), 1)
 	}
+
+	if response.NextToken != "" {
+		msg := fmt.Sprintf("To fetch more records use `--next-token %s`", response.NextToken)
+		cmd.Printf("\n%s\n", msg)
+	}
 }

--- a/cmd/cli/list/list_test.go
+++ b/cmd/cli/list/list_test.go
@@ -242,8 +242,6 @@ func (suite *ListSuite) TestList_SortFlags() {
 		reverseFlag bool
 		badSortFlag bool
 	}{
-		{sortFlag: string(list.ColumnID), reverseFlag: false},
-		{sortFlag: string(list.ColumnID), reverseFlag: true},
 		{sortFlag: createdAtSortFlag, reverseFlag: false},
 		{sortFlag: createdAtSortFlag, reverseFlag: true},
 		{sortFlag: badSortFlag, reverseFlag: false, badSortFlag: true},

--- a/pkg/jobstore/boltdb/store.go
+++ b/pkg/jobstore/boltdb/store.go
@@ -467,12 +467,8 @@ func (b *BoltJobStore) getJobsBuildList(tx *bolt.Tx, jobSet map[string]struct{},
 }
 
 func (b *BoltJobStore) getJobsWithinLimit(jobs []models.Job, query jobstore.JobQuery) []models.Job {
-	offset := query.Offset
-	if offset != 0 {
-		offset = math.Min(uint32(len(jobs)), offset)
-		if offset == uint32(len(jobs)) {
-			return []models.Job{}
-		}
+	if query.Offset >= uint32(len(jobs)) {
+		return []models.Job{}
 	}
 
 	limit := query.Limit

--- a/pkg/jobstore/boltdb/store.go
+++ b/pkg/jobstore/boltdb/store.go
@@ -324,28 +324,20 @@ func (b *BoltJobStore) getJobs(tx *bolt.Tx, query jobstore.JobQuery) (*jobstore.
 	// Sort the jobs according to the query.SortBy and query.SortOrder
 	listSorter := func(i, j int) bool {
 		switch query.SortBy {
-		case "id":
-			if query.SortReverse {
-				// what does it mean to sort by ID? (rj) it's mostly meaningless and just
-				// gives us a lexicographic sort of the UUIDs.
-				return result[i].ID > result[j].ID
-			} else {
-				return result[i].ID < result[j].ID
-			}
-		case "created_at":
-			if query.SortReverse {
-				return result[i].CreateTime > result[j].CreateTime
-			} else {
-				return result[i].CreateTime < result[j].CreateTime
-			}
-		default:
-			// We apply modifytime as a default sort so that we can use it for pagination.
-			// Without a known default we won't have a stable sort that makes sense for
-			// offsets/limits.
+		case "modified_at":
 			if query.SortReverse {
 				return result[i].ModifyTime > result[j].ModifyTime
 			} else {
 				return result[i].ModifyTime < result[j].ModifyTime
+			}
+		default:
+			// We apply created_at as a default sort so that we can use it for pagination.
+			// Without a known default we won't have a stable sort that makes sense for
+			// offsets/limits.
+			if query.SortReverse {
+				return result[i].CreateTime > result[j].CreateTime
+			} else {
+				return result[i].CreateTime < result[j].CreateTime
 			}
 		}
 	}

--- a/pkg/jobstore/boltdb/store.go
+++ b/pkg/jobstore/boltdb/store.go
@@ -301,20 +301,6 @@ func (b *BoltJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery) (*j
 }
 
 func (b *BoltJobStore) getJobs(tx *bolt.Tx, query jobstore.JobQuery) (*jobstore.JobQueryResponse, error) {
-	if query.ID != "" {
-		job, err := b.getJob(tx, query.ID)
-
-		if query.Selector != nil {
-			// If we have a selector and it doesn't match, then it isn't an error
-			// just a non-match.
-			if !query.Selector.Matches(labels.Set(job.Labels)) {
-				return &jobstore.JobQueryResponse{}, nil
-			}
-		}
-
-		return &jobstore.JobQueryResponse{Jobs: []models.Job{job}}, err
-	}
-
 	jobSet, err := b.getJobsInitialSet(tx, query)
 	if err != nil {
 		return nil, err
@@ -503,8 +489,6 @@ func (b *BoltJobStore) getJobsWithinLimit(jobs []models.Job, query jobstore.JobQ
 	} else {
 		limit = math.Min(uint32(len(jobs)), limit+query.Offset)
 	}
-
-	fmt.Printf("%v : %v\n", query.Offset, limit)
 
 	return jobs[query.Offset:limit]
 }

--- a/pkg/jobstore/boltdb/store_test.go
+++ b/pkg/jobstore/boltdb/store_test.go
@@ -288,14 +288,6 @@ func (s *BoltJobstoreTestSuite) TestLevelFilteredJobHistory() {
 }
 
 func (s *BoltJobstoreTestSuite) TestSearchJobs() {
-	s.T().Run("by client ID", func(t *testing.T) {
-		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			Namespace: "client1",
-		})
-		require.NoError(t, err)
-		require.Equal(t, 1, len(response.Jobs))
-	})
-
 	s.T().Run("by client ID and included tags", func(t *testing.T) {
 		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			Namespace:   "client1",
@@ -309,9 +301,8 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 		require.NotContains(t, jobs[0].Labels, "slow")
 	})
 
-	s.T().Run("single record with selectors", func(t *testing.T) {
+	s.T().Run("basic selectors", func(t *testing.T) {
 		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			ID:        "110",
 			Namespace: "client1",
 			Selector:  s.parseLabels("gpu=true,fast=true"),
 		})
@@ -319,16 +310,6 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 		jobs := response.Jobs
 		require.Equal(t, 1, len(jobs))
 		require.Equal(t, "client1", jobs[0].Namespace)
-
-		// The first job, but with selectors which don't match. Should not be an error
-		// but should also have no results
-		response, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			ID:        "110",
-			Namespace: "client1",
-			Selector:  s.parseLabels("slow=true"),
-		})
-		require.NoError(t, err)
-		require.Empty(t, response.Jobs)
 	})
 
 	s.T().Run("all records with selectors and paging", func(t *testing.T) {
@@ -446,15 +427,6 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(response.Jobs))
-	})
-
-	s.T().Run("by id", func(t *testing.T) {
-		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			ID: "110",
-		})
-		require.NoError(t, err)
-		require.Equal(t, 1, len(response.Jobs))
-		require.Equal(t, "110", response.Jobs[0].ID)
 	})
 }
 

--- a/pkg/jobstore/boltdb/store_test.go
+++ b/pkg/jobstore/boltdb/store_test.go
@@ -399,7 +399,7 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, 4, len(response.Jobs))
-		require.Equal(t, 1, response.Offset)
+		require.Equal(t, uint32(1), response.Offset)
 	})
 
 	s.T().Run("everything limit", func(t *testing.T) {

--- a/pkg/jobstore/boltdb/store_test.go
+++ b/pkg/jobstore/boltdb/store_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 type BoltJobstoreTestSuite struct {
@@ -66,7 +67,21 @@ func (s *BoltJobstoreTestSuite) SetupTest() {
 		{
 			id:              "130",
 			client:          "client3",
-			tags:            map[string]string{"slow": "true"},
+			tags:            map[string]string{"slow": "true", "max": "10"},
+			jobStates:       []models.JobStateType{models.JobStateTypePending, models.JobStateTypeRunning},
+			executionStates: []models.ExecutionStateType{models.ExecutionStateAskForBid, models.ExecutionStateAskForBidAccepted},
+		},
+		{
+			id:              "140",
+			client:          "client4",
+			tags:            map[string]string{"max": "10"},
+			jobStates:       []models.JobStateType{models.JobStateTypePending, models.JobStateTypeRunning},
+			executionStates: []models.ExecutionStateType{models.ExecutionStateAskForBid, models.ExecutionStateAskForBidAccepted},
+		},
+		{
+			id:              "150",
+			client:          "client5",
+			tags:            map[string]string{"max": "10"},
 			jobStates:       []models.JobStateType{models.JobStateTypePending, models.JobStateTypeRunning},
 			executionStates: []models.ExecutionStateType{models.ExecutionStateAskForBid, models.ExecutionStateAskForBidAccepted},
 		},
@@ -274,121 +289,172 @@ func (s *BoltJobstoreTestSuite) TestLevelFilteredJobHistory() {
 
 func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 	s.T().Run("by client ID", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			Namespace: "client1",
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, len(jobs))
+		require.Equal(t, 1, len(response.Jobs))
 	})
 
 	s.T().Run("by client ID and included tags", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			Namespace:   "client1",
 			IncludeTags: []string{"fast", "slow"},
 		})
 		require.NoError(t, err)
+		jobs := response.Jobs
 		require.Equal(t, 1, len(jobs))
 		require.Equal(t, "client1", jobs[0].Namespace)
 		require.Contains(t, jobs[0].Labels, "fast")
 		require.NotContains(t, jobs[0].Labels, "slow")
 	})
 
+	s.T().Run("single record with selectors", func(t *testing.T) {
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+			ID:        "110",
+			Namespace: "client1",
+			Selector:  s.parseLabels("gpu=true,fast=true"),
+		})
+		require.NoError(t, err)
+		jobs := response.Jobs
+		require.Equal(t, 1, len(jobs))
+		require.Equal(t, "client1", jobs[0].Namespace)
+
+		// The first job, but with selectors which don't match. Should not be an error
+		// but should also have no results
+		response, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
+			ID:        "110",
+			Namespace: "client1",
+			Selector:  s.parseLabels("slow=true"),
+		})
+		require.NoError(t, err)
+		require.Empty(t, response.Jobs)
+	})
+
+	s.T().Run("all records with selectors and paging", func(t *testing.T) {
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+			SortBy:   "created_at",
+			Selector: s.parseLabels("max>1"),
+			Limit:    2,
+		})
+		require.NoError(t, err)
+		jobs := response.Jobs
+		require.Equal(t, 2, len(jobs))
+
+		// Having skipped the first two s.ids because of non-matching selectors,
+		// we expect the next two to match
+		require.Equal(t, "130", jobs[0].ID)
+		require.Equal(t, "140", jobs[1].ID)
+
+		response, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
+			SortBy:   "created_at",
+			Selector: s.parseLabels("max>1"),
+			Limit:    2,
+			Offset:   2,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 1, len(response.Jobs))
+	})
+
 	s.T().Run("everything sorted by id", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll: true,
 			SortBy:    "id",
 		})
 		require.NoError(t, err)
-		require.Equal(t, 3, len(jobs))
+		jobs := response.Jobs
+		require.Equal(t, 5, len(jobs))
 		ids := lo.Map(jobs, func(item models.Job, _ int) string {
 			return item.ID
 		})
-		require.EqualValues(t, []string{"110", "120", "130"}, ids)
+		require.EqualValues(t, []string{"110", "120", "130", "140", "150"}, ids)
 
-		jobs, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll:   true,
 			SortBy:      "id",
 			SortReverse: true,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 3, len(jobs))
-
+		jobs = response.Jobs
+		require.Equal(t, 5, len(jobs))
 		ids = lo.Map(jobs, func(item models.Job, _ int) string {
 			return item.ID
 		})
-		require.EqualValues(t, []string{"130", "120", "110"}, ids)
+		require.EqualValues(t, []string{"150", "140", "130", "120", "110"}, ids)
 	})
 
 	s.T().Run("everything", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll: true,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 3, len(jobs))
+		require.Equal(t, 5, len(response.Jobs))
 	})
 
 	s.T().Run("everything offset", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll: true,
 			Offset:    1,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 2, len(jobs))
+		require.Equal(t, 4, len(response.Jobs))
+		require.Equal(t, 1, response.Offset)
 	})
 
 	s.T().Run("everything limit", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll: true,
 			Limit:     2,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 2, len(jobs))
+		require.Equal(t, 2, len(response.Jobs))
 	})
 
 	s.T().Run("everything offset/limit", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll: true,
 			Offset:    1,
 			Limit:     1,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, len(jobs))
+		require.Equal(t, 1, len(response.Jobs))
 	})
 
 	s.T().Run("include tags", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			IncludeTags: []string{"gpu"},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, len(jobs))
-		require.Equal(t, "110", jobs[0].ID)
+		require.Equal(t, 1, len(response.Jobs))
+		require.Equal(t, "110", response.Jobs[0].ID)
 	})
 
 	s.T().Run("all but exclude tags", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll:   true,
 			ExcludeTags: []string{"fast"},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 2, len(jobs))
+		require.Equal(t, 4, len(response.Jobs))
 	})
 
 	s.T().Run("include/exclude same tag", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			IncludeTags: []string{"gpu"},
 			ExcludeTags: []string{"fast"},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 0, len(jobs))
+		require.Equal(t, 0, len(response.Jobs))
 	})
 
 	s.T().Run("by id", func(t *testing.T) {
-		jobs, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
+		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ID: "110",
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, len(jobs))
-		require.Equal(t, "110", jobs[0].ID)
+		require.Equal(t, 1, len(response.Jobs))
+		require.Equal(t, "110", response.Jobs[0].ID)
 	})
 }
 
@@ -441,7 +507,7 @@ func (s *BoltJobstoreTestSuite) TestGetExecutions() {
 func (s *BoltJobstoreTestSuite) TestInProgressJobs() {
 	infos, err := s.store.GetInProgressJobs(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(1, len(infos))
+	s.Require().Equal(3, len(infos))
 	s.Require().Equal("130", infos[0].ID)
 }
 
@@ -589,6 +655,13 @@ func (s *BoltJobstoreTestSuite) TestEvaluations() {
 
 	err = s.store.DeleteEvaluation(s.ctx, eval.ID)
 	s.Require().NoError(err)
+}
+
+func (s *BoltJobstoreTestSuite) parseLabels(selector string) labels.Selector {
+	req, err := labels.ParseToRequirements(selector)
+	s.NoError(err)
+
+	return labels.NewSelector().Add(req...)
 }
 
 func makeDockerEngineJob(entrypointArray []string) *models.Job {

--- a/pkg/jobstore/boltdb/store_test.go
+++ b/pkg/jobstore/boltdb/store_test.go
@@ -338,10 +338,9 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 		require.Equal(t, 1, len(response.Jobs))
 	})
 
-	s.T().Run("everything sorted by id", func(t *testing.T) {
+	s.T().Run("everything sorted by created_at", func(t *testing.T) {
 		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll: true,
-			SortBy:    "id",
 		})
 		require.NoError(t, err)
 		jobs := response.Jobs
@@ -353,7 +352,6 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 
 		response, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			ReturnAll:   true,
-			SortBy:      "id",
 			SortReverse: true,
 		})
 		require.NoError(t, err)

--- a/pkg/jobstore/inmemory/inmemory.go
+++ b/pkg/jobstore/inmemory/inmemory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/imdario/mergo"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
@@ -101,24 +102,30 @@ func (d *InMemoryJobStore) GetJob(_ context.Context, id string) (models.Job, err
 	return d.getJob(id)
 }
 
-func (d *InMemoryJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery) ([]models.Job, error) {
+//nolint:gocyclo,funlen
+func (d *InMemoryJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery) (*jobstore.JobQueryResponse, error) {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
 	var result []models.Job
 
 	if query.ID != "" {
-		j, err := d.getJob(query.ID)
+		job, err := d.getJob(query.ID)
 		if err != nil {
 			return nil, err
 		}
-		return []models.Job{j}, nil
+
+		if query.Selector != nil {
+			// If we have a selector and it doesn't match, then it isn't an error
+			// just a non-match.
+			if !query.Selector.Matches(labels.Set(job.Labels)) {
+				return &jobstore.JobQueryResponse{}, nil
+			}
+		}
+
+		return &jobstore.JobQueryResponse{Jobs: []models.Job{job}}, nil
 	}
 
 	for _, j := range maps.Values(d.jobs) {
-		if query.Limit > 0 && uint32(len(result)) == query.Limit {
-			break
-		}
-
 		if !query.ReturnAll && query.Namespace != "" && query.Namespace != j.Namespace {
 			// Job is not for the requesting client, so ignore it.
 			continue
@@ -148,7 +155,8 @@ func (d *InMemoryJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery)
 		switch query.SortBy {
 		case "id":
 			if query.SortReverse {
-				// what does it mean to sort by ID?
+				// what does it mean to sort by ID? (rj) it's mostly meaningless and just
+				// gives us a lexicographic sort of the UUIDs.
 				return result[i].ID > result[j].ID
 			} else {
 				return result[i].ID < result[j].ID
@@ -160,11 +168,47 @@ func (d *InMemoryJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery)
 				return result[i].CreateTime < result[j].CreateTime
 			}
 		default:
-			return false
+			// We apply modifytime as a default sort so that we can use it for pagination.
+			// Without a known default we won't have a stable sort that makes sense for
+			// offsets/limits.
+			if query.SortReverse {
+				return result[i].ModifyTime > result[j].ModifyTime
+			} else {
+				return result[i].ModifyTime < result[j].ModifyTime
+			}
 		}
 	}
 	sort.Slice(result, listSorter)
-	return result, nil
+
+	if query.Selector != nil {
+		var filtered []models.Job
+		for _, j := range result {
+			if query.Selector.Matches(labels.Set(j.Labels)) {
+				filtered = append(filtered, j)
+			}
+		}
+		result = filtered
+	}
+
+	// To be able to extract based on offset and limit, we need the records to be sorted in
+	// the same order for each query.  This is why we sort the list above and why the offset
+	// and limit are applied so late.
+	if query.Offset > 0 && query.Offset <= uint32(len(result)) {
+		result = result[query.Offset:]
+	}
+
+	if query.Limit > 0 && query.Limit <= uint32(len(result)) {
+		result = result[:query.Limit+query.Offset]
+	}
+
+	response := &jobstore.JobQueryResponse{
+		Jobs:       result,
+		Offset:     query.Offset,
+		Limit:      query.Limit,
+		NextOffset: query.Limit + query.Offset,
+	}
+
+	return response, nil
 }
 
 func (d *InMemoryJobStore) GetExecutions(_ context.Context, jobID string) ([]models.Execution, error) {
@@ -517,5 +561,5 @@ func (d *InMemoryJobStore) appendExecutionHistory(updatedExecution models.Execut
 	d.history[updatedExecution.JobID] = append(d.history[updatedExecution.JobID], historyEntry)
 }
 
-// Static check to ensure that Transport implements Transport:
+// Static check to ensure that InMemoryJobStore implements jobstore.Store
 var _ jobstore.Store = (*InMemoryJobStore)(nil)

--- a/pkg/jobstore/inmemory/inmemory.go
+++ b/pkg/jobstore/inmemory/inmemory.go
@@ -108,23 +108,6 @@ func (d *InMemoryJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery)
 	defer d.mtx.RUnlock()
 	var result []models.Job
 
-	if query.ID != "" {
-		job, err := d.getJob(query.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		if query.Selector != nil {
-			// If we have a selector and it doesn't match, then it isn't an error
-			// just a non-match.
-			if !query.Selector.Matches(labels.Set(job.Labels)) {
-				return &jobstore.JobQueryResponse{}, nil
-			}
-		}
-
-		return &jobstore.JobQueryResponse{Jobs: []models.Job{job}}, nil
-	}
-
 	for _, j := range maps.Values(d.jobs) {
 		if !query.ReturnAll && query.Namespace != "" && query.Namespace != j.Namespace {
 			// Job is not for the requesting client, so ignore it.

--- a/pkg/jobstore/inmemory/inmemory.go
+++ b/pkg/jobstore/inmemory/inmemory.go
@@ -136,28 +136,20 @@ func (d *InMemoryJobStore) GetJobs(ctx context.Context, query jobstore.JobQuery)
 
 	listSorter := func(i, j int) bool {
 		switch query.SortBy {
-		case "id":
-			if query.SortReverse {
-				// what does it mean to sort by ID? (rj) it's mostly meaningless and just
-				// gives us a lexicographic sort of the UUIDs.
-				return result[i].ID > result[j].ID
-			} else {
-				return result[i].ID < result[j].ID
-			}
-		case "created_at":
-			if query.SortReverse {
-				return result[i].CreateTime > result[j].CreateTime
-			} else {
-				return result[i].CreateTime < result[j].CreateTime
-			}
-		default:
-			// We apply modifytime as a default sort so that we can use it for pagination.
-			// Without a known default we won't have a stable sort that makes sense for
-			// offsets/limits.
+		case "modified_at":
 			if query.SortReverse {
 				return result[i].ModifyTime > result[j].ModifyTime
 			} else {
 				return result[i].ModifyTime < result[j].ModifyTime
+			}
+		default:
+			// We apply createdat as a default sort so that we can use it for pagination.
+			// Without a known default we won't have a stable sort that makes sense for
+			// offsets/limits.
+			if query.SortReverse {
+				return result[i].CreateTime > result[j].CreateTime
+			} else {
+				return result[i].CreateTime < result[j].CreateTime
 			}
 		}
 	}

--- a/pkg/jobstore/inmemory/inmemory_test.go
+++ b/pkg/jobstore/inmemory/inmemory_test.go
@@ -229,14 +229,6 @@ func (s *InMemoryTestSuite) TestLevelFilteredJobHistory() {
 }
 
 func (s *InMemoryTestSuite) TestSearchJobs() {
-	s.T().Run("by client ID", func(t *testing.T) {
-		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			Namespace: "client1",
-		})
-		require.NoError(t, err)
-		require.Equal(t, 1, len(response.Jobs))
-	})
-
 	s.T().Run("by client ID and included tags", func(t *testing.T) {
 		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
 			Namespace:   "client1",
@@ -250,10 +242,9 @@ func (s *InMemoryTestSuite) TestSearchJobs() {
 		require.NotContains(t, jobs[0].Labels, "slow")
 	})
 
-	s.T().Run("single record with selectors", func(t *testing.T) {
+	s.T().Run("simple selectors", func(t *testing.T) {
 		// Get the first job, which we expect to have the selector succeed with
 		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			ID:        s.ids[0],
 			Namespace: "client1",
 			Selector:  s.parseLabels("gpu=true,fast=true"),
 		})
@@ -261,16 +252,6 @@ func (s *InMemoryTestSuite) TestSearchJobs() {
 		jobs := response.Jobs
 		require.Equal(t, 1, len(jobs))
 		require.Equal(t, "client1", jobs[0].Namespace)
-
-		// The first job, but with selectors which don't match. Should not be an error
-		// but should also have no results
-		response, err = s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			ID:        s.ids[0],
-			Namespace: "client1",
-			Selector:  s.parseLabels("slow=true"),
-		})
-		require.NoError(t, err)
-		require.Empty(t, response.Jobs)
 	})
 
 	s.T().Run("all records with selectors", func(t *testing.T) {
@@ -399,16 +380,6 @@ func (s *InMemoryTestSuite) TestSearchJobs() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(response.Jobs))
-	})
-
-	s.T().Run("by id", func(t *testing.T) {
-		response, err := s.store.GetJobs(s.ctx, jobstore.JobQuery{
-			ID: s.ids[0],
-		})
-		require.NoError(t, err)
-		jobs := response.Jobs
-		require.Equal(t, 1, len(jobs))
-		require.Equal(t, s.ids[0], jobs[0].ID)
 	})
 }
 

--- a/pkg/jobstore/inmemory/inmemory_test.go
+++ b/pkg/jobstore/inmemory/inmemory_test.go
@@ -306,9 +306,8 @@ func (s *InMemoryTestSuite) TestSearchJobs() {
 
 		require.NoError(t, err)
 		jobs = response.Jobs
-		require.Equal(t, 2, len(jobs))
+		require.Equal(t, 1, len(jobs))
 		require.Equal(t, s.ids[4], jobs[0].ID)
-		require.Empty(t, jobs[1].ID) // Empty job
 	})
 
 	s.T().Run("everything sorted by id", func(t *testing.T) {

--- a/pkg/jobstore/inmemory/inmemory_test.go
+++ b/pkg/jobstore/inmemory/inmemory_test.go
@@ -424,8 +424,13 @@ func (s *InMemoryTestSuite) TestInProgressJobs() {
 	s.NoError(err)
 	s.Equal(3, len(jobs))
 
-	last_id := s.ids[2] // skip the first two non-running jobs
-	s.Equal(last_id, jobs[0].ID)
+	sourceIDs := s.ids[2:]
+	sort.Strings(sourceIDs)
+
+	jobIDs := lo.Map(jobs, func(item models.Job, _ int) string { return item.ID })
+	sort.Strings(jobIDs)
+
+	s.Equal(sourceIDs, jobIDs)
 }
 
 func (s *InMemoryTestSuite) TestEvents() {

--- a/pkg/jobstore/mocks.go
+++ b/pkg/jobstore/mocks.go
@@ -5,6 +5,7 @@
 //
 //	mockgen --source types.go --destination mocks.go --package jobstore
 //
+
 // Package jobstore is a generated GoMock package.
 package jobstore
 
@@ -199,10 +200,10 @@ func (mr *MockStoreMockRecorder) GetJobHistory(ctx, jobID, options any) *gomock.
 }
 
 // GetJobs mocks base method.
-func (m *MockStore) GetJobs(ctx context.Context, query JobQuery) ([]models.Job, error) {
+func (m *MockStore) GetJobs(ctx context.Context, query JobQuery) (*JobQueryResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobs", ctx, query)
-	ret0, _ := ret[0].([]models.Job)
+	ret0, _ := ret[0].(*JobQueryResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/jobstore/types.go
+++ b/pkg/jobstore/types.go
@@ -9,7 +9,6 @@ import (
 )
 
 type JobQuery struct {
-	ID        string
 	Namespace string
 
 	// IncludeTags and ExcludeTags are used primarily by the requester's list API.
@@ -25,11 +24,10 @@ type JobQuery struct {
 }
 
 type JobQueryResponse struct {
-	Jobs            []models.Job
-	Offset          uint32 // Offset into the filtered results of the first returned record
-	Limit           uint32 // The number of records to return, 0 means all
-	NextOffset      uint32 // Offset + Limit of the next page of results, 0 means no more results
-	RecordsReturned uint32 // The number of jobs actually held in the Jobs field
+	Jobs       []models.Job
+	Offset     uint32 // Offset into the filtered results of the first returned record
+	Limit      uint32 // The number of records to return, 0 means all
+	NextOffset uint32 // Offset + Limit of the next page of results, 0 means no more results
 }
 
 // A Store will persist jobs and their state to the underlying storage.

--- a/pkg/jobstore/types.go
+++ b/pkg/jobstore/types.go
@@ -5,18 +5,31 @@ import (
 	"context"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 type JobQuery struct {
-	ID          string   `json:"id"`
-	Namespace   string   `json:"namespace"`
-	IncludeTags []string `json:"include_tags"`
-	ExcludeTags []string `json:"exclude_tags"`
-	Limit       uint32   `json:"limit"`
-	Offset      uint32   `json:"offset"`
-	ReturnAll   bool     `json:"return_all"`
-	SortBy      string   `json:"sort_by"`
-	SortReverse bool     `json:"sort_reverse"`
+	ID        string
+	Namespace string
+
+	// IncludeTags and ExcludeTags are used primarily by the requester's list API.
+	// In the orchestrator API, we insted use the Selector field to filter jobs.
+	IncludeTags []string
+	ExcludeTags []string
+	Limit       uint32
+	Offset      uint32
+	ReturnAll   bool
+	SortBy      string
+	SortReverse bool
+	Selector    labels.Selector
+}
+
+type JobQueryResponse struct {
+	Jobs            []models.Job
+	Offset          uint32 // Offset into the filtered results of the first returned record
+	Limit           uint32 // The number of records to return, 0 means all
+	NextOffset      uint32 // Offset + Limit of the next page of results, 0 means no more results
+	RecordsReturned uint32 // The number of jobs actually held in the Jobs field
 }
 
 // A Store will persist jobs and their state to the underlying storage.
@@ -42,7 +55,7 @@ type Store interface {
 
 	// GetJobs retrieves a slice of jobs defined by the contents of the
 	// [JobQuery]. If it fails, it will return an error
-	GetJobs(ctx context.Context, query JobQuery) ([]models.Job, error)
+	GetJobs(ctx context.Context, query JobQuery) (*JobQueryResponse, error)
 
 	// GetInProgressJobs retrieves all jobs that have a state that can be
 	// considered, 'in progress'. Failure generates an error.

--- a/pkg/models/paging_token.go
+++ b/pkg/models/paging_token.go
@@ -1,0 +1,95 @@
+package models
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	delimiter         = ":"
+	expectedPartCount = 4
+)
+
+type PagingTokenParams struct {
+	SortBy      string
+	SortReverse bool
+	Limit       uint32
+	Offset      uint32
+}
+
+type PagingToken struct {
+	SortBy      string
+	SortReverse bool
+	Limit       uint32
+	Offset      uint32
+}
+
+func NewPagingToken(params *PagingTokenParams) *PagingToken {
+	return &PagingToken{
+		SortBy:      params.SortBy,
+		SortReverse: params.SortReverse,
+		Limit:       params.Limit,
+		Offset:      params.Offset,
+	}
+}
+
+func NewPagingTokenFromString(s string) (*PagingToken, error) {
+	var err error
+	var decodedBytes []byte
+
+	if decodedBytes, err = base64.RawURLEncoding.DecodeString(s); err != nil {
+		return nil, NewErrInvalidPagingToken(s, "failed to decode paging token")
+	}
+
+	parts := strings.Split(string(decodedBytes), delimiter)
+	if len(parts) != expectedPartCount {
+		return nil, NewErrInvalidPagingToken(s, "invalid number of parts")
+	}
+
+	token := &PagingToken{
+		SortBy:      parts[0],
+		SortReverse: parts[1] == "Y",
+	}
+
+	if limit, err := strconv.ParseUint(parts[2], 10, 32); err != nil {
+		return nil, NewErrInvalidPagingToken(s, "malformed token")
+	} else {
+		token.Limit = uint32(limit)
+	}
+
+	if offset, err := strconv.ParseUint(parts[3], 10, 32); err != nil {
+		return nil, NewErrInvalidPagingToken(s, "malformed token")
+	} else {
+		token.Offset = uint32(offset)
+	}
+
+	return token, nil
+}
+
+func (pagingToken *PagingToken) RawString() string {
+	reverse := "N"
+	if pagingToken.SortReverse {
+		reverse = "Y"
+	}
+
+	return strings.Join([]string{
+		pagingToken.SortBy,
+		reverse,
+		strconv.FormatUint(uint64(pagingToken.Limit), 10),
+		strconv.FormatUint(uint64(pagingToken.Offset), 10),
+	}, delimiter)
+}
+
+// String returns the token as a base 64 encoded string where each field is
+// delimited.
+func (pagingToken *PagingToken) String() string {
+	return base64.RawURLEncoding.EncodeToString([]byte(pagingToken.RawString()))
+}
+
+func NewErrInvalidPagingToken(s string, msg string) error {
+	return errors.Wrap(fmt.Errorf("invalid paging token: %s", s), msg)
+}

--- a/pkg/models/paging_token_test.go
+++ b/pkg/models/paging_token_test.go
@@ -1,0 +1,96 @@
+//go:build unit || !integration
+
+package models_test
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type PagingTokenTestSuite struct {
+	suite.Suite
+}
+
+func TestPagingTokenSuite(t *testing.T) {
+	suite.Run(t, new(PagingTokenTestSuite))
+}
+
+func (s *PagingTokenTestSuite) TestNew() {
+	type testcase struct {
+		name      string
+		params    *models.PagingTokenParams
+		token     string
+		decoded   string
+		expectErr bool
+	}
+	testcases := []testcase{
+		{
+			name: "valid unreversed",
+			params: &models.PagingTokenParams{
+				SortBy:      "created_at",
+				SortReverse: false,
+				Offset:      0,
+				Limit:       10,
+			},
+			token:     "Y3JlYXRlZF9hdDpOOjEwOjA",
+			decoded:   "created_at:N:10:0",
+			expectErr: false,
+		},
+		{
+			name: "valid reversed",
+			params: &models.PagingTokenParams{
+				SortBy:      "created_at",
+				SortReverse: true,
+				Offset:      0,
+				Limit:       10,
+			},
+			token:     "Y3JlYXRlZF9hdDpZOjEwOjA",
+			decoded:   "created_at:Y:10:0",
+			expectErr: false,
+		},
+		{
+			name: "valid with offset",
+			params: &models.PagingTokenParams{
+				SortBy:      "created_at",
+				SortReverse: true,
+				Offset:      10,
+				Limit:       10,
+			},
+			token:     "Y3JlYXRlZF9hdDpZOjEwOjEw",
+			decoded:   "created_at:Y:10:10",
+			expectErr: false,
+		},
+		{
+			name:      "invalid token",
+			params:    &models.PagingTokenParams{},
+			token:     "abc",
+			decoded:   "created_at:Y:10:10",
+			expectErr: true,
+		},
+	}
+
+	for i := range testcases {
+		if !testcases[i].expectErr {
+			s.Run(testcases[i].name, func() {
+
+				token := models.NewPagingToken(testcases[i].params)
+				s.Equal(testcases[i].token, token.String())
+				s.Equal(testcases[i].decoded, token.RawString())
+			})
+		}
+
+		s.Run(testcases[i].name, func() {
+			token, err := models.NewPagingTokenFromString(testcases[i].token)
+			if testcases[i].expectErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+				s.Equal(testcases[i].decoded, token.RawString())
+			}
+
+		})
+	}
+
+}

--- a/pkg/publicapi/endpoint/requester/endpoints_list.go
+++ b/pkg/publicapi/endpoint/requester/endpoints_list.go
@@ -64,7 +64,7 @@ func (s *Endpoint) list(c echo.Context) error {
 }
 
 func (s *Endpoint) getJobsList(ctx context.Context, listReq legacymodels.ListRequest) ([]model.Job, error) {
-	list, err := s.jobStore.GetJobs(ctx, jobstore.JobQuery{
+	response, err := s.jobStore.GetJobs(ctx, jobstore.JobQuery{
 		Namespace:   listReq.ClientID,
 		ID:          listReq.JobID,
 		Limit:       listReq.MaxJobs,
@@ -77,9 +77,9 @@ func (s *Endpoint) getJobsList(ctx context.Context, listReq legacymodels.ListReq
 	if err != nil {
 		return nil, err
 	}
-	res := make([]model.Job, len(list))
-	for i := range list {
-		legacyJob, err := legacy.ToLegacyJob(&list[i])
+	res := make([]model.Job, len(response.Jobs))
+	for i := range response.Jobs {
+		legacyJob, err := legacy.ToLegacyJob(&response.Jobs[i])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/publicapi/endpoint/requester/endpoints_list.go
+++ b/pkg/publicapi/endpoint/requester/endpoints_list.go
@@ -30,12 +30,19 @@ import (
 //nolint:lll
 func (s *Endpoint) list(c echo.Context) error {
 	var listReq legacymodels.ListRequest
+	var err error
+	var jobList []model.Job
 
 	if err := c.Bind(&listReq); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	jobList, err := s.getJobsList(c.Request().Context(), listReq)
+	if listReq.JobID != "" {
+		jobList, err = s.getSingleJob(c.Request().Context(), listReq.JobID)
+	} else {
+		jobList, err = s.getJobsList(c.Request().Context(), listReq)
+	}
+
 	if err != nil {
 		_, ok := err.(*bacerrors.JobNotFound)
 		if ok {
@@ -63,10 +70,23 @@ func (s *Endpoint) list(c echo.Context) error {
 	})
 }
 
+func (s *Endpoint) getSingleJob(ctx context.Context, jobID string) ([]model.Job, error) {
+	job, err := s.jobStore.GetJob(ctx, jobID)
+	if err != nil {
+		return nil, err
+	}
+
+	convertedJob, err := legacy.ToLegacyJob(&job)
+	if err != nil {
+		return nil, err
+	}
+
+	return []model.Job{*convertedJob}, nil
+}
+
 func (s *Endpoint) getJobsList(ctx context.Context, listReq legacymodels.ListRequest) ([]model.Job, error) {
 	response, err := s.jobStore.GetJobs(ctx, jobstore.JobQuery{
 		Namespace:   listReq.ClientID,
-		ID:          listReq.JobID,
 		Limit:       listReq.MaxJobs,
 		IncludeTags: listReq.IncludeTags,
 		ExcludeTags: listReq.ExcludeTags,


### PR DESCRIPTION
Currently we allow users to define limit query params when listing jobs, but we always return an empty next_token (offset), which prevents users from actual pagination and querying the next set of jobs. 

This PR moves label filtering into the jobstore, and introduces a default sort order so that the offset/limit make sense. This allows for proper pagination from the CLI. The next-token is now used by the jobstore, but it only encodes the offset (e.g. it is the offset).  The next-token should really encode more information so that it can be re-constituted with the correct parameters.  Without this (as currently) it relies on the same sort being applied for each request.

