### PR TITLE
feat: add metrics to publisher and input storage

### DIFF
--- a/pkg/models/input_source.go
+++ b/pkg/models/input_source.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
 	"github.com/hashicorp/go-multierror"
+	"github.com/rs/zerolog"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
 )
 
 type InputSource struct {
@@ -19,6 +21,12 @@ type InputSource struct {
 
 	// Target is the path where the artifact should be mounted on
 	Target string `json:"Target"`
+}
+
+func (a *InputSource) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("alias", a.Alias).
+		Str("target", a.Target).
+		Object("source", a.Source)
 }
 
 // Normalize normalizes the artifact's source and target

--- a/pkg/models/spec_config.go
+++ b/pkg/models/spec_config.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/exp/maps"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
 )
 
 type SpecConfig struct {
@@ -14,6 +17,19 @@ type SpecConfig struct {
 
 	// Params is a map of the config params
 	Params map[string]interface{} `json:"Params,omitempty"`
+}
+
+func (s *SpecConfig) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("type", s.Type)
+	for k, v := range s.Params {
+		e.Interface(k, v)
+	}
+}
+
+func (s *SpecConfig) MetricAttributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("type", s.Type),
+	}
 }
 
 // NewSpecConfig returns a new spec config

--- a/pkg/publisher/tracing/metrics.go
+++ b/pkg/publisher/tracing/metrics.go
@@ -1,0 +1,17 @@
+package tracing
+
+import (
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	meter = otel.GetMeterProvider().Meter("publisher")
+
+	jobPublishDurationMilliseconds = lo.Must(meter.Int64Histogram(
+		"job_publish_duration_milliseconds",
+		metric.WithDescription("Duration of publishing a job on the compute node in milliseconds."),
+		metric.WithUnit("ms"),
+	))
+)

--- a/pkg/storage/tracing/metrics.go
+++ b/pkg/storage/tracing/metrics.go
@@ -1,0 +1,29 @@
+package tracing
+
+import (
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	meter = otel.GetMeterProvider().Meter("storage")
+
+	jobStorageUploadDurationMilliseconds = lo.Must(meter.Int64Histogram(
+		"job_storage_upload_duration_milliseconds",
+		metric.WithDescription("Duration of uploading job storage input the compute node in milliseconds."),
+		metric.WithUnit("ms"),
+	))
+
+	jobStoragePrepareDurationMilliseconds = lo.Must(meter.Int64Histogram(
+		"job_storage_prepare_duration_milliseconds",
+		metric.WithDescription("Duration of preparing job storage input the compute node in milliseconds."),
+		metric.WithUnit("ms"),
+	))
+
+	jobStorageCleanupDurationMilliseconds = lo.Must(meter.Int64Histogram(
+		"job_storage_cleanup_duration_milliseconds",
+		metric.WithDescription("Duration of job storage input cleanup the compute node in milliseconds."),
+		metric.WithUnit("ms"),
+	))
+)


### PR DESCRIPTION
- improve Telemetry time devex
- metrics for publisher
	- publish time + logs
- metrics for storage
	- upload time + logs
	- prepate time + logs
	- cleanup time + logs
- implemented LogMarshaller on SpecConfig

Progress towards: https://github.com/bacalhau-project/expanso-planning/issues/386