### PR TITLE
Add vite env to tsconfig

### DIFF
--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,10 +19,20 @@
     "jsx": "react",
     "noEmit": false,
     "outDir": "./compiled",
-    "typeRoots": ["node_modules/@types", "src/types"],
-    "types": ["node", "jest", "react", "react-dom"]
+    "typeRoots": [
+      "node_modules/@types",
+      "src/types"
+    ],
+    "types": [
+      "node",
+      "jest",
+      "react",
+      "react-dom"
+    ]
   },
-  "files": ["src/index.tsx"],
+  "files": [
+    "src/index.tsx"
+  ],
   "include": [
     "src/**/*.tsx",
     "src/**/*.ts",
@@ -26,7 +40,10 @@
     "tests/**/*.ts",
     "tests/**/*.tsx",
     "tests/mocks/svgMock.js",
-    "src/setupTests.ts"
+    "src/setupTests.ts",
+    "vite-env.d.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This is intended to allow eslint to correctly run linting workflow in github actions which is currently complaining that `vite-env.d.ts` is not included.