### PR TITLE
NATS based LogStream 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,8 @@ commands:
       - run: sudo apt install python3.10 -y
       - run: curl -sSL https://install.python-poetry.org | python3 -
       - run: echo 'export PATH="/home/circleci/.local/bin:$PATH"' >> "$BASH_ENV"
+      # Find Python 3.10 executable path and set it for Poetry
+      - run: PYTHON_PATH=$(which python3.10) && poetry env use $PYTHON_PATH
 
 jobs:
   build_cli:

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/nats-io/nats-server/v2 v2.10.7
 	github.com/nats-io/nats.go v1.31.0
+	github.com/nats-io/nuid v1.0.1
 	github.com/open-policy-agent/opa v0.60.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
@@ -156,7 +157,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nats-io/jwt/v2 v2.5.3 // indirect
 	github.com/nats-io/nkeys v0.4.6 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect

--- a/pkg/lib/concurrency/async_result.go
+++ b/pkg/lib/concurrency/async_result.go
@@ -11,6 +11,28 @@ type AsyncResult[T any] struct {
 	Err   error `json:"error,omitempty"`
 }
 
+// NewAsyncValue creates a new AsyncResult with a value
+func NewAsyncValue[T any](value T) *AsyncResult[T] {
+	return &AsyncResult[T]{
+		Value: value,
+	}
+}
+
+// NewAsyncError creates a new AsyncResult with an error
+func NewAsyncError[T any](err error) *AsyncResult[T] {
+	return &AsyncResult[T]{
+		Err: err,
+	}
+}
+
+// NewAsyncResult creates a new AsyncResult with a value and an error
+func NewAsyncResult[T any](value T, err error) *AsyncResult[T] {
+	return &AsyncResult[T]{
+		Value: value,
+		Err:   err,
+	}
+}
+
 // MarshalJSON customizes the JSON representation of AsyncResult
 func (ar AsyncResult[T]) MarshalJSON() ([]byte, error) {
 	type Alias AsyncResult[T]
@@ -41,6 +63,10 @@ func (ar *AsyncResult[T]) UnmarshalJSON(data []byte) error {
 		ar.Err = fmt.Errorf(aux.Error)
 	}
 	return nil
+}
+
+func (ar *AsyncResult[T]) ValueOrError() (T, error) {
+	return ar.Value, ar.Err
 }
 
 func errorToString(err error) string {

--- a/pkg/lib/concurrency/channel_transformer.go
+++ b/pkg/lib/concurrency/channel_transformer.go
@@ -18,13 +18,7 @@ func AsyncChannelTransform[In any, Out any](
 				if !ok {
 					return // Input channel closed
 				}
-				result := new(AsyncResult[Out])
-				transformedValue, err := transform(msg)
-				if err != nil {
-					result.Err = err
-				} else {
-					result = transformedValue
-				}
+				result := NewAsyncResult[Out](transform(msg))
 
 				select {
 				case output <- result:

--- a/pkg/lib/concurrency/channel_transformer.go
+++ b/pkg/lib/concurrency/channel_transformer.go
@@ -1,0 +1,41 @@
+package concurrency
+
+import "context"
+
+// AsyncChannelTransform copies messages from an input channel, transforms them, and sends them to an output channel.
+func AsyncChannelTransform[In any, Out any](
+	ctx context.Context,
+	input <-chan In,
+	bufferCapacity int,
+	transform func(In) (*AsyncResult[Out], error)) <-chan *AsyncResult[Out] {
+	output := make(chan *AsyncResult[Out], bufferCapacity)
+
+	go func() {
+		defer close(output)
+		for {
+			select {
+			case msg, ok := <-input:
+				if !ok {
+					return // Input channel closed
+				}
+				result := new(AsyncResult[Out])
+				transformedValue, err := transform(msg)
+				if err != nil {
+					result.Err = err
+				} else {
+					result = transformedValue
+				}
+
+				select {
+				case output <- result:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return output
+}

--- a/pkg/lib/concurrency/channel_transformer_test.go
+++ b/pkg/lib/concurrency/channel_transformer_test.go
@@ -1,0 +1,68 @@
+//go:build unit || !integration
+
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockTransform doubles the input value if no error occurs.
+func mockTransform(in int) (int, error) {
+	return in * 2, nil
+}
+
+// TestAsyncChannelTransform_Basic checks if the transform function is correctly applied to valid input messages.
+func TestAsyncChannelTransform_Basic(t *testing.T) {
+	ctx := context.Background()
+	input := make(chan *AsyncResult[int])
+	go func() {
+		input <- &AsyncResult[int]{Value: 1}
+		input <- &AsyncResult[int]{Value: 2}
+		close(input)
+	}()
+
+	output := AsyncChannelTransform(ctx, input, 10, mockTransform)
+
+	var results []*AsyncResult[int]
+	for res := range output {
+		results = append(results, res)
+	}
+
+	if len(results) != 2 || results[0].Value != 2 || results[1].Value != 4 || results[0].Err != nil || results[1].Err != nil {
+		t.Errorf("Unexpected transformation results: %+v", results)
+	}
+}
+
+// TestAsyncChannelTransform_ErrorPropagation checks if errors in input messages are correctly propagated.
+func TestAsyncChannelTransform_ErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+	inputError := errors.New("input error")
+	input := make(chan *AsyncResult[int])
+	go func() {
+		input <- &AsyncResult[int]{Err: inputError}
+		close(input)
+	}()
+
+	output := AsyncChannelTransform(ctx, input, 10, mockTransform)
+
+	result := <-output
+	if result.Err == nil || result.Err != inputError {
+		t.Errorf("Expected error to be propagated, got: %+v", result.Err)
+	}
+}
+
+// TestAsyncChannelTransform_ContextCancellation checks if the operation stops gracefully upon context cancellation.
+func TestAsyncChannelTransform_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	input := make(chan *AsyncResult[int])
+	cancel()
+
+	output := AsyncChannelTransform(ctx, input, 10, mockTransform)
+
+	_, ok := <-output
+	if ok {
+		t.Errorf("Expected output channel to be closed due to context cancellation")
+	}
+}

--- a/pkg/nats/proxy/compute_proxy.go
+++ b/pkg/nats/proxy/compute_proxy.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/nats/stream"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog/log"
+)
+
+const (
+	// asyncRequestChanLen is the channel length for buffering asynchronous results.
+	asyncRequestChanLen = 8
 )
 
 type ComputeProxyParams struct {
@@ -21,75 +26,132 @@ type ComputeProxyParams struct {
 // to a local compute node if the target peer ID is the same as the local host, and a LocalEndpoint implementation
 // is provided.
 type ComputeProxy struct {
-	conn *nats.Conn
+	conn            *nats.Conn
+	streamingClient *stream.Client
 }
 
-func NewComputeProxy(params ComputeProxyParams) *ComputeProxy {
-	proxy := &ComputeProxy{
-		conn: params.Conn,
+func NewComputeProxy(params ComputeProxyParams) (*ComputeProxy, error) {
+	sc, err := stream.NewClient(stream.ClientParams{Conn: params.Conn})
+	if err != nil {
+		return nil, err
 	}
-	return proxy
+	proxy := &ComputeProxy{
+		conn:            params.Conn,
+		streamingClient: sc,
+	}
+	return proxy, nil
 }
 
 func (p *ComputeProxy) AskForBid(ctx context.Context, request compute.AskForBidRequest) (compute.AskForBidResponse, error) {
 	return proxyRequest[compute.AskForBidRequest, compute.AskForBidResponse](
-		ctx, p.conn, request.TargetPeerID, AskForBid, request)
+		ctx, p.conn, &BaseRequest[compute.AskForBidRequest]{
+			TargetNodeID: request.TargetPeerID,
+			Method:       AskForBid,
+			Body:         request,
+		})
 }
 
 func (p *ComputeProxy) BidAccepted(ctx context.Context, request compute.BidAcceptedRequest) (compute.BidAcceptedResponse, error) {
 	return proxyRequest[compute.BidAcceptedRequest, compute.BidAcceptedResponse](
-		ctx, p.conn, request.TargetPeerID, BidAccepted, request)
+		ctx, p.conn, &BaseRequest[compute.BidAcceptedRequest]{
+			TargetNodeID: request.TargetPeerID,
+			Method:       BidAccepted,
+			Body:         request,
+		})
 }
 
 func (p *ComputeProxy) BidRejected(ctx context.Context, request compute.BidRejectedRequest) (compute.BidRejectedResponse, error) {
 	return proxyRequest[compute.BidRejectedRequest, compute.BidRejectedResponse](
-		ctx, p.conn, request.TargetPeerID, BidRejected, request)
+		ctx, p.conn, &BaseRequest[compute.BidRejectedRequest]{
+			TargetNodeID: request.TargetPeerID,
+			Method:       BidRejected,
+			Body:         request,
+		})
 }
 
 func (p *ComputeProxy) CancelExecution(
 	ctx context.Context, request compute.CancelExecutionRequest) (compute.CancelExecutionResponse, error) {
 	return proxyRequest[compute.CancelExecutionRequest, compute.CancelExecutionResponse](
-		ctx, p.conn, request.TargetPeerID, CancelExecution, request)
+		ctx, p.conn, &BaseRequest[compute.CancelExecutionRequest]{
+			TargetNodeID: request.TargetPeerID,
+			Method:       CancelExecution,
+			Body:         request,
+		})
 }
 
 func (p *ComputeProxy) ExecutionLogs(ctx context.Context, request compute.ExecutionLogsRequest) (
 	<-chan *concurrency.AsyncResult[models.ExecutionLog], error) {
-	//TODO implement me
-	panic("implement me")
+	return proxyStreamingRequest[compute.ExecutionLogsRequest, models.ExecutionLog](
+		ctx, p.streamingClient, &BaseRequest[compute.ExecutionLogsRequest]{
+			TargetNodeID: request.TargetPeerID,
+			Method:       ExecutionLogs,
+			Body:         request,
+		})
 }
 
 func proxyRequest[Request any, Response any](
 	ctx context.Context,
 	conn *nats.Conn,
-	destNodeID string,
-	method string,
-	request Request) (Response, error) {
+	request *BaseRequest[Request]) (Response, error) {
 	// response object
 	response := new(Response)
 
-	// deserialize the request object
-	data, err := json.Marshal(request)
+	subject := request.ComputeEndpoint()
+	log.Ctx(ctx).Trace().Msgf("Sending request %+v to subject %s", request, subject)
+
+	// serialize the request object
+	data, err := json.Marshal(request.Body)
 	if err != nil {
-		return *response, fmt.Errorf("%s: failed to marshal request: %w", reflect.TypeOf(request), err)
+		return *response, fmt.Errorf("%T: failed to marshal request: %w", request.Body, err)
 	}
 
-	subject := computeEndpointPublishSubject(destNodeID, method)
-	log.Ctx(ctx).Trace().Msgf("Sending request %+v to subject %s", request, subject)
 	res, err := conn.RequestWithContext(ctx, subject, data)
 	if err != nil {
-		return *response, fmt.Errorf("%s: failed to send request to node %s: %w", reflect.TypeOf(request), destNodeID, err)
+		return *response, fmt.Errorf("%T: failed to send request to node %s: %w", request.Body, request.TargetNodeID, err)
 	}
 
 	// The handler will have wrapped the response in a Result[T] along with
 	// any error that occurred, so we will decode it and pass the
 	// inner response/error on to the caller.
-	result := &Result[Response]{}
+	result := new(concurrency.AsyncResult[Response])
 	err = json.Unmarshal(res.Data, result)
 	if err != nil {
-		return *response, fmt.Errorf("%s: failed to decode response from peer %s: %w", reflect.TypeOf(request), destNodeID, err)
+		return *response, fmt.Errorf("%T: failed to decode response from peer %s: %w", request.Body, request.TargetNodeID, err)
 	}
 
-	return result.Rehydrate()
+	return result.ValueOrError()
+}
+
+func proxyStreamingRequest[Request any, Response any](
+	ctx context.Context,
+	client *stream.Client,
+	request *BaseRequest[Request]) (
+	<-chan *concurrency.AsyncResult[Response], error) {
+	subject := request.ComputeEndpoint()
+	log.Ctx(ctx).Trace().Msgf("Sending streaming request %+v to subject %s", request.Body, subject)
+
+	// serialize the request object
+	data, err := json.Marshal(request.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%T: failed to marshal request: %w", request.Body, err)
+	}
+	res, err := client.OpenStream(ctx, subject, data)
+	if err != nil {
+		return nil, fmt.Errorf("%T: failed to send request to node %s: %w", request.Body, request.TargetNodeID, err)
+	}
+
+	return concurrency.AsyncChannelTransform[*concurrency.AsyncResult[[]byte], Response](ctx, res, asyncRequestChanLen,
+		func(r *concurrency.AsyncResult[[]byte]) (*concurrency.AsyncResult[Response], error) {
+			if r.Err != nil {
+				return concurrency.NewAsyncError[Response](r.Err), nil
+			}
+			response := new(concurrency.AsyncResult[Response])
+			err = json.Unmarshal(r.Value, response)
+			if err != nil {
+				return nil, fmt.Errorf("%T: failed to decode response from node %s: %w", request.Body, request.TargetNodeID, err)
+			}
+			return response, nil
+		}), nil
 }
 
 // Compile-time interface check:

--- a/pkg/nats/proxy/types.go
+++ b/pkg/nats/proxy/types.go
@@ -1,30 +1,17 @@
 package proxy
 
-import "errors"
-
-type Result[T any] struct {
-	Response T
-	Error    string
+type BaseRequest[T any] struct {
+	TargetNodeID string
+	Method       string
+	Body         T
 }
 
-func newResult[T any](response *T, err error) Result[T] {
-	if err != nil {
-		return Result[T]{
-			Error: err.Error(),
-		}
-	}
-
-	return Result[T]{
-		Response: *response,
-	}
+// ComputeEndpoint return the compute endpoint for the base request.
+func (r *BaseRequest[T]) ComputeEndpoint() string {
+	return computeEndpointPublishSubject(r.TargetNodeID, r.Method)
 }
 
-func (r *Result[T]) Rehydrate() (T, error) {
-	var e error = nil
-
-	if r.Error != "" {
-		e = errors.New(r.Error)
-	}
-
-	return r.Response, e
+// OrchestratorEndpoint return the orchestrator endpoint for the base request.
+func (r *BaseRequest[T]) OrchestratorEndpoint() string {
+	return callbackPublishSubject(r.TargetNodeID, r.Method)
 }

--- a/pkg/nats/stream/base_test.go
+++ b/pkg/nats/stream/base_test.go
@@ -1,0 +1,112 @@
+//go:build unit || !integration
+
+package stream
+
+import (
+	"context"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
+	"github.com/google/uuid"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/suite"
+)
+
+type BaseTestSuite struct {
+	suite.Suite
+	natsServer      *server.Server
+	natsClient      *nats.Conn
+	inboxSubject    string
+	streamingClient *Client
+	writer          *Writer
+	ch              <-chan *concurrency.AsyncResult[[]byte]
+	ctx             context.Context
+	cancel          context.CancelFunc
+}
+
+func (suite *BaseTestSuite) SetupSuite() {
+	// Start a NATS server for testing
+	opts := &server.Options{Port: -1} // Automatically select a port
+	var err error
+	suite.natsServer, err = server.NewServer(opts)
+	suite.Require().NoError(err)
+	suite.natsServer.Start()
+
+	// Wait for the server to be ready
+	time.Sleep(1 * time.Second)
+
+	// Create a NATS client
+	suite.natsClient, err = nats.Connect(suite.natsServer.ClientURL())
+	suite.Require().NoError(err)
+
+	suite.streamingClient, err = NewClient(ClientParams{Conn: suite.natsClient})
+	suite.Require().NoError(err)
+}
+
+// SetupTest will run before each test in the suite
+func (suite *BaseTestSuite) SetupTest() {
+	suite.ctx, suite.cancel = context.WithCancel(context.Background())
+
+	// send a request to the setup subject to get the inbox subject, and to start consuming responses
+	s := suite.newTestStream()
+	suite.inboxSubject = s.replySubject
+	suite.ch = s.ch
+	suite.writer = s.writer
+}
+
+func (suite *BaseTestSuite) TearDownSuite() {
+	suite.natsClient.Close()
+	suite.natsServer.Shutdown()
+}
+
+// testStream is a struct that will be used to test the streaming request
+// it holds the dynamic reply subject and the channel that will receive the response
+type testStream struct {
+	ch           <-chan *concurrency.AsyncResult[[]byte]
+	replySubject string
+	writer       *Writer
+}
+
+// newTestStream will setup a testStream with a random subject
+func (suite *BaseTestSuite) newTestStream() *testStream {
+	subject := uuid.NewString()
+	s := &testStream{}
+	_, err := suite.natsClient.Subscribe(subject, func(m *nats.Msg) {
+		s.replySubject = m.Reply
+	})
+	suite.Require().NoError(err)
+
+	ch, err := suite.streamingClient.OpenStream(suite.ctx, subject, []byte("test data"))
+	suite.Require().NoError(err)
+	suite.Require().NotNil(ch)
+	s.ch = ch
+
+	suite.Eventually(func() bool {
+		return s.replySubject != ""
+	}, 1*time.Second, 10*time.Millisecond, "h.replySubject should not be empty within 1 second")
+
+	s.writer = NewWriter(suite.streamingClient, s.replySubject)
+	return s
+
+}
+
+// readResponse reads a response from the channel and returns it
+func (suite *BaseTestSuite) readResponse() *concurrency.AsyncResult[[]byte] {
+	select {
+	case res := <-suite.ch:
+		return res
+	case <-time.After(200 * time.Millisecond):
+		return nil
+	}
+}
+
+// readResponse reads a response from the channel and returns it
+func (suite *BaseTestSuite) readResponseFromStream(s *testStream) *concurrency.AsyncResult[[]byte] {
+	select {
+	case res := <-s.ch:
+		return res
+	case <-time.After(200 * time.Millisecond):
+		return nil
+	}
+}

--- a/pkg/nats/stream/client.go
+++ b/pkg/nats/stream/client.go
@@ -1,0 +1,267 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
+	"github.com/rs/zerolog/log"
+)
+
+// RequestChanLen Default request channel length for buffering asynchronous results.
+const RequestChanLen = 16
+
+// inboxPrefix is the prefix for all streaming inbox subjects.
+// similar to https://github.com/nats-io/nats.go/blob/main/nats.go#L4015
+const (
+	inboxPrefix    = "_SINBOX."
+	inboxPrefixLen = len(inboxPrefix)
+	replySuffixLen = 8 // Gives us 62^8
+	rdigits        = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	base           = 62
+	nuidSize       = 22
+)
+
+// streamingBucket is a structure to hold the response channel and context
+type streamingBucket struct {
+	// ctx is the context for the channel consumer that requested and waiting for messages
+	ctx       context.Context
+	token     string
+	ch        chan *concurrency.AsyncResult[[]byte]
+	cancel    context.CancelFunc
+	closeOnce sync.Once
+}
+
+// newStreamingBucket creates a new streamingBucket.
+func newStreamingBucket(ctx context.Context, token string) *streamingBucket {
+	ctx, cancel := context.WithCancel(ctx)
+	return &streamingBucket{
+		ctx:    ctx,
+		cancel: cancel,
+		token:  token,
+		ch:     make(chan *concurrency.AsyncResult[[]byte], RequestChanLen),
+	}
+}
+
+// close will close the channel and cancel the context.
+func (sb *streamingBucket) close() {
+	sb.closeOnce.Do(func() {
+		sb.cancel()
+		close(sb.ch)
+	})
+}
+
+type ClientParams struct {
+	Conn *nats.Conn
+}
+
+// Client represents a NATS streaming client.
+type Client struct {
+	Conn *nats.Conn
+	mu   sync.RWMutex // Protects access to the response map.
+
+	// response handler
+	respSub       string                      // The wildcard subject
+	respSubPrefix string                      // the wildcard prefix including trailing .
+	respSubLen    int                         // the length of the wildcard prefix excluding trailing .
+	respScanf     string                      // The scanf template to extract mux token
+	respMux       *nats.Subscription          // A single response subscription
+	respMap       map[string]*streamingBucket // Request map for the response msg channels
+	respRand      *rand.Rand                  // Used for generating suffix
+}
+
+// NewClient creates a new NATS client.
+func NewClient(params ClientParams) (*Client, error) {
+	nc := &Client{
+		Conn:     params.Conn,
+		respMap:  make(map[string]*streamingBucket),
+		respRand: rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec // using same inbox naming as nats
+	}
+
+	// Setup response subscription.
+	nc.respSubPrefix = fmt.Sprintf("%s.", nc.newInbox())
+	nc.respSubLen = len(nc.respSubPrefix)
+	nc.respSub = fmt.Sprintf("%s*", nc.respSubPrefix)
+
+	// Create the response subscription we will use for all streaming responses.
+	// This will be on an _SINBOX with an additional terminal token. The subscription
+	// will be on a wildcard.
+	sub, err := nc.Conn.Subscribe(nc.respSub, nc.respHandler)
+	if err != nil {
+		return nil, err
+	}
+	nc.respScanf = strings.Replace(nc.respSub, "*", "%s", -1)
+	nc.respMux = sub
+
+	log.Debug().Msgf("Streaming client created with inbox %s", sub.Subject)
+	return nc, nil
+}
+
+// newInbox will return a new inbox string for this client.
+func (nc *Client) newInbox() string {
+	var b [inboxPrefixLen + nuidSize]byte
+	pres := b[:inboxPrefixLen]
+	copy(pres, inboxPrefix)
+	ns := b[inboxPrefixLen:]
+	copy(ns, nuid.Next())
+	return string(b[:])
+}
+
+// respHandler is the global response handler. It will look up
+// the appropriate channel based on the last token and place
+// the message on the channel if possible.
+func (nc *Client) respHandler(m *nats.Msg) {
+	// Just return if closed.
+	if nc.Conn.IsClosed() {
+		return
+	}
+
+	nc.mu.Lock()
+	rt := nc.respToken(m.Subject)
+	bucket, ok := nc.respMap[rt]
+	nc.mu.Unlock()
+	if !ok {
+		log.Debug().Str("subject", m.Subject).Msg("No response handler for subject")
+		return
+	}
+
+	closeErr := new(CloseError)
+	var asyncResult *concurrency.AsyncResult[[]byte]
+
+	sMsg := new(StreamingMsg)
+	err := json.Unmarshal(m.Data, sMsg)
+	if err != nil {
+		closeErr = &CloseError{Code: CloseUnsupportedData, Text: err.Error()}
+		asyncResult = concurrency.NewAsyncError[[]byte](closeErr)
+	} else {
+		switch sMsg.Type {
+		case streamingMsgTypeClose:
+			closeErr = sMsg.CloseError
+			asyncResult = concurrency.NewAsyncError[[]byte](closeErr)
+		case streamingMsgTypeData:
+			asyncResult = concurrency.NewAsyncValue(sMsg.Data)
+		default:
+			log.Warn().Msgf("Unknown streaming message type: %d", sMsg.Type)
+			return
+		}
+	}
+
+	// if normal closure, then we close the channel without adding any error message
+	if closeErr != nil && closeErr.Code == CloseNormalClosure {
+		nc.cleanupBucket(rt)
+		return
+	}
+
+	// Explicitly check if the context is done before attempting to send a message.
+	if err = bucket.ctx.Err(); err != nil {
+		// The context is already done. Handle cleanup and exit.
+		nc.cleanupBucket(rt)
+		return
+	}
+
+	// while the channel is buffered, this will block if processing messages is slow.
+	// TODO: Consider a non-blocking send here.
+	select {
+	case bucket.ch <- asyncResult:
+		// if there was an error, we close the channel after notifying the channel consumer
+		if asyncResult.Err != nil {
+			nc.cleanupBucket(rt)
+		}
+	case <-bucket.ctx.Done():
+		// remove the bucket from the map and close the channel
+		nc.cleanupBucket(rt)
+	}
+}
+
+func (nc *Client) cleanupBucket(token string) {
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+	if bucket, ok := nc.respMap[token]; ok {
+		delete(nc.respMap, token)
+		bucket.close()
+	}
+}
+
+// newRespInbox creates a new literal response subject
+// that will trigger the mux subscription handler.
+// Lock should be held.
+func (nc *Client) newRespInbox() string {
+	var sb strings.Builder
+	sb.WriteString(nc.respSubPrefix)
+
+	rn := nc.respRand.Int63()
+	for i := 0; i < replySuffixLen; i++ {
+		sb.WriteByte(rdigits[rn%base])
+		rn /= base
+	}
+
+	return sb.String()
+}
+
+// respToken will return the last token of a literal response inbox
+// which we use for the message channel lookup.
+// Lock should be held.
+func (nc *Client) respToken(respInbox string) string {
+	var token string
+	n, err := fmt.Sscanf(respInbox, nc.respScanf, &token)
+	if err != nil || n != 1 {
+		return ""
+	}
+	return token
+}
+
+// OpenStream takes a context, a subject and payload
+// in bytes and expects a channel with multiple responses.
+func (nc *Client) OpenStream(ctx context.Context, subj string, data []byte) (<-chan *concurrency.AsyncResult[[]byte], error) {
+	if ctx == nil {
+		return nil, nats.ErrInvalidContext
+	}
+	if nc == nil {
+		return nil, nats.ErrInvalidConnection
+	}
+	// Check whether the context is done already before making
+	// the request.
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	bucket, err := nc.createNewRequestAndSend(ctx, subj, data)
+	if err != nil {
+		return nil, err
+	}
+	return bucket.ch, nil
+}
+
+// createNewRequestAndSend sets up and sends a new request, returning the response bucket.
+func (nc *Client) createNewRequestAndSend(ctx context.Context, subj string, data []byte) (*streamingBucket, error) {
+	nc.mu.Lock()
+
+	// Create new literal Inbox and map to a bucket.
+	respInbox := nc.newRespInbox()
+	token := respInbox[nc.respSubLen:]
+	bucket := newStreamingBucket(ctx, token)
+
+	nc.respMap[token] = bucket
+	nc.mu.Unlock()
+
+	if err := nc.Conn.PublishRequest(subj, respInbox, data); err != nil {
+		return nil, err
+	}
+
+	return bucket, nil
+}
+
+// NewWriter creates a new streaming writer.
+func (nc *Client) NewWriter(subject string) *Writer {
+	return &Writer{
+		client:  nc,
+		subject: subject,
+	}
+}

--- a/pkg/nats/stream/client_test.go
+++ b/pkg/nats/stream/client_test.go
@@ -1,0 +1,80 @@
+//go:build unit || !integration
+
+package stream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ClientTestSuite struct {
+	BaseTestSuite
+}
+
+func (suite *ClientTestSuite) TearDownSuite() {
+	suite.natsClient.Close()
+	suite.natsServer.Shutdown()
+}
+
+// TestMultipleStreams tests that multiple streams can be read from with no interference
+func (suite *ClientTestSuite) TestMultipleStreams() {
+	stream1 := suite.newTestStream()
+	stream2 := suite.newTestStream()
+
+	data1 := []byte("test data 1")
+	data2 := []byte("test data 2")
+
+	_, err := stream1.writer.Write(data1)
+	suite.Require().NoError(err)
+
+	_, err = stream2.writer.Write(data2)
+	suite.Require().NoError(err)
+
+	// Verify
+	response1 := suite.readResponseFromStream(stream1)
+	suite.Require().NoError(response1.Err)
+	suite.Require().Equal(data1, response1.Value, "Expected response to be equal to the data")
+
+	response2 := suite.readResponseFromStream(stream2)
+	suite.Require().NoError(response2.Err)
+	suite.Require().Equal(data2, response2.Value, "Expected response to be equal to the data")
+
+	// Verify no more records
+	suite.Require().Nil(suite.readResponseFromStream(stream1), "Expected no more responses after the first one")
+	suite.Require().Nil(suite.readResponseFromStream(stream2), "Expected no more responses after the first one")
+}
+
+func (suite *ClientTestSuite) TestContextCancel() {
+	suite.cancel()
+	// ctx cancellation will be detected after a new record is streamed
+	_, err := suite.writer.Write([]byte("test"))
+	suite.Require().NoError(err)
+
+	select {
+	case _, ok := <-suite.ch:
+		suite.Require().False(ok, "Expected the channel to be closed")
+	case <-time.After(1 * time.Second):
+		suite.Fail("Timeout waiting for the channel to be closed")
+	}
+}
+
+func (suite *ClientTestSuite) TestRequestWithContextCancellation() {
+	// Test that a request is properly cancelled by context
+	subj := "test.cancel"
+	ctx, cancel := context.WithCancel(context.Background())
+	payload := []byte("cancel test payload")
+
+	// Cancel context before making request
+	cancel()
+
+	// Attempt to make the request
+	_, err := suite.streamingClient.OpenStream(ctx, subj, payload)
+	suite.Require().Error(err, "Expected an error due to cancelled context")
+}
+
+func TestClientTestSuite(t *testing.T) {
+	suite.Run(t, new(ClientTestSuite))
+}

--- a/pkg/nats/stream/constants.go
+++ b/pkg/nats/stream/constants.go
@@ -1,0 +1,29 @@
+package stream
+
+// Close error codes that follow these semantics:
+// - 1000 Series: Normal and controlled shutdown scenarios. These are standard and expected reasons for closing a stream.
+// - 4000 Series: Client-related errors or issues with the transmitted data, indicating problems that originate from the caller's side.
+// - 5000 Series: Server-side errors, indicating problems that are internal to the server or the processing system.
+const (
+	// CloseNormalClosure Indicates that the stream was closed after completing its
+	// intended purpose. No errors occurred, and the closure was planned.
+	CloseNormalClosure = 1000
+	// CloseGoingAway Used when a service is shutting down or a client
+	// is disconnecting normally but unexpectedly
+	CloseGoingAway = 1001
+	// CloseUnsupportedData Indicates that data sent over an established stream is invalid,
+	// corrupt, or cannot be processed. This is used after a stream has been successfully
+	// established but encounters data-related issues.
+	CloseUnsupportedData = 1003
+	// CloseAbnormalClosure Indicates that a stream was closed unexpectedly,
+	// without a known reason. This might be used when a connection is dropped
+	// due to network issues, or a service crashes.
+	CloseAbnormalClosure = 1006
+	// CloseBadRequest Signifies that the initial request to establish a stream contained
+	// invalid parameters or was malformed, preventing the stream from being established.
+	CloseBadRequest = 4000
+	// CloseInternalServerErr Used when an unexpected condition was encountered
+	// by the server, preventing it from fulfilling the request. This signals issues
+	// that are internal to the server or the processing system.
+	CloseInternalServerErr = 5000
+)

--- a/pkg/nats/stream/stream.go
+++ b/pkg/nats/stream/stream.go
@@ -1,0 +1,89 @@
+/*
+Package stream provides a NATS client for streaming records between clients with asynchronous
+response handling.
+
+Overview:
+
+This package implements a client leveraging NATS for sending and receiving streaming data records.
+It abstracts NATS connections, subscriptions, and message handling complexities, offering a
+simplified interface for data streaming. The client supports multiplexing multiple streams over a
+single NATS subscription, handling responses from different streams using a unique token-based
+mechanism. Additionally, the package introduces a Writer component, designed to abstract the
+complexities of data encoding and NATS publishing into a simple, intuitive interface.
+
+How It Works:
+
+  - The Client part of the package manages dynamic inboxes for each streaming session, facilitating
+    the sending of data and listening for responses on dedicated subjects. It leverages the NATS
+    publish-subscribe model for asynchronous communication, efficiently routing and correlating
+    messages to their respective streams.
+
+  - The Writer component allows for easy publishing of structured data to any NATS subject. It
+    integrates tightly with the Client, utilizing the same connection for streamlined data streaming.
+    The Writer simplifies the publication process, automatically handling data serialization and
+    supporting graceful stream closure with custom codes.
+
+Multiplexing Streams:
+
+To efficiently handle multiple streams, the client uses a single wildcard subscription for all
+responses. Each request is sent with a unique response subject (derived from a base inbox prefix),
+with responses routed back to this subject. The client demultiplexes incoming messages by extracting
+a token from the response subject, identifying the correct stream (or "bucket") for the message.
+This approach allows managing multiple concurrent streams with minimal overhead, leveraging NATS's
+lightweight subjects and messaging capabilities.
+
+Key Features:
+
+  - Asynchronous Streaming: Supports asynchronous data streaming, allowing clients to send data and
+    receive responses without blocking.
+
+  - Context Support: Integrates with Go's context package for timeouts, cancellation, and deadlines
+    for streaming requests.
+
+  - Multiplexing: Efficiently multiplexes multiple streams over a single NATS subscription, using
+    unique response subjects for message correlation.
+
+  - Error Handling: Provides robust error handling, including custom error codes for stream-related
+    errors (e.g., bad data, normal closure).
+
+  - Data Publication: The Writer simplifies structured data publishing to NATS, with support for
+    automatic serialization and stream closure signals.
+
+Usage:
+
+Initialize the client with a NATS connection and use the provided methods to send streaming requests
+and handle responses. The client manages the NATS subscription and response routing, simplifying the
+process of working with streaming data.
+
+Example:
+
+	params := stream.ClientParams{Conn: natsConn}
+	client, err := stream.NewClient(params)
+	if err != nil {
+	    log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	responseChan, err := client.OpenStream(ctx, "subject", []byte("data"))
+	if err != nil {
+	    log.Fatal(err)
+	}
+
+	for asyncResult := range responseChan {
+	    if asyncResult.Err != nil {
+	        log.Printf("Received an error: %v", asyncResult.Err)
+	        continue
+	    }
+	    log.Printf("Received data: %s", asyncResult.Value)
+	}
+
+This package leverages the concurrency.AsyncResult type for handling asynchronous responses,
+allowing clients to distinguish between successful data responses and error conditions.
+
+Note: This client is designed for use with NATS and requires an established NATS connection to
+function. It does not handle NATS connection management, which must be performed separately by
+the user.
+*/
+package stream

--- a/pkg/nats/stream/types.go
+++ b/pkg/nats/stream/types.go
@@ -1,0 +1,58 @@
+package stream
+
+import "strconv"
+
+// StreamingMsgType represents the type of a streaming message.
+type StreamingMsgType int
+
+const (
+	streamingMsgTypeUnknown StreamingMsgType = iota //nolint:unused
+	// streamingMsgTypeData represents a data message.
+	streamingMsgTypeData
+	// streamingMsgTypeClose represents a close message.
+	streamingMsgTypeClose
+)
+
+// StreamingMsg represents a streaming message that can be sent over NATS.
+// It can be a data message or a close message.
+type StreamingMsg struct {
+	// Type is the type of the message.
+	Type StreamingMsgType `json:"type"`
+	// Data is the optional data payload. It is only used if Type is streamingMsgTypeData.
+	Data []byte `json:"data,omitempty"`
+	// CloseError is the optional close message. It is only used if Type is streamingMsgTypeClose.
+	CloseError *CloseError `json:"closeError,omitempty"`
+}
+
+// CloseError represents a close message.
+type CloseError struct {
+	// Code is defined in RFC 6455, section 11.7.
+	Code int
+	// Text is the optional text payload.
+	Text string
+}
+
+// CloseError implements the error interface.
+func (e *CloseError) Error() string {
+	s := []byte("nats stream: close ")
+	s = strconv.AppendInt(s, int64(e.Code), 10) //nolint:gomnd
+	switch e.Code {
+	case CloseNormalClosure:
+		s = append(s, " (normal)"...)
+	case CloseGoingAway:
+		s = append(s, " (going away)"...)
+	case CloseUnsupportedData:
+		s = append(s, " (unsupported data)"...)
+	case CloseAbnormalClosure:
+		s = append(s, " (abnormal closure)"...)
+	case CloseBadRequest:
+		s = append(s, " (bad request)"...)
+	case CloseInternalServerErr:
+		s = append(s, " (internal server error)"...)
+	}
+	if e.Text != "" {
+		s = append(s, ": "...)
+		s = append(s, e.Text...)
+	}
+	return string(s)
+}

--- a/pkg/nats/stream/writer.go
+++ b/pkg/nats/stream/writer.go
@@ -1,0 +1,84 @@
+package stream
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+type Writer struct {
+	client    *Client
+	subject   string
+	closeOnce sync.Once
+}
+
+// NewWriter creates a new Writer.
+func NewWriter(client *Client, subject string) *Writer {
+	return &Writer{
+		client:  client,
+		subject: subject,
+	}
+}
+
+// WriteData writes data to the stream.
+func (w *Writer) Write(data []byte) (int, error) {
+	msg := &StreamingMsg{
+		Type: streamingMsgTypeData,
+		Data: data,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return 0, fmt.Errorf("error encoding streaming data: %s", err)
+	}
+
+	return len(data), w.client.Conn.Publish(w.subject, data)
+}
+
+// WriteObject writes an object to the stream.
+func (w *Writer) WriteObject(obj interface{}) (int, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return 0, fmt.Errorf("error encoding object: %s", err)
+	}
+	return w.Write(data)
+}
+
+// CloseWithCode closes the stream with a specific code.
+func (w *Writer) CloseWithCode(code int, text ...string) error {
+	return w.doClose(code, strings.Join(text, ": "))
+}
+
+// Close closes the stream.
+func (w *Writer) Close() error {
+	return w.doClose(CloseNormalClosure, "")
+}
+
+// doClose closes the stream.
+func (w *Writer) doClose(code int, text string) error {
+	var err error
+	w.closeOnce.Do(func() {
+		msg := &StreamingMsg{
+			Type: streamingMsgTypeClose,
+			CloseError: &CloseError{
+				Code: code,
+				Text: text,
+			},
+		}
+
+		var data []byte
+		data, err = json.Marshal(msg)
+		if err != nil {
+			err = fmt.Errorf("error encoding close error: %s", err)
+			return
+		}
+
+		err = w.client.Conn.Publish(w.subject, data)
+	})
+	return err
+}
+
+// compile time check for interface
+var _ = io.WriteCloser(new(Writer))

--- a/pkg/nats/stream/writer_test.go
+++ b/pkg/nats/stream/writer_test.go
@@ -1,0 +1,82 @@
+//go:build unit || !integration
+
+package stream
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const overheadWrittenBytes = 23 // additional bytes to wrap the data with StreamingMsg
+
+type WriterTestSuite struct {
+	BaseTestSuite
+}
+
+func (suite *WriterTestSuite) TestWrite() {
+	// Test data
+	data := []byte("test data")
+
+	// Execute
+	n, err := suite.writer.Write(data)
+	suite.Require().NoError(err)
+
+	// Verify
+	response := suite.readResponse()
+	suite.Require().NoError(response.Err)
+	suite.Require().Equal(data, response.Value, "Expected response to be equal to the data")
+	suite.Require().Equal(len(data)+overheadWrittenBytes, n, "Expected written bytes to be equal to the length of the data plus overhead")
+
+	// Verify no more records
+	suite.Require().Nil(suite.readResponse(), "Expected no more responses after the first one")
+}
+
+func (suite *WriterTestSuite) TestWriteObject() {
+	// Test object
+	obj := map[string]string{"key": "value"}
+	data, err := json.Marshal(obj)
+	suite.Require().NoError(err)
+
+	// Execute
+	n, err := suite.writer.WriteObject(obj)
+	suite.Require().NoError(err)
+
+	// Verify
+	response := suite.readResponse()
+	suite.Require().NoError(response.Err)
+	suite.Require().Equal(data, response.Value, "Expected response to be equal to the data")
+	suite.Require().Greater(n, 0, "Expected non-zero bytes written")
+
+	// Verify no more records
+	suite.Require().Nil(suite.readResponse(), "Expected no more responses after the first one")
+}
+
+func (suite *WriterTestSuite) TestClose() {
+	// Execute
+	err := suite.writer.Close()
+	suite.Require().NoError(err)
+
+	// Verify
+	response := suite.readResponse()
+	suite.Require().Nil(response, "Expected no response after normally closing the writer")
+}
+
+func (suite *WriterTestSuite) TestCloseWithCode() {
+	// Execute
+	closeError := &CloseError{Code: CloseInternalServerErr, Text: "test close error message"}
+	err := suite.writer.CloseWithCode(closeError.Code, closeError.Text)
+	suite.Require().NoError(err)
+
+	// Verify
+	response := suite.readResponse()
+	suite.Require().Error(response.Err)
+	suite.Require().Equal(closeError, response.Err, "Expected response to be equal to the close error")
+	suite.Require().Nil(response.Value, "Expected no response after closing the writer with an error")
+}
+
+// Entry point for the test suite
+func TestWriterTestSuite(t *testing.T) {
+	suite.Run(t, new(WriterTestSuite))
+}

--- a/pkg/nats/transport/nats.go
+++ b/pkg/nats/transport/nats.go
@@ -141,9 +141,12 @@ func NewNATSTransport(ctx context.Context,
 	}
 
 	// compute proxy
-	computeProxy := proxy.NewComputeProxy(proxy.ComputeProxyParams{
+	computeProxy, err := proxy.NewComputeProxy(proxy.ComputeProxyParams{
 		Conn: nc.Client,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Callback to send compute events (i.e. requester endpoint)
 	computeCallback := proxy.NewCallbackProxy(proxy.CallbackProxyParams{


### PR DESCRIPTION
This PR introduces a NATS `stream` package that enables response streams patterns. NATS currently supports request/response patterns which is great when expecting a single response per request. However, this is not sufficient to serve job logs where a user initiates a request to stream logs, and the compute node start serving those logs.

## Overview of `stream` package

This package implements a client leveraging NATS for sending and receiving streaming data records. It abstracts NATS connections, subscriptions, and message handling complexities, offering a simplified interface for data streaming. The client supports multiplexing multiple streams over a single NATS subscription, handling responses from different streams using a unique token-based mechanism. Additionally, the package introduces a Writer component, designed to abstract the complexities of data encoding and NATS publishing into a simple, intuitive interface.

## How It Works

- **The Client** part of the package manages dynamic inboxes for each streaming session, facilitating the sending of data and listening for responses on dedicated subjects. It leverages the NATS publish-subscribe model for asynchronous communication, efficiently routing and correlating messages to their respective streams.
  
- **The Writer** component allows for easy publishing of structured data to any NATS subject. It integrates tightly with the Client, utilizing the same connection for streamlined data streaming. The Writer simplifies the publication process, automatically handling data serialization and supporting graceful stream closure with custom codes.

## Multiplexing Streams

To efficiently handle multiple streams, the client uses a single wildcard subscription for all responses. Each request is sent with a unique response subject (derived from a base inbox prefix), with responses routed back to this subject. The client demultiplexes incoming messages by extracting a token from the response subject, identifying the correct stream (or "bucket") for the message. This approach allows managing multiple concurrent streams with minimal overhead, leveraging NATS's lightweight subjects and messaging capabilities.

## Key Features

- **Asynchronous Streaming**: Supports asynchronous data streaming, allowing clients to send data and receive responses without blocking.

- **Context Support**: Integrates with Go's context package for timeouts, cancellation, and deadlines for streaming requests.

- **Multiplexing**: Efficiently multiplexes multiple streams over a single NATS subscription, using unique response subjects for message correlation.

- **Error Handling**: Provides robust error handling, including custom error codes for stream-related errors (e.g., bad data, normal closure).

- **Data Publication**: The Writer simplifies structured data publishing to NATS, with support for automatic serialization and stream closure signals.

## Usage

Initialize the client with a NATS connection and use the provided methods to send streaming requests and handle responses. The client manages the NATS subscription and response routing, simplifying the process of working with streaming data.

### Example

```go
params := stream.ClientParams{Conn: natsConn}
client, err := stream.NewClient(params)
if err != nil {
    log.Fatal(err)
}

ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
defer cancel()

responseChan, err := client.OpenStream(ctx, "subject", []byte("data"))
if err != nil {
    log.Fatal(err)
}

for asyncResult := range responseChan {
    if asyncResult.Err != nil {
        log.Printf("Received an error: %v", asyncResult.Err)
        continue
    }
    log.Printf("Received data: %s", asyncResult.Value)
}

### Remaining Work
- The compute node has no knowledge when the requester is no longer interested to stream logs. We need to implement a heartbeat or a feedback loop to let the compute node stop publishing logs when there are no active consumers
- The requester node has no knowledge if the compute node is still alive and publishing logs. We do have a graceful handling when the compute node reaches the end of the stream where it informs the requester node that no more logs are coming, but we don't handle ungraceful termination of compute nodes 