### PR TITLE
Stops linters from 'fixing' code

### DIFF
--- a/.gitprecommit/golangci-lint.sh
+++ b/.gitprecommit/golangci-lint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-golangci-lint run --allow-parallel-runners --timeout 10m --fix
+golangci-lint run --allow-parallel-runners --timeout 10m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     entry: .gitprecommit/go_fmt.sh
     language: script
   - id: golangci-lint
-    name: golangci-lint --fix
+    name: golangci-lint
     entry: .gitprecommit/golangci-lint.sh
     language: script
   - id: go-mod-tidy-check

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ lint:
 
 .PHONY: lint-fix
 lint-fix:
-	golangci-lint run --timeout 10m --fix
+	golangci-lint run --timeout 10m
 
 ################################################################################
 # Target: modtidy


### PR DESCRIPTION
Currently we run golangci-lint run with the `--fix` flag that allows individual linters to make changes to the files where it finds problems. Ideally the linter should just flag the issue for the developer to fix, using --fix if they wish, but not making that choice on their behalf.