### PR TITLE
s3 only publish compressed results

### DIFF
--- a/cmd/util/opts/publisher_test.go
+++ b/cmd/util/opts/publisher_test.go
@@ -37,7 +37,7 @@ func TestParsePublisher(t *testing.T) {
 		},
 		{
 			name:  "s3 with endpoint and region",
-			input: "s3://myBucket/dir/file-001.txt,opt=endpoint=http://127.0.0.1:9000,opt=region=us-east-1,opt=compress=true",
+			input: "s3://myBucket/dir/file-001.txt,opt=endpoint=http://127.0.0.1:9000,opt=region=us-east-1",
 			expected: &model.PublisherSpec{
 				Type: model.PublisherS3,
 				Params: map[string]interface{}{
@@ -45,7 +45,6 @@ func TestParsePublisher(t *testing.T) {
 					"key":      "dir/file-001.txt",
 					"endpoint": "http://127.0.0.1:9000",
 					"region":   "us-east-1",
-					"compress": "true",
 				},
 			},
 		},

--- a/docs/docs/setting-up/data-ingestion/s3.md
+++ b/docs/docs/setting-up/data-ingestion/s3.md
@@ -147,7 +147,6 @@ PublisherSpec:
   Params:
     Bucket: <bucket>              # Specify the bucket where results will be stored
     Key: <object-key>             # Define the object key (supports dynamic naming using placeholders)
-    Compress: <true/false>        # Specify whether to publish results as a single gzip file (default: false)
     Endpoint: <optional>          # Optionally specify the S3 endpoint
     Region: <optional>            # Optionally specify the S3 region
 ```
@@ -170,7 +169,7 @@ bacalhau docker run -p s3://<bucket>/<object-key>,opt=endpoint=http://s3.example
 - Publishing results to S3 as a single compressed file
 
 ```
-bacalhau docker run -p s3://<bucket>/<object-key>,opt=compress=true ubuntu ...
+bacalhau docker run -p s3://<bucket>/<object-key> ubuntu ...
 ```
 
 - Utilizing naming placeholders in the object key

--- a/docs/docs/setting-up/other-specifications/publishers/s3.md
+++ b/docs/docs/setting-up/other-specifications/publishers/s3.md
@@ -13,11 +13,7 @@ Bacalhau's S3 Publisher provides users with a secure and efficient method to pub
 - **Key** `(string: <required>)`: The object key within the specified bucket where the task results will be stored.
 - **Endpoint** `(string: <optional>)`: The endpoint URL of the S3 service (useful for S3-compatible services).
 - **Region** `(string: <optional>)`: The region where the S3 bucket is located.
-- **Compress** `(bool: false)`: Indicates whether the task results should be compressed before storage. Only compressed objects can be downloaded using the `bacalhau get <job_id>` command.
 
-## Publishing Flexibility
-
-The S3 Publisher is adept at handling both individual files and full directories. Each file within a directory is uploaded as a separate S3 object. If the `Compress` option is enabled, the entire directory is compressed into a single object, enhancing efficiency and reducing storage requirements. Only compressed objects can be downloaded using the `bacalhau get <job_id>` command.
 
 ## Published Result Spec
 
@@ -29,10 +25,6 @@ Results published to S3 are stored as objects that can also be used as inputs to
 - **Endpoint**: Records the endpoint URL for S3-compatible storage services.
 - **VersionID**: The version ID of the stored object, enabling versioning support for retrieving specific versions of stored data.
 - **ChecksumSHA256**: The SHA-256 checksum of the stored object, providing a method to verify data integrity.
-
-**Note:** 
-- `ChecksumSHA256` and `VersionID` are only returned when the `Compress` option is enabled, offering users a method to verify the integrity of the compressed data and to track different versions of the stored objects.
-- `ChecksumSHA256` is set only when working with AWS S3, but is not set for all other S3-compatible services.
 
 
 ## Dynamic Naming
@@ -78,7 +70,6 @@ Publisher:
     Bucket: "my-task-results"
     Key: "task123/result.tar.gz"
     Endpoint: "https://s3.us-west-2.amazonaws.com"
-    Compress: true
 ```
 
 In this configuration, task results will be published to the specified S3 bucket and object key. If you’re using an S3-compatible service, simply update the `Endpoint` parameter with the appropriate URL.
@@ -104,7 +95,7 @@ The Bacalhau command-line interface (CLI) provides an imperative approach to spe
    ```bash
    bacalhau docker run -p s3://bucket/key ubuntu ...
    ```
-   This command writes to the S3 bucket using default endpoint and region settings without compressing the result.
+   This command writes to the S3 bucket using default endpoint and region settings.
 
 2. **Docker job writing to S3 with a specific endpoint and region**:
    ```bash
@@ -112,13 +103,7 @@ The Bacalhau command-line interface (CLI) provides an imperative approach to spe
    ```
    This command specifies a unique endpoint and region for the S3 bucket.
 
-3. **Docker job writing a single archived file to S3**:
-   ```bash
-   bacalhau docker run -p s3://bucket/key,opt=compress=true ubuntu ...
-   ```
-   This command compresses the result into a single archived file before writing it to the S3 bucket.
-
-4. **Using naming placeholders**:
+3. **Using naming placeholders**:
    ```bash
    bacalhau docker run -p s3://bucket/result-{date}-{jobID} ubuntu ...
    ```

--- a/pkg/publisher/s3/publisher.go
+++ b/pkg/publisher/s3/publisher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -56,18 +55,6 @@ func (publisher *Publisher) PublishResult(
 		return models.SpecConfig{}, err
 	}
 
-	if spec.Compress {
-		return publisher.publishArchive(ctx, spec, execution, resultPath)
-	}
-	return publisher.publishDirectory(ctx, spec, execution, resultPath)
-}
-
-func (publisher *Publisher) publishArchive(
-	ctx context.Context,
-	spec s3helper.PublisherSpec,
-	execution *models.Execution,
-	resultPath string,
-) (models.SpecConfig, error) {
 	client := publisher.clientProvider.GetClient(spec.Endpoint, spec.Region)
 	key := ParsePublishedKey(spec.Key, execution, true)
 
@@ -118,71 +105,6 @@ func (publisher *Publisher) publishArchive(
 			Region:         spec.Region,
 			ChecksumSHA256: aws.ToString(res.ChecksumSHA256),
 			VersionID:      aws.ToString(res.VersionID),
-		}.ToMap(),
-	}, nil
-}
-
-func (publisher *Publisher) publishDirectory(
-	ctx context.Context,
-	spec s3helper.PublisherSpec,
-	execution *models.Execution,
-	resultPath string,
-) (models.SpecConfig, error) {
-	client := publisher.clientProvider.GetClient(spec.Endpoint, spec.Region)
-	key := ParsePublishedKey(spec.Key, execution, false)
-
-	// Walk the directory tree and upload each file to S3.
-	err := filepath.Walk(resultPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil // skip directories
-		}
-		// Read the file contents.
-		data, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer data.Close()
-
-		relativePath, err := filepath.Rel(resultPath, path)
-		if err != nil {
-			return err
-		}
-
-		putObjectInput := &s3.PutObjectInput{
-			Bucket: aws.String(spec.Bucket),
-			Key:    aws.String(key + filepath.ToSlash(relativePath)),
-			Body:   data,
-		}
-
-		// Only use SHA256 checksums if the endpoint is AWS, as it is
-		// not supported by other S3-compatible providers, such as GCP buckets
-		if client.IsAWSEndpoint() {
-			putObjectInput.ChecksumAlgorithm = types.ChecksumAlgorithmSha256
-		}
-
-		// Upload the file to S3.
-		res, err := client.Uploader.Upload(ctx, putObjectInput)
-		if err != nil {
-			return err
-		}
-		log.Debug().Msgf("Uploaded s3://%s/%s", spec.Bucket, aws.ToString(res.Key))
-		return nil
-	})
-
-	if err != nil {
-		return models.SpecConfig{}, err
-	}
-
-	return models.SpecConfig{
-		Type: models.StorageSourceS3,
-		Params: s3helper.SourceSpec{
-			Bucket:   spec.Bucket,
-			Key:      key,
-			Region:   spec.Region,
-			Endpoint: spec.Endpoint,
 		}.ToMap(),
 	}, nil
 }

--- a/pkg/s3/test/suite.go
+++ b/pkg/s3/test/suite.go
@@ -148,7 +148,6 @@ func (s *HelperSuite) PreparePublisherSpec(compressed bool) s3helper.PublisherSp
 	return s3helper.PublisherSpec{
 		Bucket:   s.Bucket,
 		Key:      prefix,
-		Compress: compressed,
 		Region:   s.Region,
 		Endpoint: s.Endpoint,
 	}

--- a/pkg/s3/types.go
+++ b/pkg/s3/types.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/fatih/structs"
@@ -52,7 +51,6 @@ type PublisherSpec struct {
 	Key      string `json:"Key"`
 	Endpoint string `json:"Endpoint"`
 	Region   string `json:"Region"`
-	Compress bool   `json:"Compress"`
 }
 
 func DecodeSourceSpec(spec *models.SpecConfig) (SourceSpec, error) {
@@ -99,14 +97,6 @@ func DecodePublisherSpec(spec *models.SpecConfig) (PublisherSpec, error) {
 	inputParams := spec.Params
 	if inputParams == nil {
 		return PublisherSpec{}, fmt.Errorf("invalid publisher params. cannot be nil")
-	}
-
-	// convert compress to bool
-	if _, ok := inputParams["Compress"]; ok && reflect.TypeOf(inputParams["Compress"]).Kind() == reflect.String {
-		inputParams["Compress"] = inputParams["Compress"] == "true"
-	}
-	if _, ok := inputParams["compress"]; ok && reflect.TypeOf(inputParams["compress"]).Kind() == reflect.String {
-		inputParams["compress"] = inputParams["compress"] == "true"
 	}
 
 	var c PublisherSpec

--- a/pkg/s3/types_test.go
+++ b/pkg/s3/types_test.go
@@ -25,7 +25,6 @@ func (s *ParamsTestSuite) TestDecodeMap() {
 		Key:      uuid.NewString(),
 		Endpoint: "localhost:9000",
 		Region:   "us-east-1",
-		Compress: true,
 	}
 	decoded, err := DecodePublisherSpec(&models.SpecConfig{
 		Type:   models.PublisherS3,
@@ -41,14 +40,12 @@ func (s *ParamsTestSuite) TestDecodeInterface() {
 		Key:      uuid.NewString(),
 		Endpoint: "localhost:9000",
 		Region:   "us-east-1",
-		Compress: true,
 	}
 	params := map[string]interface{}{
 		"Bucket":   expected.Bucket,
 		"Key":      expected.Key,
 		"Endpoint": expected.Endpoint,
 		"Region":   expected.Region,
-		"Compress": "true",
 	}
 	decoded, err := DecodePublisherSpec(&models.SpecConfig{
 		Type:   models.PublisherS3,
@@ -64,14 +61,12 @@ func (s *ParamsTestSuite) TestDecodeInterfaceLowerCase() {
 		Key:      uuid.NewString(),
 		Endpoint: "localhost:9000",
 		Region:   "us-east-1",
-		Compress: true,
 	}
 	params := map[string]interface{}{
 		"bucket":   expected.Bucket,
 		"key":      expected.Key,
 		"endpoint": expected.Endpoint,
 		"region":   expected.Region,
-		"compress": "true",
 	}
 	decoded, err := DecodePublisherSpec(&models.SpecConfig{
 		Type:   models.PublisherS3,
@@ -87,7 +82,6 @@ func (s *ParamsTestSuite) TestDecodeJson() {
 		Key:      uuid.NewString(),
 		Endpoint: "localhost:9000",
 		Region:   "us-east-1",
-		Compress: true,
 	}
 	bytes, err := json.Marshal(expected)
 	s.Require().NoError(err)


### PR DESCRIPTION
The conclusion of discussing [Improvements to Bacalhau Get](https://www.notion.so/expanso/Improvements-to-Bacalhau-Get-62602e6678af41c181996253ef424002?pvs=4) was to disable uncompressed results and only support compressed results for now to support `bacalhau get` for all S3 results, and make sure checksum is encoded in each result.