### PR TITLE
run staging on nats

### DIFF
--- a/ops/terraform/stage.tfvars
+++ b/ops/terraform/stage.tfvars
@@ -31,3 +31,4 @@ public_ip_addresses         = ["34.85.228.65", "34.86.73.105", "34.150.138.100",
 log_level                   = "debug"
 otel_collector_version  = "0.70.0"
 otel_collector_endpoint = "http://localhost:4318"
+network_type            = "nats"


### PR DESCRIPTION
This PR switches staging to use NATS transport layer instead of Libp2p. It has been baking for couple of days with no issues reported by the canaries.

Keep in mind that this is working with no additional changes related to auth because of the bug reported [here](https://github.com/bacalhau-project/expanso-planning/issues/518), where requester nodes can join a network even without auth keys. When we fix that issue, we will need to pre-provision the auth key instead of letting the requester node auto-generate it, or reuse the terraform modules using for marketplace