### PR TITLE
fix: set EvalID in execution

### DIFF
--- a/pkg/orchestrator/scheduler/batch_service_job.go
+++ b/pkg/orchestrator/scheduler/batch_service_job.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/math"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
-	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 )
 
 // BatchServiceJobScheduler is a scheduler for:
@@ -129,6 +130,7 @@ func (b *BatchServiceJobScheduler) createMissingExecs(
 			JobID:        job.ID,
 			Job:          job,
 			ID:           idgen.ExecutionIDPrefix + uuid.NewString(),
+			EvalID:       plan.EvalID,
 			Namespace:    job.Namespace,
 			ComputeState: models.NewExecutionState(models.ExecutionStateNew),
 			DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStatePending),

--- a/pkg/orchestrator/scheduler/daemon_job.go
+++ b/pkg/orchestrator/scheduler/daemon_job.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
-	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 )
 
 // DaemonJobScheduler is a scheduler for batch jobs that run until completion
@@ -103,6 +104,7 @@ func (b *DaemonJobScheduler) createMissingExecs(
 		execution := &models.Execution{
 			JobID:        job.ID,
 			Job:          job,
+			EvalID:       plan.EvalID,
 			ID:           idgen.ExecutionIDPrefix + uuid.NewString(),
 			Namespace:    job.Namespace,
 			ComputeState: models.NewExecutionState(models.ExecutionStateNew),

--- a/pkg/orchestrator/scheduler/ops_job.go
+++ b/pkg/orchestrator/scheduler/ops_job.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
-	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 )
 
 // OpsJobScheduler is a scheduler for batch jobs that run until completion
@@ -113,6 +114,7 @@ func (b *OpsJobScheduler) createMissingExecs(
 		execution := &models.Execution{
 			JobID:        job.ID,
 			Job:          job,
+			EvalID:       plan.EvalID,
 			ID:           idgen.ExecutionIDPrefix + uuid.NewString(),
 			Namespace:    job.Namespace,
 			ComputeState: models.NewExecutionState(models.ExecutionStateNew),


### PR DESCRIPTION
- previously this field was never set. It's now set based on the evaluationID in the plan when an execution is created.