### PR TITLE
Verify signatures of JWTs when authorizing

### DIFF
--- a/pkg/authz/policies/policy_ns_anon.rego
+++ b/pkg/authz/policies/policy_ns_anon.rego
@@ -84,8 +84,7 @@ token_namespaces := ns if {
     startswith(authHeader, "Bearer ")
     accessToken := trim_prefix(authHeader, "Bearer ")
 
-    # TODO: verify signature
-    [header, claims, sig] := io.jwt.decode(accessToken)
+    [valid, header, claims] := io.jwt.decode_verify(accessToken, input.constraints)
     ns := claims["ns"]
 }
 

--- a/pkg/authz/policy_ns_anon_test.go
+++ b/pkg/authz/policy_ns_anon_test.go
@@ -4,6 +4,9 @@ package authz
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"net/http"
 	"testing"
 
@@ -23,13 +26,24 @@ const (
 	NamespaceCancellable  uint8 = 0b1000
 )
 
-func getJWTWithNamespace(t *testing.T, namespace string, perms uint8) string {
-	token, err := jwt.NewWithClaims(jwt.GetSigningMethod("none"), jwt.MapClaims{
-		"ns": map[string]uint8{namespace: perms},
-	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
+func getJWTWithNamespace(t *testing.T, signingKey crypto.PrivateKey, namespace string, perms uint8) string {
+	token, err := jwt.NewWithClaims(jwt.GetSigningMethod(jwt.SigningMethodRS256.Name), jwt.MapClaims{
+		"aud": []string{"test-node"},
+		"iss": "test-node",
+		"ns":  map[string]uint8{namespace: perms},
+	}).SignedString(signingKey)
 	require.NoError(t, err)
 	return token
 }
+
+var (
+	sameKey = func(t *testing.T, in crypto.PrivateKey) crypto.PrivateKey { return in }
+	newKey  = func(t *testing.T, in crypto.PrivateKey) crypto.PrivateKey {
+		newKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		return newKey
+	}
+)
 
 func TestAppliesAnonymousNamespacePolicy(t *testing.T) {
 	cases := []struct {
@@ -40,29 +54,35 @@ func TestAppliesAnonymousNamespacePolicy(t *testing.T) {
 		token_perms     uint8
 		method          string
 		path            string
+		getSignerKey    func(*testing.T, crypto.PrivateKey) crypto.PrivateKey
 		checker         func(require.TestingT, bool, ...interface{})
 	}{
 		{"allow valid job submission",
-			"test", "test", "test", NamespaceWritable, http.MethodPut, "/api/v1/orchestrator/jobs", require.True},
+			"test", "test", "test", NamespaceWritable, http.MethodPut, "/api/v1/orchestrator/jobs", sameKey, require.True},
 		{"deny job submit to unwritable namespace",
-			"test", "test", "test", NamespaceReadable, http.MethodPut, "/api/v1/orchestrator/jobs", require.False},
+			"test", "test", "test", NamespaceReadable, http.MethodPut, "/api/v1/orchestrator/jobs", sameKey, require.False},
 		{"deny job submit to alternative namespace",
-			"other", "other", "test", NamespaceWritable, http.MethodPut, "/api/v1/orchestrator/jobs", require.False},
+			"other", "other", "test", NamespaceWritable, http.MethodPut, "/api/v1/orchestrator/jobs", sameKey, require.False},
 		{"allow valid job read",
-			"test", "test", "test", NamespaceReadable, http.MethodGet, "/api/v1/orchestrator/jobs", require.True},
+			"test", "test", "test", NamespaceReadable, http.MethodGet, "/api/v1/orchestrator/jobs", sameKey, require.True},
 		{"deny job read to unreadable namespace",
-			"test", "test", "test", NamespaceWritable, http.MethodGet, "/api/v1/orchestrator/jobs", require.False},
+			"test", "test", "test", NamespaceWritable, http.MethodGet, "/api/v1/orchestrator/jobs", sameKey, require.False},
 		{"deny job read to alternative namespace",
-			"other", "other", "test", NamespaceReadable, http.MethodGet, "/api/v1/orchestrator/jobs", require.False},
+			"other", "other", "test", NamespaceReadable, http.MethodGet, "/api/v1/orchestrator/jobs", sameKey, require.False},
 		{"allow reading other APIs without token",
-			"other", "other", "test", NamespaceNoPermission, http.MethodGet, "/api/v1/orchestrator/nodes", require.True},
+			"other", "other", "test", NamespaceNoPermission, http.MethodGet, "/api/v1/orchestrator/nodes", sameKey, require.True},
 		{"deny writing other APIs",
-			"other", "other", "test", NamespaceNoPermission, http.MethodDelete, "/api/v1/orchestrator/nodes", require.False},
+			"other", "other", "test", NamespaceNoPermission, http.MethodDelete, "/api/v1/orchestrator/nodes", sameKey, require.False},
+		{"deny signed by wrong key",
+			"test", "test", "test", NamespaceWritable, http.MethodPut, "/api/v1/orchestrator/jobs", newKey, require.False},
 	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
 
 	policy, err := policy.FromFS(policies, "policies/policy_ns_anon.rego")
 	require.NoError(t, err)
-	authorizer := NewPolicyAuthorizer(policy)
+	authorizer := NewPolicyAuthorizer(policy, &key.PublicKey, "test-node")
 
 	for _, testcase := range cases {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -82,7 +102,7 @@ func TestAppliesAnonymousNamespacePolicy(t *testing.T) {
 			require.NoError(t, err)
 
 			if testcase.token_perms > 0 {
-				token := getJWTWithNamespace(t, testcase.token_namespace, testcase.token_perms)
+				token := getJWTWithNamespace(t, testcase.getSignerKey(t, key), testcase.token_namespace, testcase.token_perms)
 				request.Header.Add("Authorization", "Bearer "+token)
 			}
 

--- a/pkg/authz/policy_test.go
+++ b/pkg/authz/policy_test.go
@@ -17,7 +17,7 @@ func TestAllowsWhenPolicySaysAllow(t *testing.T) {
 	policy, err := policy.FromFS(policies, "policies/policy_test_allow.rego")
 	require.NoError(t, err)
 
-	authorizer := NewPolicyAuthorizer(policy)
+	authorizer := NewPolicyAuthorizer(policy, nil, "")
 	require.NotNil(t, authorizer)
 
 	result, err := authorizer.Authorize(request)
@@ -32,7 +32,7 @@ func TestDeniesWhenPolicySaysDeny(t *testing.T) {
 	policy, err := policy.FromFS(policies, "policies/policy_test_deny.rego")
 	require.NoError(t, err)
 
-	authorizer := NewPolicyAuthorizer(policy)
+	authorizer := NewPolicyAuthorizer(policy, nil, "")
 	require.NotNil(t, authorizer)
 
 	result, err := authorizer.Authorize(request)
@@ -44,7 +44,7 @@ func TestPolicyEvaluatedAgainstHTTPRequest(t *testing.T) {
 	policy, err := policy.FromFS(policies, "policies/policy_test_http.rego")
 	require.NoError(t, err)
 
-	authorizer := NewPolicyAuthorizer(policy)
+	authorizer := NewPolicyAuthorizer(policy, nil, "")
 	require.NotNil(t, authorizer)
 
 	goodRequest, err := http.NewRequest(http.MethodGet, "/api/v1/hello", nil)

--- a/pkg/lib/policy/policy.go
+++ b/pkg/lib/policy/policy.go
@@ -67,7 +67,7 @@ type Query[Input, Output any] func(ctx context.Context, input Input) (Output, er
 // certain input type and returns a function that will execute the query when
 // given input of that type.
 func AddQuery[Input, Output any](runner *Policy, rule string) Query[Input, Output] {
-	opts := append(runner.modules, rego.Query("data."+rule), scryptFn)
+	opts := append(runner.modules, rego.Query("data."+rule), scryptFn, rego.StrictBuiltinErrors(true))
 	query := lo.Must(rego.New(opts...).PrepareForEval(context.Background()))
 
 	return func(ctx context.Context, t Input) (Output, error) {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -169,6 +169,11 @@ func NewNode(
 		return nil, err
 	}
 
+	signingKey, err := pkgconfig.GetClientPublicKey()
+	if err != nil {
+		return nil, err
+	}
+
 	serverVersion := version.Get()
 	// public http api server
 	serverParams := publicapi.ServerParams{
@@ -177,7 +182,7 @@ func NewNode(
 		Port:       config.APIPort,
 		HostID:     config.NodeID,
 		Config:     config.APIServerConfig,
-		Authorizer: authz.NewPolicyAuthorizer(authzPolicy),
+		Authorizer: authz.NewPolicyAuthorizer(authzPolicy, signingKey, config.NodeID),
 		Headers: map[string]string{
 			apimodels.HTTPHeaderBacalhauGitVersion: serverVersion.GitVersion,
 			apimodels.HTTPHeaderBacalhauGitCommit:  serverVersion.GitCommit,

--- a/webui/package.json
+++ b/webui/package.json
@@ -59,8 +59,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "build": "yarn build:dev",
-    "build:dev": "tsc && NODE_ENV=development vite build",
-    "build:prod": "tsc && NODE_ENV=production vite build",
+    "build:dev": "npx tsc && NODE_ENV=development vite build",
+    "build:prod": "npx tsc && NODE_ENV=production vite build",
     "start": "vite",
     "serve": "yarn start"
   },


### PR DESCRIPTION
This commit upgrades the authoriser to pass all the metadata necessary to verify received JWTs, assuming that they were signed by this node.

(Policy authors are free to verify tokens issued from other sources and ignore the material passed to the policy.)

Policies can now call `io.jwt.decode_verify` as in the ns_anon policy to verify submitted JWTs.

Resolves https://github.com/bacalhau-project/expanso-planning/issues/475.