### PR TITLE
Adding example ask authn policy that uses a shared secret

### DIFF
--- a/pkg/authn/ask/ask_ns_secret.rego
+++ b/pkg/authn/ask/ask_ns_secret.rego
@@ -1,0 +1,57 @@
+package bacalhau.authn
+
+import rego.v1
+
+# Implements a policy where clients that supply a valid secret are
+# permitted access. Anonymous users are not authenticated.
+#
+# Modify the `expected_secret` to control what secret is permitted access.
+# Modify the `ns` key of the token to control what namespaces they can access.
+
+schema := {
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"token": {"type": "string", "writeOnly": true},
+	},
+	"required": ["token"],
+}
+
+now := time.now_ns() / 1000
+
+one_month := time.add_date(time.now_ns(), 0, 1, 0) / 1000
+
+# expected_secret should be a random string issued to the user. in a simple live
+# setup they can be hard coded here, and then apply appropriate file permissions
+# to this policy.
+expected_secret := "insert a secret string here"
+
+valid_secret if {
+	expected_secret == input.ask.token
+}
+
+token := io.jwt.encode_sign(
+	{
+		"typ": "JWT",
+		"alg": "RS256",
+	},
+	{
+		"iss": input.nodeId,
+		"aud": [input.nodeId],
+		"iat": now,
+		"exp": one_month,
+		"ns": {
+			# Full access to all namespaces
+			"*": full_access,
+		},
+	},
+	input.signingKey,
+)
+
+namespace_read := 1
+namespace_write := 2
+namespace_download := 4
+namespace_cancel := 8
+
+read_only := bits.and(namespace_read, namespace_download)
+full_access := bits.and(bits.and(namespace_write, namespace_cancel), read_only)


### PR DESCRIPTION
For the Marketplace code, we want something simpler than a username and password to get us started. This adds an example "shared secret" policy that we can use in Marketplace deployments. The deployment will need to generate a secret string and output it as part of the Terraform deployment, and then the user will need to supply this string on first boot.

To see this in action:

* Add the following to your config.yaml.

    ```yaml
     auth:
        methods:
            shared_secret:
                type: ask
                policypath: "/path/to/bacalhau/pkg/authn/ask/ask_ns_secret.rego"
    ```

* Start up Bacalhau as a requester node.
* Run an example command, e.g. `bacalhau --api-host=localhost job list`, and observe that you are asked for the token.
* Supply the correct token and receive the output.

Resolves https://github.com/bacalhau-project/expanso-planning/issues/431.