### PR TITLE
Make publisher optional in CLI

### DIFF
--- a/cmd/cli/docker/docker_run.go
+++ b/cmd/cli/docker/docker_run.go
@@ -200,7 +200,6 @@ func CreateJob(ctx context.Context, image string, parameters []string, opts *Doc
 
 	spec, err := jobutils.MakeDockerSpec(
 		image, opts.WorkingDirectory, opts.Entrypoint, opts.SpecSettings.EnvVar, parameters,
-		jobutils.WithPublisher(opts.SpecSettings.Publisher.Value()),
 		jobutils.WithResources(
 			opts.ResourceSettings.CPU,
 			opts.ResourceSettings.Memory,
@@ -221,6 +220,14 @@ func CreateJob(ctx context.Context, image string, parameters []string, opts *Doc
 			opts.DealSettings.Concurrency,
 		),
 	)
+
+	// Publisher is optional and we won't provide it if not specified
+	if opts.SpecSettings.Publisher != nil {
+		p := opts.SpecSettings.Publisher.Value()
+		spec.Publisher = p.Type //nolint:staticcheck
+		spec.PublisherSpec = p
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/docker/docker_run.go
+++ b/cmd/cli/docker/docker_run.go
@@ -222,10 +222,10 @@ func CreateJob(ctx context.Context, image string, parameters []string, opts *Doc
 	)
 
 	// Publisher is optional and we won't provide it if not specified
-	if opts.SpecSettings.Publisher != nil {
-		p := opts.SpecSettings.Publisher.Value()
+	p := opts.SpecSettings.Publisher.Value()
+	if p != nil {
 		spec.Publisher = p.Type //nolint:staticcheck
-		spec.PublisherSpec = p
+		spec.PublisherSpec = *p
 	}
 
 	if err != nil {

--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -216,8 +216,8 @@ func PrepareJob(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, opti
 		}
 	}
 
-	if options.SpecSettings.Publisher != nil {
-		publisherSpec := options.SpecSettings.Publisher.Value()
+	publisherSpec := options.SpecSettings.Publisher.Value()
+	if publisherSpec != nil {
 		job.Tasks[0].Publisher = &models.SpecConfig{
 			Type:   publisherSpec.Type.String(),
 			Params: publisherSpec.Params,

--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -216,11 +216,12 @@ func PrepareJob(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, opti
 		}
 	}
 
-	// Add the default publisher (which is currently IPFS)
-	publisherSpec := options.SpecSettings.Publisher.Value()
-	job.Tasks[0].Publisher = &models.SpecConfig{
-		Type:   publisherSpec.Type.String(),
-		Params: publisherSpec.Params,
+	if options.SpecSettings.Publisher != nil {
+		publisherSpec := options.SpecSettings.Publisher.Value()
+		job.Tasks[0].Publisher = &models.SpecConfig{
+			Type:   publisherSpec.Type.String(),
+			Params: publisherSpec.Params,
+		}
 	}
 
 	// Handle ResultPaths by using the legacy parser and converting.

--- a/cmd/cli/get/get_test.go
+++ b/cmd/cli/get/get_test.go
@@ -106,6 +106,7 @@ func (s *GetSuite) getDockerRunArgs(extraArgs []string) []string {
 	require.NoError(s.T(), err)
 	args := []string{
 		"docker", "run",
+		"--publisher", "ipfs",
 		"--ipfs-swarm-addrs", strings.Join(swarmAddresses, ","),
 		"-o", "data:/data",
 		"--wait",
@@ -133,6 +134,7 @@ func (s *GetSuite) TestDockerRunWriteToJobFolderAutoDownload() {
 	})
 	_, runOutput, err := s.ExecuteTestCobraCommand(args...)
 	require.NoError(s.T(), err, "Error submitting job")
+
 	jobID := system.FindJobIDInTestOutputLegacy(runOutput)
 	hostID := s.Node.ID
 	outputFolder := filepath.Join(tempDir, util.GetDefaultJobFolder(jobID))

--- a/cmd/cli/wasm/wasm_run.go
+++ b/cmd/cli/wasm/wasm_run.go
@@ -199,7 +199,6 @@ func CreateJob(ctx context.Context, cmdArgs []string, opts *WasmRunOptions) (*mo
 
 	spec, err := job.MakeWasmSpec(
 		*entryModule, opts.Entrypoint, parameters, wasmEnvvar, opts.ImportModules,
-		job.WithPublisher(opts.SpecSettings.Publisher.Value()),
 		job.WithResources(
 			opts.ResourceSettings.CPU,
 			opts.ResourceSettings.Memory,
@@ -222,6 +221,13 @@ func CreateJob(ctx context.Context, cmdArgs []string, opts *WasmRunOptions) (*mo
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// Publisher is now optional
+	if opts.SpecSettings.Publisher != nil {
+		p := opts.SpecSettings.Publisher.Value()
+		spec.Publisher = p.Type //nolint:staticcheck
+		spec.PublisherSpec = p
 	}
 
 	return &model.Job{

--- a/cmd/cli/wasm/wasm_run.go
+++ b/cmd/cli/wasm/wasm_run.go
@@ -224,10 +224,10 @@ func CreateJob(ctx context.Context, cmdArgs []string, opts *WasmRunOptions) (*mo
 	}
 
 	// Publisher is now optional
-	if opts.SpecSettings.Publisher != nil {
-		p := opts.SpecSettings.Publisher.Value()
+	p := opts.SpecSettings.Publisher.Value()
+	if p != nil {
 		spec.Publisher = p.Type //nolint:staticcheck
-		spec.PublisherSpec = p
+		spec.PublisherSpec = *p
 	}
 
 	return &model.Job{

--- a/cmd/util/download.go
+++ b/cmd/util/download.go
@@ -34,7 +34,9 @@ func DownloadResultsHandler(
 
 	if len(response.Results) == 0 {
 		// No results doesn't mean error, so we should print out a message and return nil
-		cmd.Println("no results found")
+		cmd.Println("No results found")
+		cmd.Println("You can check the logged output of the job using the logs command.")
+		cmd.Printf("\n  bacalhau logs %s\n", jobID)
 		return nil
 	}
 

--- a/cmd/util/download.go
+++ b/cmd/util/download.go
@@ -33,7 +33,9 @@ func DownloadResultsHandler(
 	}
 
 	if len(response.Results) == 0 {
-		return fmt.Errorf("no results found")
+		// No results doesn't mean error, so we should print out a message and return nil
+		cmd.Println("no results found")
+		return nil
 	}
 
 	downloaderProvider := util.NewStandardDownloaders(cm)

--- a/cmd/util/flags/cliflags/spec.go
+++ b/cmd/util/flags/cliflags/spec.go
@@ -21,7 +21,7 @@ Examples:
 
 func NewSpecFlagDefaultSettings() *SpecFlagSettings {
 	return &SpecFlagSettings{
-		Publisher:     nil,
+		Publisher:     opts.NewPublisherOpt(),
 		Inputs:        opts.StorageOpt{},
 		OutputVolumes: []string{"outputs:/outputs"},
 		EnvVar:        []string{},
@@ -33,20 +33,20 @@ func NewSpecFlagDefaultSettings() *SpecFlagSettings {
 }
 
 type SpecFlagSettings struct {
-	Publisher     *opts.PublisherOpt // Publisher - publisher.Publisher
-	Inputs        opts.StorageOpt    // Array of inputs
-	OutputVolumes []string           // Array of output volumes in 'name:mount point' form
-	EnvVar        []string           // Array of environment variables
-	Timeout       int64              // Job execution timeout in seconds
-	Labels        []string           // Labels for the job on the Bacalhau network (for searching)
-	Selector      string             // Selector (label query) to filter nodes on which this job can be executed
+	Publisher     opts.PublisherOpt // Publisher - publisher.Publisher
+	Inputs        opts.StorageOpt   // Array of inputs
+	OutputVolumes []string          // Array of output volumes in 'name:mount point' form
+	EnvVar        []string          // Array of environment variables
+	Timeout       int64             // Job execution timeout in seconds
+	Labels        []string          // Labels for the job on the Bacalhau network (for searching)
+	Selector      string            // Selector (label query) to filter nodes on which this job can be executed
 	DoNotTrack    bool
 }
 
 func SpecFlags(settings *SpecFlagSettings) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("Spec settings", pflag.ContinueOnError)
 	flags.VarP(
-		settings.Publisher,
+		&settings.Publisher,
 		"publisher",
 		"p",
 		"Where to publish the result of the job",

--- a/cmd/util/flags/cliflags/spec.go
+++ b/cmd/util/flags/cliflags/spec.go
@@ -21,7 +21,7 @@ Examples:
 
 func NewSpecFlagDefaultSettings() *SpecFlagSettings {
 	return &SpecFlagSettings{
-		Publisher:     opts.NewPublisherOptFromSpec(model.PublisherSpec{Type: model.PublisherIpfs}),
+		Publisher:     nil,
 		Inputs:        opts.StorageOpt{},
 		OutputVolumes: []string{"outputs:/outputs"},
 		EnvVar:        []string{},
@@ -33,20 +33,20 @@ func NewSpecFlagDefaultSettings() *SpecFlagSettings {
 }
 
 type SpecFlagSettings struct {
-	Publisher     opts.PublisherOpt // Publisher - publisher.Publisher
-	Inputs        opts.StorageOpt   // Array of inputs
-	OutputVolumes []string          // Array of output volumes in 'name:mount point' form
-	EnvVar        []string          // Array of environment variables
-	Timeout       int64             // Job execution timeout in seconds
-	Labels        []string          // Labels for the job on the Bacalhau network (for searching)
-	Selector      string            // Selector (label query) to filter nodes on which this job can be executed
+	Publisher     *opts.PublisherOpt // Publisher - publisher.Publisher
+	Inputs        opts.StorageOpt    // Array of inputs
+	OutputVolumes []string           // Array of output volumes in 'name:mount point' form
+	EnvVar        []string           // Array of environment variables
+	Timeout       int64              // Job execution timeout in seconds
+	Labels        []string           // Labels for the job on the Bacalhau network (for searching)
+	Selector      string             // Selector (label query) to filter nodes on which this job can be executed
 	DoNotTrack    bool
 }
 
 func SpecFlags(settings *SpecFlagSettings) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("Spec settings", pflag.ContinueOnError)
 	flags.VarP(
-		&settings.Publisher,
+		settings.Publisher,
 		"publisher",
 		"p",
 		"Where to publish the result of the job",

--- a/cmd/util/opts/publisher.go
+++ b/cmd/util/opts/publisher.go
@@ -14,11 +14,11 @@ import (
 var _ flag.Value = &PublisherOpt{}
 
 type PublisherOpt struct {
-	value model.PublisherSpec
+	value *model.PublisherSpec
 }
 
-func NewPublisherOptFromSpec(spec model.PublisherSpec) PublisherOpt {
-	return PublisherOpt{value: spec}
+func NewPublisherOpt() PublisherOpt {
+	return PublisherOpt{value: nil}
 }
 
 func (o *PublisherOpt) Set(value string) error {
@@ -57,7 +57,8 @@ func (o *PublisherOpt) Set(value string) error {
 			return fmt.Errorf("invalid publisher option: %s", field)
 		}
 	}
-	o.value, err = job.ParsePublisherString(destinationURI, options)
+	v, err := job.ParsePublisherString(destinationURI, options)
+	o.value = &v
 	return err
 }
 
@@ -66,15 +67,15 @@ func (o *PublisherOpt) Type() string {
 }
 
 func (o *PublisherOpt) String() string {
-	if o == nil {
+	if o.value == nil {
 		return ""
 	}
 	return o.value.Type.String()
 }
 
-func (o *PublisherOpt) Value() model.PublisherSpec {
-	if o == nil {
-		return model.PublisherSpec{}
+func (o *PublisherOpt) Value() *model.PublisherSpec {
+	if o.value == nil {
+		return nil
 	}
 	return o.value
 }

--- a/cmd/util/opts/publisher.go
+++ b/cmd/util/opts/publisher.go
@@ -73,5 +73,8 @@ func (o *PublisherOpt) String() string {
 }
 
 func (o *PublisherOpt) Value() model.PublisherSpec {
+	if o == nil {
+		return model.PublisherSpec{}
+	}
 	return o.value
 }

--- a/cmd/util/opts/publisher.go
+++ b/cmd/util/opts/publisher.go
@@ -66,6 +66,9 @@ func (o *PublisherOpt) Type() string {
 }
 
 func (o *PublisherOpt) String() string {
+	if o == nil {
+		return ""
+	}
 	return o.value.Type.String()
 }
 

--- a/cmd/util/opts/publisher_test.go
+++ b/cmd/util/opts/publisher_test.go
@@ -14,20 +14,20 @@ func TestParsePublisher(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		input    string
-		expected model.PublisherSpec
+		expected *model.PublisherSpec
 		error    bool
 	}{
 		{
 			name:  "ipfs",
 			input: "ipfs",
-			expected: model.PublisherSpec{
+			expected: &model.PublisherSpec{
 				Type: model.PublisherIpfs,
 			},
 		},
 		{
 			name:  "s3",
 			input: "s3://myBucket/dir/file-001.txt",
-			expected: model.PublisherSpec{
+			expected: &model.PublisherSpec{
 				Type: model.PublisherS3,
 				Params: map[string]interface{}{
 					"bucket": "myBucket",
@@ -38,7 +38,7 @@ func TestParsePublisher(t *testing.T) {
 		{
 			name:  "s3 with endpoint and region",
 			input: "s3://myBucket/dir/file-001.txt,opt=endpoint=http://127.0.0.1:9000,opt=region=us-east-1,opt=compress=true",
-			expected: model.PublisherSpec{
+			expected: &model.PublisherSpec{
 				Type: model.PublisherS3,
 				Params: map[string]interface{}{
 					"bucket":   "myBucket",
@@ -52,7 +52,7 @@ func TestParsePublisher(t *testing.T) {
 		{
 			name:  "s3 non URI",
 			input: "s3,opt=bucket=myBucket,opt=key=dir/file-001.txt,opt=region=us-east-1",
-			expected: model.PublisherSpec{
+			expected: &model.PublisherSpec{
 				Type: model.PublisherS3,
 				Params: map[string]interface{}{
 					"bucket": "myBucket",

--- a/pkg/orchestrator/endpoint.go
+++ b/pkg/orchestrator/endpoint.go
@@ -266,7 +266,11 @@ func (e *BaseEndpoint) GetResults(ctx context.Context, request *GetResultsReques
 			if err != nil {
 				return GetResultsResponse{}, err
 			}
-			results = append(results, result)
+
+			// Only add valid results
+			if result.Type != "" {
+				results = append(results, result)
+			}
 		}
 	}
 

--- a/pkg/publicapi/endpoint/orchestrator/job.go
+++ b/pkg/publicapi/endpoint/orchestrator/job.go
@@ -36,6 +36,7 @@ func (e *Endpoint) putJob(c echo.Context) error {
 	if err := c.Bind(&args); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
+
 	if err := c.Validate(&args); err != nil {
 		return err
 	}
@@ -367,6 +368,7 @@ func (e *Endpoint) jobResults(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
 	return publicapi.UnescapedJSON(c, http.StatusOK, &apimodels.ListJobResultsResponse{
 		Results: resp.Results,
 	})

--- a/pkg/publicapi/test/job_test.go
+++ b/pkg/publicapi/test/job_test.go
@@ -75,7 +75,7 @@ func (s *ServerSuite) TestJobOperations() {
 	resultsResponse, err := s.client.Jobs().Results(ctx, &apimodels.ListJobResultsRequest{JobID: putResponse.JobID})
 	s.Require().NoError(err)
 	s.Require().NotNil(resultsResponse)
-	s.Require().NotEmpty(resultsResponse.Results)
+	s.Require().Empty(resultsResponse.Results, "expected no results as we did not specify a publisher")
 
 	// stop the job should fail as it is already complete
 	_, err = s.client.Jobs().Stop(ctx, &apimodels.StopJobRequest{JobID: putResponse.JobID})


### PR DESCRIPTION
Currently we default to IPFS for the publisher if one is not specified. This commit changes this to allow no publisher to be specified.  It is expected that this will allow us to run jobs with no publisher, and also to have the requester node choose which publisher to use.