### PR TITLE
Devstack cancellations

### DIFF
--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -136,6 +136,7 @@ func Setup(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get ipfs swarm addresses: %w", err)
 			}
+
 			// Only use a single address as libp2p seems to have concurrency issues, like two nodes not able to finish
 			// connecting/joining topics, when using multiple addresses for a single host.
 			// All the IPFS nodes are running within the same process, so connecting over localhost will be fine.
@@ -372,12 +373,6 @@ func (stack *DevStack) PrintNodeInfo(ctx context.Context, fsRepo *repo.FsRepo, c
 	devStackAPIHost := stack.Nodes[0].APIServer.Address
 	devStackIPFSSwarmAddress := ""
 	var devstackPeerAddrs []string
-
-	// TODO remove this it's wrong and never printed, nothing sets the env vars its printing
-	logString += `
------------------------------------------
------------------------------------------
-`
 
 	requesterOnlyNodes := 0
 	computeOnlyNodes := 0

--- a/pkg/ipfs/client.go
+++ b/pkg/ipfs/client.go
@@ -128,6 +128,10 @@ func (cl Client) SwarmAddresses(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
+	if len(multiAddresses) == 0 {
+		return nil, fmt.Errorf("no swarm addresses found")
+	}
+
 	// It's common for callers to this function to use the result to connect to another IPFS node.
 	// This sorts the addresses so IPv4 localhost is first, with the aim of using the localhost connection during tests
 	// and so avoid any unneeded network hops. Other callers to this either sort the list themselves or just output the

--- a/pkg/ipfs/node.go
+++ b/pkg/ipfs/node.go
@@ -84,7 +84,8 @@ func NewNodeWithConfig(ctx context.Context, cm *system.CleanupManager, cfg types
 	// TODO if cfg.PrivateInternal is true do we actually want to connect to peers?
 	if err = connectToPeers(ctx, api, ipfsNode, cfg.GetSwarmAddresses()); err != nil {
 		if err == context.Canceled {
-			return nil, nil // context was canceled, so we should just stop running
+			log.Ctx(ctx).Debug().Msg("gracefully shutting down ipfs node due to context cancellation")
+			return nil, nil
 		}
 		log.Ctx(ctx).Error().Msgf("ipfs node failed to connect to peers: %s", err)
 	}

--- a/pkg/routing/node_info_publisher.go
+++ b/pkg/routing/node_info_publisher.go
@@ -105,8 +105,9 @@ func (n *NodeInfoPublisher) publishBackgroundTask(ctx context.Context, interval 
 
 				err := n.Publish(ctx)
 				if err != nil {
-					if err != context.Canceled {
-						// We will only log this if it is not a cancellation
+					if err == context.Canceled {
+						log.Ctx(ctx).Debug().Msg("gracefully shutting down ipfs node due to context cancellation")
+					} else {
 						log.Ctx(ctx).Err(err).Msg("failed to publish node info")
 					}
 				}


### PR DESCRIPTION
When exiting devstack, there are often errors logged that are unnecessary, or in some cases delay when the process actuall exits.  

This commit checks some obvious context cancellation errors and gives the code a chance to exit without logging and continuing.  

Should also fix https://github.com/bacalhau-project/bacalhau/issues/3484 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved error handling in IPFS client and node operations.
	- Enhanced logging clarity by removing unused statements and adjusting error logging conditions.
- **Bug Fixes**
	- Ensured appropriate error messages are returned when no swarm addresses are found in IPFS operations.
- **Chores**
	- Added a comment regarding using a single address for libp2p due to concurrency issues.
	- Introduced handling for the context being canceled during peer connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->