### PR TITLE
Select network address based on type

### DIFF
--- a/pkg/lib/network/network.go
+++ b/pkg/lib/network/network.go
@@ -1,0 +1,94 @@
+package network
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+type AddressType int
+
+const (
+	PrivateAddress AddressType = iota
+	PublicAddress
+	LoopbackAddress
+	LinkLocal
+	Multicast
+	Any
+)
+
+type AddressLister func() ([]net.IP, error)
+
+func AllAddresses() ([]net.IP, error) {
+	var result []net.IP
+
+	addresses, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get interface addresses")
+	}
+
+	for _, address := range addresses {
+		ip, _, err := net.ParseCIDR(address.String())
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to parse address: %s", address.String()))
+		}
+
+		ipAs4 := ip.To4()
+		if ipAs4 != nil {
+			result = append(result, ipAs4)
+		}
+	}
+
+	return result, nil
+}
+
+// GetNetworkAddress returns a list of network addresses of the requested type,
+// sourcing the addresses from the provided AddressLister. It is expected that
+// network.AddAddresses() will be the default address lister. The result is
+// a list of strings representing the network addresses in the order they
+// were returned by the AddressLister.
+func GetNetworkAddress(requested AddressType, getAddresses AddressLister) ([]string, error) {
+	addresses, err := getAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(addresses))
+
+	for i := range addresses {
+		addr := addresses[i]
+
+		switch requested {
+		case Any:
+			result = append(result, addr.String())
+		case PrivateAddress:
+			if addr.IsPrivate() {
+				result = append(result, addr.String())
+			}
+		case PublicAddress:
+			if !addr.IsPrivate() && addr.IsGlobalUnicast() {
+				result = append(result, addr.String())
+			}
+		case LoopbackAddress:
+			if addr.IsLoopback() {
+				result = append(result, addr.String())
+			}
+		case LinkLocal:
+			if addr.IsLinkLocalMulticast() || addr.IsLinkLocalUnicast() {
+				result = append(result, addr.String())
+			}
+		case Multicast:
+			if isMulticastAddress(addr) {
+				result = append(result, addr.String())
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func isMulticastAddress(addr net.IP) bool {
+	_, net, _ := net.ParseCIDR("224.0.0.0/4")
+	return net.Contains(addr)
+}

--- a/pkg/lib/network/network.go
+++ b/pkg/lib/network/network.go
@@ -64,11 +64,11 @@ func GetNetworkAddress(requested AddressType, getAddresses AddressLister) ([]str
 		case Any:
 			result = append(result, addr.String())
 		case PrivateAddress:
-			if addr.IsPrivate() {
+			if addr.IsPrivate() || isCarrierGradeNAT(addr) {
 				result = append(result, addr.String())
 			}
 		case PublicAddress:
-			if !addr.IsPrivate() && addr.IsGlobalUnicast() {
+			if !addr.IsPrivate() && addr.IsGlobalUnicast() && !isCarrierGradeNAT(addr) {
 				result = append(result, addr.String())
 			}
 		case LoopbackAddress:
@@ -106,6 +106,11 @@ func AddressTypeFromString(t string) (AddressType, bool) {
 	default:
 		return Any, false
 	}
+}
+
+func isCarrierGradeNAT(addr net.IP) bool {
+	_, net, _ := net.ParseCIDR("100.64.0.0/10")
+	return net.Contains(addr)
 }
 
 func isMulticastAddress(addr net.IP) bool {

--- a/pkg/lib/network/network.go
+++ b/pkg/lib/network/network.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -86,6 +87,25 @@ func GetNetworkAddress(requested AddressType, getAddresses AddressLister) ([]str
 	}
 
 	return result, nil
+}
+
+func AddressTypeFromString(t string) (AddressType, bool) {
+	switch strings.ToLower(t) {
+	case "private":
+		return PrivateAddress, true
+	case "public":
+		return PublicAddress, true
+	case "loopback", "localhost", "local":
+		return LoopbackAddress, true
+	case "linklocal":
+		return LinkLocal, true
+	case "multicast":
+		return Multicast, true
+	case "any":
+		return Any, true
+	default:
+		return Any, false
+	}
 }
 
 func isMulticastAddress(addr net.IP) bool {

--- a/pkg/lib/network/network_test.go
+++ b/pkg/lib/network/network_test.go
@@ -14,7 +14,7 @@ type NetworkTestSuite struct {
 	suite.Suite
 }
 
-func TestEnvTestSuite(t *testing.T) {
+func TestNetworkSuite(t *testing.T) {
 	suite.Run(t, new(NetworkTestSuite))
 }
 

--- a/pkg/lib/network/network_test.go
+++ b/pkg/lib/network/network_test.go
@@ -1,0 +1,67 @@
+//go:build unit || !integration
+
+package network_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
+	"github.com/stretchr/testify/suite"
+)
+
+type NetworkTestSuite struct {
+	suite.Suite
+}
+
+func TestEnvTestSuite(t *testing.T) {
+	suite.Run(t, new(NetworkTestSuite))
+}
+
+func test_addresses() []string {
+	return []string{
+		"127.0.0.1",       // localhost
+		"169.254.46.5",    // link local
+		"192.168.0.1",     // private
+		"10.10.10.10",     // private
+		"172.16.20.24",    // private
+		"225.255.255.255", // multicast
+		"86.13.65.80",     //public
+	}
+}
+
+func AddressList() ([]net.IP, error) {
+	addr := test_addresses()
+	result := make([]net.IP, len(addr))
+
+	for i := range addr {
+		result[i] = net.ParseIP(addr[i])
+	}
+
+	return result, nil
+}
+
+func (s *NetworkTestSuite) TestFetch() {
+	type testcase struct {
+		name        string
+		addressType network.AddressType
+		expected    []string
+	}
+	testcases := []testcase{
+		{"localhost", network.LoopbackAddress, []string{"127.0.0.1"}},
+		{"linklocal", network.LinkLocal, []string{"169.254.46.5"}},
+		{"multicast", network.Multicast, []string{"225.255.255.255"}},
+		{"private", network.PrivateAddress, []string{"192.168.0.1", "10.10.10.10", "172.16.20.24"}},
+		{"public", network.PublicAddress, []string{"86.13.65.80"}},
+		{"any", network.Any, test_addresses()},
+	}
+
+	for t := range testcases {
+		tc := testcases[t]
+		s.Run(tc.name, func() {
+			addr, err := network.GetNetworkAddress(tc.addressType, AddressList)
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(tc.expected, addr)
+		})
+	}
+}


### PR DESCRIPTION
Currently we use 0.0.0.0 a lot when a bind address is required, and as a result we end up binding to all addresses.  This is both confusing and potentially an issue if we can't more closely control which address types to use (e.g. we may end up binding compute nodes to public addresses unintentionally).

This PR provides functionality to iterate the addresses available on the current host and to filter them based on network type.  This means we can filter on public, private, local or linklocal addresses for various use-cases.  

It also changes the configuarion getter for Server API Host to allow the address type to be specified in place of an IP address.  This means we can set Server.API.Host to an IP address as currently, or "public" to get a public address, or "private" to get a private address. Care must be taken as most dev laptops won't have a public address and as the 'production' environment is the default, we can't (and this PR doesn't) default to 'public'.    It also only uses the first address of a type it finds, and so does not handle special cases which may have multiple public addresses.

This should resolve #3322 by allowing us to specify an address type rather than 0.0.0.0 once we are using the appropriate env.

Future changes should allow for a comma separated list to also support:

* "public,private" 
* "public,100.10.10.100"

