### PR TITLE
Fix too-speedy shutdown in devstack

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,8 @@ import (
 //// 	@scope.admin							Grants read and write access to administrative information
 
 func main() {
+	localCtx, localCancel := context.WithCancel(context.Background())
+
 	defer func() {
 		// Make sure any buffered logs are written if something failed before logging was configured.
 		logger.LogBufferedLogs(nil)
@@ -87,11 +89,13 @@ func main() {
 	go func() {
 		cli.Execute(ctx)
 		cancel()
+
+		localCancel()
 	}()
 
 	// Wait for the context to be cancelled
 	// either by a signal or by the command completing
-	<-ctx.Done()
+	<-localCtx.Done()
 
 	// Print a newline to ensure the next prompt is on a new line
 	fmt.Println()


### PR DESCRIPTION
Currently the main() func and the devstack are sharing a cancellable context, and when it is cancelled by SIGINT, the main function exits before the deferred tasks in devstack can complete. This resulted in devstack not running a second time because of the existing pid or port (or both) files.

Now main has its own context which is cancelled only when the job is complete (or cancelled from SIGINT). This gives devstack enough time to shutdown.