### PR TITLE
3381 - Just one yaml

### DIFF
--- a/cmd/cli/config/set_test.go
+++ b/cmd/cli/config/set_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"

--- a/cmd/cli/create/create.go
+++ b/cmd/cli/create/create.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kubectl/pkg/util/i18n"
-	"sigs.k8s.io/yaml"
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 

--- a/cmd/cli/describe/describe.go
+++ b/cmd/cli/describe/describe.go
@@ -133,8 +133,6 @@ func describe(cmd *cobra.Command, cmdArgs []string, OD *DescribeOptions) error {
 		if err != nil {
 			return fmt.Errorf("able to marshal to YAML but not JSON '%s': %w", j.Job.Metadata.ID, err)
 		}
-		fmt.Println(string(b))
-		fmt.Println(y)
 		cmd.Print(y)
 	} else {
 		// Print as Json

--- a/cmd/cli/describe/describe.go
+++ b/cmd/cli/describe/describe.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels/legacymodels"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/i18n"
-	"sigs.k8s.io/yaml"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
@@ -130,11 +129,13 @@ func describe(cmd *cobra.Command, cmdArgs []string, OD *DescribeOptions) error {
 
 	if !OD.JSON {
 		// Convert Json to Yaml
-		y, err := yaml.JSONToYAML(b)
+		y, err := util.JSONToYaml(b)
 		if err != nil {
-			return fmt.Errorf("able to marshal to YAML but not JSON whatttt '%s': %w", j.Job.Metadata.ID, err)
+			return fmt.Errorf("able to marshal to YAML but not JSON '%s': %w", j.Job.Metadata.ID, err)
 		}
-		cmd.Print(string(y))
+		fmt.Println(string(b))
+		fmt.Println(y)
+		cmd.Print(y)
 	} else {
 		// Print as Json
 		cmd.Print(string(b))

--- a/cmd/cli/docker/docker_run.go
+++ b/cmd/cli/docker/docker_run.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kubectl/pkg/util/i18n"
-	"sigs.k8s.io/yaml"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"

--- a/cmd/cli/validate/validate.go
+++ b/cmd/cli/validate/validate.go
@@ -13,9 +13,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/util/templates"
-
 	"k8s.io/kubectl/pkg/util/i18n"
-	"sigs.k8s.io/yaml"
 
 	"github.com/xeipuuv/gojsonschema"
 
@@ -138,14 +136,13 @@ func validate(cmd *cobra.Command, cmdArgs []string, OV *ValidateOptions) error {
 
 	// Convert the schema to JSON - this is required for the gojsonschema library
 	// Noop if you pass JSON through
-	fileContentsAsJSONBytes, err := yaml.YAMLToJSON(byteResult)
+	fileContentsAsJSON, err := util.YamlToJSON(byteResult)
 	if err != nil {
 		return fmt.Errorf("error converting yaml to json: %w", err)
 	}
 
-	// println(str)
 	schemaLoader := gojsonschema.NewStringLoader(string(jsonSchemaData))
-	documentLoader := gojsonschema.NewStringLoader(string(fileContentsAsJSONBytes))
+	documentLoader := gojsonschema.NewStringLoader(fileContentsAsJSON)
 
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {

--- a/cmd/cli/wasm/wasm_run.go
+++ b/cmd/cli/wasm/wasm_run.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kubectl/pkg/util/i18n"
-	"sigs.k8s.io/yaml"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags"

--- a/cmd/util/conversion.go
+++ b/cmd/util/conversion.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+func YamlToJSON(data []byte) (string, error) {
+	var body interface{}
+	var res string
+
+	if err := yaml.Unmarshal(data, &body); err != nil {
+		return "", err
+	}
+
+	body = convert(body)
+
+	if b, err := json.Marshal(body); err != nil {
+		return "", err
+	} else {
+		res = string(b)
+	}
+
+	return res, nil
+}
+
+func JSONToYaml(data []byte) (string, error) {
+	var body interface{}
+	var res string
+
+	if err := json.Unmarshal(data, &body); err != nil {
+		return "", err
+	}
+
+	body = convert(body)
+
+	if b, err := yaml.Marshal(body); err != nil {
+		return "", err
+	} else {
+		res = string(b)
+	}
+
+	return res, nil
+}
+
+// find any `map[interface{}]interface{}` and convert them to `map[string]interface{}`
+func convert(obj interface{}) interface{} {
+	switch newObj := obj.(type) {
+	case map[interface{}]interface{}:
+		m := map[string]interface{}{}
+		for k, v := range newObj {
+			m[k.(string)] = convert(v)
+		}
+		return m
+	case map[string]interface{}:
+		m := map[string]interface{}{}
+		for k, v := range newObj {
+			m[k] = convert(v)
+		}
+		return m
+	case []interface{}:
+		for i, v := range newObj {
+			newObj[i] = convert(v)
+		}
+	}
+	return obj
+}

--- a/cmd/util/output/output.go
+++ b/cmd/util/output/output.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type OutputFormat string

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/dylibso/observe-sdk/go v0.0.0-20231201014635-141351c24659
 	github.com/fatih/structs v1.1.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/validator/v10 v10.16.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.5.0
@@ -88,7 +87,6 @@ require (
 	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61
 	k8s.io/apimachinery v0.29.0
 	k8s.io/kubectl v0.29.0
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -177,6 +175,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -302,7 +302,6 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=

--- a/pkg/lib/marshaller/utils.go
+++ b/pkg/lib/marshaller/utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/c2h5oh/datasize"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 type KeyString string

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/c2h5oh/datasize"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/yaml"
 )
 
 type KeyString string

--- a/pkg/orchestrator/endpoint.go
+++ b/pkg/orchestrator/endpoint.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 type BaseEndpointParams struct {


### PR DESCRIPTION
Currently we're using 3 different YAML parsing libraries of various versions.  This is unnecessary so this PR moves us towards using "gopkg.in/yaml.v3" (go-yaml). Other unused yaml parsers are removed from the list of installed mods.

Resolves #3381 