### PR TITLE
fix nats logstream

### DIFF
--- a/pkg/nats/proxy/compute_proxy.go
+++ b/pkg/nats/proxy/compute_proxy.go
@@ -142,12 +142,11 @@ func proxyStreamingRequest[Request any, Response any](
 
 	return concurrency.AsyncChannelTransform[[]byte, Response](ctx, res, asyncRequestChanLen,
 		func(r []byte) (Response, error) {
-			response := new(Response)
-			err = json.Unmarshal(r, response)
-			if err != nil {
-				err = fmt.Errorf("%T: failed to decode response from node %s: %w", request.Body, request.TargetNodeID, err)
+			response := new(concurrency.AsyncResult[Response])
+			if err := json.Unmarshal(r, response); err != nil {
+				return *new(Response), fmt.Errorf("%T: failed to decode response from node %s: %w", request.Body, request.TargetNodeID, err)
 			}
-			return *response, err
+			return response.ValueOrError()
 		}), nil
 }
 

--- a/pkg/nats/stream/writer.go
+++ b/pkg/nats/stream/writer.go
@@ -29,12 +29,12 @@ func (w *Writer) Write(data []byte) (int, error) {
 		Data: data,
 	}
 
-	data, err := json.Marshal(msg)
+	msgData, err := json.Marshal(msg)
 	if err != nil {
 		return 0, fmt.Errorf("error encoding streaming data: %s", err)
 	}
 
-	return len(data), w.client.Conn.Publish(w.subject, data)
+	return len(msgData), w.client.Conn.Publish(w.subject, msgData)
 }
 
 // WriteObject writes an object to the stream.


### PR DESCRIPTION
Fixing a bug in channel transformer where it tries to unmarshal `models.ExecutionLog` where the object is `concurrency.AsyncResult[models.ExecutionLog]`