### PR TITLE
Replace freeport dependency with modified version

### DIFF
--- a/cmd/cli/serve/serve_test.go
+++ b/cmd/cli/serve/serve_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/multiformats/go-multiaddr"
-	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
 
@@ -22,6 +21,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/docker"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
 
 	cmd2 "github.com/bacalhau-project/bacalhau/cmd/cli"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/serve"
@@ -89,7 +89,7 @@ func (s *ServeSuite) serve(extraArgs ...string) (uint16, error) {
 		}
 	}
 
-	bigPort, err := freeport.GetFreePort()
+	bigPort, err := network.GetFreePort()
 	s.Require().NoError(err)
 	port := uint16(bigPort)
 
@@ -299,7 +299,7 @@ func (s *ServeSuite) Test200ForNotStartingWebUI() {
 }
 
 func (s *ServeSuite) Test200ForRoot() {
-	webUIPort, err := freeport.GetFreePort()
+	webUIPort, err := network.GetFreePort()
 	if err != nil {
 		s.T().Fatal(err, "Could not get port for web-ui")
 	}

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/open-policy-agent/opa v0.60.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
-	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/ricochet2200/go-disk-usage/du v0.0.0-20210707232629-ac9918953285
 	github.com/rs/zerolog v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -986,8 +986,6 @@ github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZ
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+Tv1WTxkukpXeMlviSxvL7SRgk=
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
-github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
-github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/lib/network/ports.go
+++ b/pkg/lib/network/ports.go
@@ -1,0 +1,45 @@
+package network
+
+import (
+	"net"
+)
+
+// GetFreePort returns a single available port by asking the operating
+// system to pick one for us. Luckily ports are not re-used so after asking
+// for a port number, we attempt to create a tcp listener.
+//
+// Essentially the same code as https://github.com/phayes/freeport but we bind
+// to 0.0.0.0 to ensure the port is free on all interfaces, and not just localhost.GetFreePort
+// Ports must be unique for an address, not an entire system and so checking just localhost
+// is not enough.
+func GetFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// GetFreePorts returns an array available ports by asking the operating
+// system to pick one for us.
+//
+// Essentially the same code as https://github.com/phayes/freeport apart from
+// the caveats described in GetFreePort.
+func GetFreePorts(count int) ([]int, error) {
+	ports := []int{}
+
+	for i := 0; i < count; i++ {
+		port, err := GetFreePort()
+		if err != nil {
+			return nil, err
+		}
+		ports = append(ports, port)
+	}
+	return ports, nil
+}

--- a/pkg/lib/network/ports_test.go
+++ b/pkg/lib/network/ports_test.go
@@ -1,0 +1,47 @@
+//go:build unit || !integration
+
+package network_test
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
+	"github.com/stretchr/testify/suite"
+)
+
+type FreePortTestSuite struct {
+	suite.Suite
+}
+
+func TestFreePortTestSuite(t *testing.T) {
+	suite.Run(t, new(FreePortTestSuite))
+}
+
+func (s *FreePortTestSuite) TestGetFreePort() {
+	port, err := network.GetFreePort()
+	s.Require().NoError(err)
+	s.NotEqual(0, port, "expected a non-zero port")
+
+	// Try to listen on the port
+	l, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	s.Require().NoError(err)
+	defer l.Close()
+}
+
+func (s *FreePortTestSuite) TestGetFreePorts() {
+	count := 3
+	ports, err := network.GetFreePorts(count)
+	s.Require().NoError(err)
+	s.Equal(count, len(ports), "expected %d ports", count)
+
+	for _, port := range ports {
+		s.NotEqual(0, port, "expected a non-zero port")
+
+		// Try to listen on the port
+		l, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+		s.Require().NoError(err, "failed to listen on newly given port")
+		defer l.Close()
+	}
+}

--- a/pkg/libp2p/rcmgr/metrics_test.go
+++ b/pkg/libp2p/rcmgr/metrics_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	netwk "github.com/bacalhau-project/bacalhau/pkg/lib/network"
+
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peerstore"
-	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -39,12 +40,12 @@ func TestMetricsReporter(t *testing.T) {
 		sdkmetric.WithReader(reader),
 	)
 
-	port1, err := freeport.GetFreePort()
+	port1, err := netwk.GetFreePort()
 	require.NoError(t, err)
 
 	host1 := startListener(t, port1, meterProvider)
 
-	port2, err := freeport.GetFreePort()
+	port2, err := netwk.GetFreePort()
 	require.NoError(t, err)
 
 	host2 := startListener(t, port2, meterProvider)

--- a/pkg/libp2p/utils.go
+++ b/pkg/libp2p/utils.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
+
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/phayes/freeport"
 	"github.com/rs/zerolog/log"
 )
 
@@ -33,7 +34,7 @@ func encapsulateP2pAddrs(peerInfo peer.AddrInfo) ([]multiaddr.Multiaddr, error) 
 }
 
 func NewHostForTest(ctx context.Context, peers ...host.Host) (host.Host, error) {
-	port, err := freeport.GetFreePort()
+	port, err := network.GetFreePort()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nats/pubsub/pubsub_test.go
+++ b/pkg/nats/pubsub/pubsub_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
 	nats_helper "github.com/bacalhau-project/bacalhau/pkg/nats"
 	"github.com/bacalhau-project/bacalhau/pkg/pubsub"
 	"github.com/nats-io/nats-server/v2/server"
-	"github.com/phayes/freeport"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/suite"
 )
@@ -64,7 +64,7 @@ func (s *PubSubSuite) TearDownSuite() {
 // createNatsServer creates a new nats server
 func (s *PubSubSuite) createNatsServer() *server.Server {
 	ctx := context.Background()
-	port, err := freeport.GetFreePort()
+	port, err := network.GetFreePort()
 	s.Require().NoError(err)
 
 	serverOpts := server.Options{

--- a/pkg/publicapi/test/util_test.go
+++ b/pkg/publicapi/test/util_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
@@ -35,7 +35,7 @@ func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.No
 	cm := system.NewCleanupManager()
 	t.Cleanup(func() { cm.Cleanup(context.Background()) })
 
-	libp2pPort, err := freeport.GetFreePort()
+	libp2pPort, err := network.GetFreePort()
 	require.NoError(t, err)
 
 	privKey, err := config.GetLibp2pPrivKey()

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/bacalhau-project/bacalhau/pkg/authz"
@@ -17,6 +16,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	noop_executor "github.com/bacalhau-project/bacalhau/pkg/executor/noop"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
 	"github.com/bacalhau-project/bacalhau/pkg/libp2p"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -70,7 +70,7 @@ func (s *ComputeSuite) SetupTest() {
 
 func (s *ComputeSuite) setupNode() {
 	repo := repo2.SetupBacalhauRepoForTesting(s.T())
-	libp2pPort, err := freeport.GetFreePort()
+	libp2pPort, err := network.GetFreePort()
 	s.NoError(err)
 
 	privKey, err := config.GetLibp2pPrivKey()


### PR DESCRIPTION
Currently we use phayes/freeport, but it has a couple of issues and isn't actively maintained.  As it isn't a large amount of code, it's imported and modified to provide free ports across all interfaces, not just the 127.0.0.1 address.

This also leaves us room to extend the package and add per-address free-port lookups.