### PR TITLE
Enable access to local publisher content on demo network

### DIFF
--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -295,6 +295,7 @@ resource "google_compute_firewall" "bacalhau_ingress_firewall" {
       "4001",  // ipfs swarm
       "1234",  // bacalhau API
       "1235",  // bacalhau swarm
+      "6001",  // local publisher httpd - compute nodes
       "13133", // otel collector health_check extension
       "55679", // otel collector zpages extension
       "44443", // nginx is healthy - for running health check scripts

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -42,7 +42,8 @@ if [[ "${BACALHAU_NODE_NETWORK_TYPE}" == "nats" ]]; then
     --web-ui "${BACALHAU_NODE_WEBUI}" \
     --web-ui-port 80 \
     --labels owner=bacalhau \
-    --requester-job-translation-enabled
+    --requester-job-translation-enabled \
+    --default-publisher local
 
 else
   function getMultiaddress() {
@@ -95,5 +96,6 @@ else
     --web-ui "${BACALHAU_NODE_WEBUI}" \
     --web-ui-port 80 \
     --labels owner=bacalhau \
-    --requester-job-translation-enabled
+    --requester-job-translation-enabled \
+    --default-publisher local
 fi


### PR DESCRIPTION
This opens up the necessary firewall port to allow in requests for local publisher content at each compute node, for the demo network.  It also tells the requester node to default to the local publisher if the incoming job does not specify a publisher to use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled a new port "6001" for local publisher HTTPD on compute nodes to enhance network communication.
	- Improved startup script to default to local publisher mode, optimizing node network configurations based on environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->