### PR TITLE
Remove invalid or expired authorization tokens

### DIFF
--- a/cmd/cli/agent/alive.go
+++ b/cmd/cli/agent/alive.go
@@ -37,7 +37,7 @@ func NewAliveCmd() *cobra.Command {
 // Run executes alive command
 func (o *AliveOptions) runAlive(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	response, err := util.GetAPIClientV2().Agent().Alive(ctx)
+	response, err := util.GetAPIClientV2(cmd).Agent().Alive(ctx)
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("could not get server alive: %w", err), 1)
 	}

--- a/cmd/cli/agent/node.go
+++ b/cmd/cli/agent/node.go
@@ -38,7 +38,7 @@ func NewNodeCmd() *cobra.Command {
 // Run executes node command
 func (o *NodeOptions) runNode(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	response, err := util.GetAPIClientV2().Agent().Node(ctx, &apimodels.GetAgentNodeRequest{})
+	response, err := util.GetAPIClientV2(cmd).Agent().Node(ctx, &apimodels.GetAgentNodeRequest{})
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("could not get server node: %w", err), 1)
 	}

--- a/cmd/cli/agent/version.go
+++ b/cmd/cli/agent/version.go
@@ -38,7 +38,7 @@ func NewVersionCmd() *cobra.Command {
 // Run executes version command
 func (oV *VersionOptions) runVersion(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	serverVersionResponse, err := util.GetAPIClientV2().Agent().Version(ctx)
+	serverVersionResponse, err := util.GetAPIClientV2(cmd).Agent().Version(ctx)
 	if err != nil {
 		util.Fatal(cmd, fmt.Errorf("could not get server version: %w", err), 1)
 	}

--- a/cmd/cli/create/create.go
+++ b/cmd/cli/create/create.go
@@ -161,7 +161,7 @@ func create(cmd *cobra.Command, cmdArgs []string, OC *CreateOptions) error { //n
 
 	if len(byteResult) == 0 {
 		// TODO better error
-		return fmt.Errorf("%s", userstrings.JobSpecBad)
+		return fmt.Errorf("%s: job is empty", userstrings.JobSpecBad)
 	}
 
 	// Turns out the yaml parser supports both yaml & json (because json is a subset of yaml)
@@ -174,7 +174,7 @@ func create(cmd *cobra.Command, cmdArgs []string, OC *CreateOptions) error { //n
 	// See if the job spec is empty
 	if j == nil || reflect.DeepEqual(j.Spec, &model.Job{}) {
 		// TODO better error
-		return fmt.Errorf("%s", userstrings.JobSpecBad)
+		return fmt.Errorf("%s: job is empty", userstrings.JobSpecBad)
 	}
 
 	// Warn on fields with data that will be ignored

--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -111,7 +111,7 @@ func exec(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, options *E
 		return fmt.Errorf("%s: %w", userstrings.JobSpecBad, err)
 	}
 
-	client := util.GetAPIClientV2()
+	client := util.GetAPIClientV2(cmd)
 	resp, err := client.Jobs().Put(cmd.Context(), &apimodels.PutJobRequest{
 		Job: job,
 	})

--- a/cmd/cli/job/describe.go
+++ b/cmd/cli/job/describe.go
@@ -63,7 +63,7 @@ func NewDescribeCmd() *cobra.Command {
 func (o *DescribeOptions) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	jobID := args[0]
-	response, err := util.GetAPIClientV2().Jobs().Get(ctx, &apimodels.GetJobRequest{
+	response, err := util.GetAPIClientV2(cmd).Jobs().Get(ctx, &apimodels.GetJobRequest{
 		JobID:   jobID,
 		Include: "executions",
 	})

--- a/cmd/cli/job/executions.go
+++ b/cmd/cli/job/executions.go
@@ -123,7 +123,7 @@ var executionColumns = []output.TableColumn[*models.Execution]{
 func (o *ExecutionOptions) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	jobID := args[0]
-	response, err := util.GetAPIClientV2().Jobs().Executions(ctx, &apimodels.ListJobExecutionsRequest{
+	response, err := util.GetAPIClientV2(cmd).Jobs().Executions(ctx, &apimodels.ListJobExecutionsRequest{
 		JobID: jobID,
 		BaseListRequest: apimodels.BaseListRequest{
 			Limit:     o.Limit,

--- a/cmd/cli/job/history.go
+++ b/cmd/cli/job/history.go
@@ -126,7 +126,7 @@ var historyColumns = []output.TableColumn[*models.JobHistory]{
 func (o *HistoryOptions) run(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	jobID := args[0]
-	response, err := util.GetAPIClientV2().Jobs().History(ctx, &apimodels.ListJobHistoryRequest{
+	response, err := util.GetAPIClientV2(cmd).Jobs().History(ctx, &apimodels.ListJobHistoryRequest{
 		JobID:       jobID,
 		EventType:   o.EventType,
 		ExecutionID: o.ExecutionID,

--- a/cmd/cli/job/list.go
+++ b/cmd/cli/job/list.go
@@ -124,7 +124,7 @@ func (o *ListOptions) run(cmd *cobra.Command, _ []string) {
 			util.Fatal(cmd, fmt.Errorf("could not parse labels: %w", err), 1)
 		}
 	}
-	response, err := util.GetAPIClientV2().Jobs().List(ctx, &apimodels.ListJobsRequest{
+	response, err := util.GetAPIClientV2(cmd).Jobs().List(ctx, &apimodels.ListJobsRequest{
 		Labels: labelRequirements,
 		BaseListRequest: apimodels.BaseListRequest{
 			Limit:     o.Limit,

--- a/cmd/cli/job/run.go
+++ b/cmd/cli/job/run.go
@@ -151,7 +151,7 @@ func (o *RunOptions) run(cmd *cobra.Command, args []string) {
 	}
 
 	// Submit the job
-	client := util.GetAPIClientV2()
+	client := util.GetAPIClientV2(cmd)
 	resp, err := client.Jobs().Put(ctx, &apimodels.PutJobRequest{
 		Job: j,
 	})

--- a/cmd/cli/job/run_test.go
+++ b/cmd/cli/job/run_test.go
@@ -44,10 +44,11 @@ func (s *RunSuite) TestRun() {
 
 			fmt.Println(tc.Data)
 
-			require.NoError(s.T(), err, "Error submitting job")
 			if tc.Invalid {
+				require.Error(s.T(), err, "Should have seen error submitting job")
 				assert.Contains(s.T(), out, userstrings.JobSpecBad)
 			} else {
+				require.NoError(s.T(), err, "Error submitting job")
 				testutils.GetJobFromTestOutput(ctx, s.T(), s.ClientV2, out)
 			}
 		})

--- a/cmd/cli/job/stop.go
+++ b/cmd/cli/job/stop.go
@@ -109,7 +109,7 @@ func (o *StopOptions) run(cmd *cobra.Command, cmdArgs []string) error {
 
 	// Let the user know we are initiating the request
 	spinner.NextStep(connectingMessage)
-	apiClient := util.GetAPIClientV2()
+	apiClient := util.GetAPIClientV2(cmd)
 
 	// Fetch the job information so we can check whether the task is already
 	// terminal or not. We will not send requests if it is.

--- a/cmd/cli/node/describe.go
+++ b/cmd/cli/node/describe.go
@@ -39,7 +39,7 @@ func NewDescribeCmd() *cobra.Command {
 func (o *DescribeOptions) runDescribe(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	nodeID := args[0]
-	response, err := util.GetAPIClientV2().Nodes().Get(ctx, &apimodels.GetNodeRequest{
+	response, err := util.GetAPIClientV2(cmd).Nodes().Get(ctx, &apimodels.GetNodeRequest{
 		NodeID: nodeID,
 	})
 	if err != nil {

--- a/cmd/cli/node/list.go
+++ b/cmd/cli/node/list.go
@@ -63,7 +63,7 @@ func (o *ListOptions) run(cmd *cobra.Command, _ []string) {
 			util.Fatal(cmd, fmt.Errorf("could not parse labels: %w", err), 1)
 		}
 	}
-	response, err := util.GetAPIClientV2().Nodes().List(ctx, &apimodels.ListNodesRequest{
+	response, err := util.GetAPIClientV2(cmd).Nodes().List(ctx, &apimodels.ListNodesRequest{
 		Labels: labelRequirements,
 		BaseListRequest: apimodels.BaseListRequest{
 			Limit:     o.Limit,

--- a/cmd/cli/validate/validate_test.go
+++ b/cmd/cli/validate/validate_test.go
@@ -38,11 +38,12 @@ func (s *ValidateSuite) TestValidate() {
 			_, out, err := s.ExecuteTestCobraCommand("validate",
 				test.testFile.AsTempFile(s.T(), fmt.Sprintf("%s.*.yaml", name)),
 			)
-			require.NoError(s.T(), err)
 
 			if test.valid {
+				require.NoError(s.T(), err)
 				require.Contains(s.T(), out, "The Job is valid", fmt.Sprintf("%s: Jobspec Invalid", name))
 			} else {
+				require.Error(s.T(), err)
 				fatalError, err := testutils.FirstFatalError(s.T(), out)
 				require.NoError(s.T(), err)
 				require.Contains(s.T(), fatalError.Message, "The Job is not valid.", fmt.Sprintf("%s: Jobspec Invalid returning valid", name))

--- a/cmd/testing/base.go
+++ b/cmd/testing/base.go
@@ -29,7 +29,7 @@ type BaseSuite struct {
 	suite.Suite
 	Node     *node.Node
 	Client   *client.APIClient
-	ClientV2 *clientv2.Client
+	ClientV2 clientv2.API
 	Host     string
 	Port     uint16
 }

--- a/cmd/testing/base.go
+++ b/cmd/testing/base.go
@@ -114,7 +114,11 @@ func (s *BaseSuite) ExecuteTestCobraCommandWithStdin(stdin io.Reader, args ...st
 
 	s.T().Logf("Command to execute: %v", arguments)
 
+	util.TestError = nil
 	c, err = root.ExecuteC()
+	if err == nil {
+		err = util.TestError
+	}
 	return c, buf.String(), err
 }
 

--- a/cmd/util/auth/auth.go
+++ b/cmd/util/auth/auth.go
@@ -2,34 +2,32 @@ package auth
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 
-	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/choose"
 	"github.com/bacalhau-project/bacalhau/pkg/authn"
 	"github.com/bacalhau-project/bacalhau/pkg/authn/challenge"
-	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 )
 
 type responder = func(request *json.RawMessage) (response []byte, err error)
 
-func RunAuthenticationFlow(cmd *cobra.Command) (string, error) {
+func RunAuthenticationFlow(cmd *cobra.Command, auth *client.Auth) (*apimodels.HTTPCredential, error) {
 	supportedMethods := map[authn.MethodType]responder{
 		authn.MethodTypeChallenge: challenge.Respond,
 		authn.MethodTypeAsk:       askResponder(cmd),
 	}
 
-	client := util.GetAPIClientV2()
-	methods, err := client.Auth().Methods(cmd.Context(), &apimodels.ListAuthnMethodsRequest{})
+	methods, err := auth.Methods(cmd.Context(), &apimodels.ListAuthnMethodsRequest{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	filteredMethods := make(map[string]authn.Requirement, len(methods.Methods))
@@ -42,7 +40,7 @@ func RunAuthenticationFlow(cmd *cobra.Command) (string, error) {
 
 	if len(filteredMethods) == 0 {
 		serverTypes := lo.Map(maps.Values(methods.Methods), func(r authn.Requirement, _ int) authn.MethodType { return r.Type })
-		return "", fmt.Errorf("no common authentication method: client supports %v, server supports %v", clientTypes, serverTypes)
+		return nil, fmt.Errorf("no common authentication method: client supports %v, server supports %v", clientTypes, serverTypes)
 	}
 
 	var authentication authn.Authentication
@@ -50,24 +48,24 @@ func RunAuthenticationFlow(cmd *cobra.Command) (string, error) {
 		supportedNames := maps.Keys(filteredMethods)
 		chosenMethodName, err := choose.Choose(cmd, "How would you like to authenticate?", supportedNames)
 		if errors.Is(err, io.EOF) {
-			return "", nil
+			return nil, nil
 		} else if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		methodRequirement := methods.Methods[chosenMethodName]
 		methodResponder := supportedMethods[methodRequirement.Type]
 		response, err := methodResponder(methodRequirement.Params)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
-		authnResponse, err := client.Auth().Authenticate(cmd.Context(), &apimodels.AuthnRequest{
+		authnResponse, err := auth.Authenticate(cmd.Context(), &apimodels.AuthnRequest{
 			Name:       chosenMethodName,
 			MethodData: response,
 		})
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		authentication = authnResponse.Authentication
@@ -76,33 +74,8 @@ func RunAuthenticationFlow(cmd *cobra.Command) (string, error) {
 		}
 	}
 
-	return authentication.Token, nil
-}
-
-// A Cobra pre-run hook that will run the authentication flow.
-func Authenticate(cmd *cobra.Command, args []string) error {
-	base := config.ClientAPIBase()
-
-	// See if we have a token for the server we will be using.
-	token, err := util.ReadToken(base)
-	if err != nil {
-		return err
-	}
-	if token != "" {
-		return nil
-	}
-
-	// No token found – so eagerly run an authentication flow to try and get a
-	// valid token.
-	token, err = RunAuthenticationFlow(cmd)
-	if err != nil {
-		return err
-	}
-	if token != "" {
-		return util.WriteToken(base, token)
-	}
-
-	// Failed to authenticate. That's ok – this server may accept
-	// unauthenticated requests.
-	return nil
+	return &apimodels.HTTPCredential{
+		Scheme: "Bearer",
+		Value:  authentication.Token,
+	}, nil
 }

--- a/cmd/util/download.go
+++ b/cmd/util/download.go
@@ -25,7 +25,7 @@ func DownloadResultsHandler(
 ) error {
 	cmd.PrintErrf("Fetching results of job '%s'...\n", jobID)
 	cm := GetCleanupManager(ctx)
-	response, err := GetAPIClientV2().Jobs().Results(ctx, &apimodels.ListJobResultsRequest{
+	response, err := GetAPIClientV2(cmd).Jobs().Results(ctx, &apimodels.ListJobResultsRequest{
 		JobID: jobID,
 	})
 	if err != nil {

--- a/cmd/util/hook/hooks.go
+++ b/cmd/util/hook/hooks.go
@@ -1,7 +1,6 @@
 package hook
 
 import (
-	"github.com/bacalhau-project/bacalhau/cmd/util/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +75,6 @@ var ClientPreRunHooks runHookE = Chain(
 // communicate with remote servers should have applied.
 var RemoteCmdPreRunHooks runHookE = Chain(
 	ClientPreRunHooks,
-	auth.Authenticate,
 )
 
 // ClientPostRunHooks is the set of post-run hooks that all client commands

--- a/cmd/util/hook/version.go
+++ b/cmd/util/hook/version.go
@@ -19,7 +19,7 @@ func StartUpdateCheck(cmd *cobra.Command, args []string) {
 	version.RunUpdateChecker(
 		cmd.Context(),
 		func(ctx context.Context) (*models.BuildVersionInfo, error) {
-			if response, err := util.GetAPIClientV2().Agent().Version(ctx); err != nil {
+			if response, err := util.GetAPIClientV2(cmd).Agent().Version(ctx); err != nil {
 				return nil, err
 			} else if response != nil {
 				return response.BuildVersionInfo, nil

--- a/cmd/util/logging.go
+++ b/cmd/util/logging.go
@@ -35,7 +35,7 @@ func Logs(cmd *cobra.Command, options LogOptions) error {
 		requestedJobID = string(byteResult)
 	}
 
-	apiClient := GetAPIClientV2()
+	apiClient := GetAPIClientV2(cmd)
 	ch, err := apiClient.Jobs().Logs(cmd.Context(), &apimodels.GetLogsRequest{
 		JobID:       options.JobID,
 		ExecutionID: options.ExecutionID,

--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -45,7 +45,7 @@ func PrintJobExecution(
 	jobID string,
 	cmd *cobra.Command,
 	runtimeSettings *cliflags.RunTimeSettings,
-	client *clientv2.Client,
+	client clientv2.API,
 ) error {
 	// if we are in --wait=false - print the id then exit
 	// because all code after this point is related to
@@ -107,7 +107,7 @@ func PrintJobExecution(
 	return nil
 }
 
-func followLogs(cmd *cobra.Command, jobID string, client *clientv2.Client) error {
+func followLogs(cmd *cobra.Command, jobID string, client clientv2.API) error {
 	cmd.Printf("Job successfully submitted. Job ID: %s\n", jobID)
 	cmd.Printf("Waiting for logs... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
 
@@ -139,7 +139,7 @@ func followLogs(cmd *cobra.Command, jobID string, client *clientv2.Client) error
 //
 //nolint:gocyclo,funlen
 func waitForJobAndPrintResultsToUser(
-	ctx context.Context, cmd *cobra.Command, jobID string, quiet bool, client *clientv2.Client) error {
+	ctx context.Context, cmd *cobra.Command, jobID string, quiet bool, client clientv2.API) error {
 	getMoreInfoString := fmt.Sprintf(`
 To get more information at any time, run:
    bacalhau job describe %s`, jobID)

--- a/cmd/util/testing.go
+++ b/cmd/util/testing.go
@@ -7,6 +7,8 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 )
 
+var TestError error
+
 // FakeFatalErrorHandler captures the error for testing, responsibility of the test to handle the exit (if any)
 // NOTE: If your test is not idempotent, you can cause side effects
 // (the underlying function will continue to run)
@@ -15,4 +17,5 @@ func FakeFatalErrorHandler(cmd *cobra.Command, msg error, code int) {
 	c := model.TestFatalErrorHandlerContents{Message: msg.Error(), Code: code}
 	b, _ := marshaller.JSONMarshalWithMax(c)
 	cmd.Println(string(b))
+	TestError = msg
 }

--- a/ops/aws/canary/lambda/pkg/scenarios/utils.go
+++ b/ops/aws/canary/lambda/pkg/scenarios/utils.go
@@ -147,7 +147,7 @@ func getClient() *client.APIClient {
 	return client.NewAPIClient(legacyTLS, host, port)
 }
 
-func getClientV2() *clientv2.Client {
+func getClientV2() clientv2.API {
 	host, port := getClientHostAndPort()
 	return clientv2.New(fmt.Sprintf("http://%s:%d", host, port))
 }

--- a/pkg/authz/policies/policy_test_allow.rego
+++ b/pkg/authz/policies/policy_test_allow.rego
@@ -2,3 +2,4 @@ package bacalhau.authz
 import rego.v1
 
 allow := true
+token_valid := true

--- a/pkg/authz/policies/policy_test_deny.rego
+++ b/pkg/authz/policies/policy_test_deny.rego
@@ -2,3 +2,4 @@ package bacalhau.authz
 import rego.v1
 
 allow := false
+token_valid := true

--- a/pkg/authz/policies/policy_test_http.rego
+++ b/pkg/authz/policies/policy_test_http.rego
@@ -6,4 +6,11 @@ default allow = false
 allow if {
     input.http.method == "GET"
     input.http.path == ["api", "v1", "hello"]
+    token_valid
+}
+
+default token_valid = false
+
+token_valid if {
+    input.http.headers["Authorization"] != ""
 }

--- a/pkg/authz/policy_test.go
+++ b/pkg/authz/policy_test.go
@@ -23,6 +23,7 @@ func TestAllowsWhenPolicySaysAllow(t *testing.T) {
 	result, err := authorizer.Authorize(request)
 	require.NoError(t, err)
 	require.True(t, result.Approved)
+	require.True(t, result.TokenValid)
 }
 
 func TestDeniesWhenPolicySaysDeny(t *testing.T) {
@@ -38,9 +39,10 @@ func TestDeniesWhenPolicySaysDeny(t *testing.T) {
 	result, err := authorizer.Authorize(request)
 	require.NoError(t, err)
 	require.False(t, result.Approved)
+	require.True(t, result.TokenValid)
 }
 
-func TestPolicyEvaluatedAgainstHTTPRequest(t *testing.T) {
+func TestPolicyEvaluatedAgainstGoodHTTPRequest(t *testing.T) {
 	policy, err := policy.FromFS(policies, "policies/policy_test_http.rego")
 	require.NoError(t, err)
 
@@ -49,15 +51,44 @@ func TestPolicyEvaluatedAgainstHTTPRequest(t *testing.T) {
 
 	goodRequest, err := http.NewRequest(http.MethodGet, "/api/v1/hello", nil)
 	require.NoError(t, err)
+	goodRequest.Header.Add("Authorization", "anything")
 
 	goodResult, err := authorizer.Authorize(goodRequest)
 	require.NoError(t, err)
 	require.True(t, goodResult.Approved)
+	require.True(t, goodResult.TokenValid)
+}
+
+func TestPolicyEvaluatedAgainstInvalidHTTPRequest(t *testing.T) {
+	policy, err := policy.FromFS(policies, "policies/policy_test_http.rego")
+	require.NoError(t, err)
+
+	authorizer := NewPolicyAuthorizer(policy, nil, "")
+	require.NotNil(t, authorizer)
+
+	invalidRequest, err := http.NewRequest(http.MethodGet, "/api/v1/hello", nil)
+	require.NoError(t, err)
+	// Not adding authz header
+
+	invalidResult, err := authorizer.Authorize(invalidRequest)
+	require.NoError(t, err)
+	require.False(t, invalidResult.Approved)
+	require.False(t, invalidResult.TokenValid)
+}
+
+func TestPolicyEvaluatedAgainstDeniedHTTPRequest(t *testing.T) {
+	policy, err := policy.FromFS(policies, "policies/policy_test_http.rego")
+	require.NoError(t, err)
+
+	authorizer := NewPolicyAuthorizer(policy, nil, "")
+	require.NotNil(t, authorizer)
 
 	badRequest, err := http.NewRequest(http.MethodDelete, "/api/v1/hello", nil)
 	require.NoError(t, err)
+	badRequest.Header.Add("Authorization", "anything")
 
 	badResult, err := authorizer.Authorize(badRequest)
 	require.NoError(t, err)
 	require.False(t, badResult.Approved)
+	require.True(t, badResult.TokenValid)
 }

--- a/pkg/authz/types.go
+++ b/pkg/authz/types.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Authorization struct {
-	Approved bool   `json:"approved"`
-	Reason   string `json:"reason"`
+	Approved   bool   `json:"approved"`
+	TokenValid bool   `json:"tokenValid"`
+	Reason     string `json:"reason"`
 }
 
 type Authorizer interface {

--- a/pkg/publicapi/apimodels/auth.go
+++ b/pkg/publicapi/apimodels/auth.go
@@ -1,8 +1,12 @@
 package apimodels
 
 import (
+	"errors"
+
 	"github.com/bacalhau-project/bacalhau/pkg/authn"
 )
+
+var ErrInvalidToken = errors.New("invalid token")
 
 type ListAuthnMethodsRequest struct {
 	BaseListRequest

--- a/pkg/publicapi/apimodels/base.go
+++ b/pkg/publicapi/apimodels/base.go
@@ -1,6 +1,8 @@
 package apimodels
 
 type Request interface {
+	// SetCredential is used to set the authorization token for the request
+	SetCredential(*HTTPCredential)
 	// ToHTTPRequest is used to convert the request to an HTTP request
 	ToHTTPRequest() *HTTPRequest
 }

--- a/pkg/publicapi/apimodels/base_requests.go
+++ b/pkg/publicapi/apimodels/base_requests.go
@@ -6,11 +6,9 @@ import (
 
 // BaseRequest is the base request used for all requests
 type BaseRequest struct {
-	Namespace string            `query:"namespace"`
-	Headers   map[string]string `query:"-" json:"-"`
-
-	// A good place to define other fields that are common to all requests,
-	// such as auth tokens
+	Namespace  string            `query:"namespace"`
+	Headers    map[string]string `query:"-" json:"-"`
+	Credential *HTTPCredential   `header:"Authorization"`
 }
 
 // ToHTTPRequest is used to convert the request to an HTTP request
@@ -21,11 +19,19 @@ func (o *BaseRequest) ToHTTPRequest() *HTTPRequest {
 		r.Params.Set("namespace", o.Namespace)
 	}
 
+	if o.Credential != nil {
+		r.Header.Set("Authorization", o.Credential.String())
+	}
+
 	for k, v := range o.Headers {
 		r.Header.Set(k, v)
 	}
 
 	return r
+}
+
+func (o *BaseRequest) SetCredential(cred *HTTPCredential) {
+	o.Credential = cred
 }
 
 // BasePutRequest is the base request used for all put requests

--- a/pkg/publicapi/client/v2/api.go
+++ b/pkg/publicapi/client/v2/api.go
@@ -1,0 +1,41 @@
+package client
+
+// API is the root of the Bacalhau server API. The structure mirrors the
+// structure of the API: each method returns an object that can submit requests
+// to control a single part of the system.
+type API interface {
+	Agent() *Agent
+	Auth() *Auth
+	Jobs() *Jobs
+	Nodes() *Nodes
+}
+
+type api struct {
+	Client
+}
+
+func (c *api) Agent() *Agent {
+	return &Agent{client: c.Client}
+}
+
+func (c *api) Auth() *Auth {
+	return &Auth{client: c.Client}
+}
+
+func (c *api) Jobs() *Jobs {
+	return &Jobs{client: c.Client}
+}
+
+func (c *api) Nodes() *Nodes {
+	return &Nodes{client: c.Client}
+}
+
+func NewAPI(transport Client) API {
+	return &api{Client: transport}
+}
+
+func New(address string, optFns ...OptionFn) API {
+	return NewAPI(NewHTTPClient(address, optFns...))
+}
+
+var _ API = (*api)(nil)

--- a/pkg/publicapi/client/v2/api_agent.go
+++ b/pkg/publicapi/client/v2/api_agent.go
@@ -7,31 +7,26 @@ import (
 )
 
 type Agent struct {
-	client *Client
-}
-
-// Agent returns a handle on the agent endpoints.
-func (c *Client) Agent() *Agent {
-	return &Agent{client: c}
+	client Client
 }
 
 // Alive is used to check if the agent is alive.
 func (c *Agent) Alive(ctx context.Context) (*apimodels.IsAliveResponse, error) {
 	var res apimodels.IsAliveResponse
-	err := c.client.get(ctx, "/api/v1/agent/alive", &apimodels.BaseGetRequest{}, &res)
+	err := c.client.Get(ctx, "/api/v1/agent/alive", &apimodels.BaseGetRequest{}, &res)
 	return &res, err
 }
 
 // Version is used to get the agent version.
 func (c *Agent) Version(ctx context.Context) (*apimodels.GetVersionResponse, error) {
 	var res apimodels.GetVersionResponse
-	err := c.client.get(ctx, "/api/v1/agent/version", &apimodels.BaseGetRequest{}, &res)
+	err := c.client.Get(ctx, "/api/v1/agent/version", &apimodels.BaseGetRequest{}, &res)
 	return &res, err
 }
 
 // Node is used to get the agent node info.
 func (c *Agent) Node(ctx context.Context, req *apimodels.GetAgentNodeRequest) (*apimodels.GetAgentNodeResponse, error) {
 	var res apimodels.GetAgentNodeResponse
-	err := c.client.get(ctx, "/api/v1/agent/node", req, &res)
+	err := c.client.Get(ctx, "/api/v1/agent/node", req, &res)
 	return &res, err
 }

--- a/pkg/publicapi/client/v2/api_auth.go
+++ b/pkg/publicapi/client/v2/api_auth.go
@@ -9,22 +9,18 @@ import (
 const authBase = "/api/v1/auth"
 
 type Auth struct {
-	client *Client
-}
-
-func (c *Client) Auth() *Auth {
-	return &Auth{client: c}
+	client Client
 }
 
 func (auth *Auth) Methods(ctx context.Context, r *apimodels.ListAuthnMethodsRequest) (*apimodels.
 	ListAuthnMethodsResponse, error) {
 	var resp apimodels.ListAuthnMethodsResponse
-	err := auth.client.list(ctx, authBase, r, &resp)
+	err := auth.client.List(ctx, authBase, r, &resp)
 	return &resp, err
 }
 
 func (auth *Auth) Authenticate(ctx context.Context, r *apimodels.AuthnRequest) (*apimodels.AuthnResponse, error) {
 	var resp apimodels.AuthnResponse
-	err := auth.client.post(ctx, authBase+"/"+r.Name, r, &resp)
+	err := auth.client.Post(ctx, authBase+"/"+r.Name, r, &resp)
 	return &resp, err
 }

--- a/pkg/publicapi/client/v2/api_jobs.go
+++ b/pkg/publicapi/client/v2/api_jobs.go
@@ -11,18 +11,13 @@ import (
 const jobsPath = "/api/v1/orchestrator/jobs"
 
 type Jobs struct {
-	client *Client
-}
-
-// Jobs returns a handle on the jobs endpoints.
-func (c *Client) Jobs() *Jobs {
-	return &Jobs{client: c}
+	client Client
 }
 
 // Put is used to submit a new job to the cluster, or update an existing job with matching ID.
 func (j *Jobs) Put(ctx context.Context, r *apimodels.PutJobRequest) (*apimodels.PutJobResponse, error) {
 	var resp apimodels.PutJobResponse
-	if err := j.client.put(ctx, jobsPath, r, &resp); err != nil {
+	if err := j.client.Put(ctx, jobsPath, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -31,7 +26,7 @@ func (j *Jobs) Put(ctx context.Context, r *apimodels.PutJobRequest) (*apimodels.
 // Get is used to get a job by ID.
 func (j *Jobs) Get(ctx context.Context, r *apimodels.GetJobRequest) (*apimodels.GetJobResponse, error) {
 	var resp apimodels.GetJobResponse
-	if err := j.client.get(ctx, jobsPath+"/"+r.JobID, r, &resp); err != nil {
+	if err := j.client.Get(ctx, jobsPath+"/"+r.JobID, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -40,7 +35,7 @@ func (j *Jobs) Get(ctx context.Context, r *apimodels.GetJobRequest) (*apimodels.
 // List is used to list all jobs in the cluster.
 func (j *Jobs) List(ctx context.Context, r *apimodels.ListJobsRequest) (*apimodels.ListJobsResponse, error) {
 	var resp apimodels.ListJobsResponse
-	if err := j.client.list(ctx, jobsPath, r, &resp); err != nil {
+	if err := j.client.List(ctx, jobsPath, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -49,7 +44,7 @@ func (j *Jobs) List(ctx context.Context, r *apimodels.ListJobsRequest) (*apimode
 // History returns history events for a job.
 func (j *Jobs) History(ctx context.Context, r *apimodels.ListJobHistoryRequest) (*apimodels.ListJobHistoryResponse, error) {
 	var resp apimodels.ListJobHistoryResponse
-	if err := j.client.list(ctx, jobsPath+"/"+r.JobID+"/history", r, &resp); err != nil {
+	if err := j.client.List(ctx, jobsPath+"/"+r.JobID+"/history", r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -59,7 +54,7 @@ func (j *Jobs) History(ctx context.Context, r *apimodels.ListJobHistoryRequest) 
 func (j *Jobs) Executions(ctx context.Context, r *apimodels.ListJobExecutionsRequest) (*apimodels.ListJobExecutionsResponse,
 	error) {
 	var resp apimodels.ListJobExecutionsResponse
-	if err := j.client.list(ctx, jobsPath+"/"+r.JobID+"/executions", r, &resp); err != nil {
+	if err := j.client.List(ctx, jobsPath+"/"+r.JobID+"/executions", r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -68,7 +63,7 @@ func (j *Jobs) Executions(ctx context.Context, r *apimodels.ListJobExecutionsReq
 // Results returns results for a job.
 func (j *Jobs) Results(ctx context.Context, r *apimodels.ListJobResultsRequest) (*apimodels.ListJobResultsResponse, error) {
 	var resp apimodels.ListJobResultsResponse
-	if err := j.client.list(ctx, jobsPath+"/"+r.JobID+"/results", r, &resp); err != nil {
+	if err := j.client.List(ctx, jobsPath+"/"+r.JobID+"/results", r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -77,7 +72,7 @@ func (j *Jobs) Results(ctx context.Context, r *apimodels.ListJobResultsRequest) 
 // Stop is used to stop a job by ID.
 func (j *Jobs) Stop(ctx context.Context, r *apimodels.StopJobRequest) (*apimodels.StopJobResponse, error) {
 	var resp apimodels.StopJobResponse
-	if err := j.client.delete(ctx, jobsPath+"/"+r.JobID, r, &resp); err != nil {
+	if err := j.client.Delete(ctx, jobsPath+"/"+r.JobID, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -85,5 +80,5 @@ func (j *Jobs) Stop(ctx context.Context, r *apimodels.StopJobRequest) (*apimodel
 
 // Logs returns a stream of logs for a given job/execution.
 func (j *Jobs) Logs(ctx context.Context, r *apimodels.GetLogsRequest) (<-chan *concurrency.AsyncResult[models.ExecutionLog], error) {
-	return webSocketDialer[models.ExecutionLog](ctx, j.client, jobsPath+"/"+r.JobID+"/logs", r)
+	return webSocketDialer[models.ExecutionLog](ctx, j.client.(*httpClient), jobsPath+"/"+r.JobID+"/logs", r)
 }

--- a/pkg/publicapi/client/v2/api_nodes.go
+++ b/pkg/publicapi/client/v2/api_nodes.go
@@ -9,18 +9,13 @@ import (
 const nodesPath = "/api/v1/orchestrator/nodes"
 
 type Nodes struct {
-	client *Client
-}
-
-// Nodes returns a handle on the nodes endpoints.
-func (c *Client) Nodes() *Nodes {
-	return &Nodes{client: c}
+	client Client
 }
 
 // Get is used to get a node by ID.
 func (c *Nodes) Get(ctx context.Context, r *apimodels.GetNodeRequest) (*apimodels.GetNodeResponse, error) {
 	var resp apimodels.GetNodeResponse
-	if err := c.client.get(ctx, nodesPath+"/"+r.NodeID, r, &resp); err != nil {
+	if err := c.client.Get(ctx, nodesPath+"/"+r.NodeID, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -29,7 +24,7 @@ func (c *Nodes) Get(ctx context.Context, r *apimodels.GetNodeRequest) (*apimodel
 // List is used to list all nodes in the cluster.
 func (c *Nodes) List(ctx context.Context, r *apimodels.ListNodesRequest) (*apimodels.ListNodesResponse, error) {
 	var resp apimodels.ListNodesResponse
-	if err := c.client.list(ctx, nodesPath, r, &resp); err != nil {
+	if err := c.client.List(ctx, nodesPath, r, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/pkg/publicapi/client/v2/errors.go
+++ b/pkg/publicapi/client/v2/errors.go
@@ -178,6 +178,6 @@ func requireStatusIn(statuses ...int) doRequestWrapper {
 			}
 		}
 
-		return d, nil, newUnexpectedResponseError(fromHTTPResponse(resp), withExpectedStatuses(statuses))
+		return d, resp, newUnexpectedResponseError(fromHTTPResponse(resp), withExpectedStatuses(statuses))
 	}
 }

--- a/pkg/publicapi/client/v2/options.go
+++ b/pkg/publicapi/client/v2/options.go
@@ -13,8 +13,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-
-	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 )
 
 type Config struct {
@@ -27,9 +25,6 @@ type Config struct {
 	// HTTPClient is the client to use. Default will be used if not provided.
 	// If set, other configuration options will be ignored, such as Timeout
 	HTTPClient *http.Client
-
-	// HTTPAuth is the auth info to use for http access.
-	HTTPAuth *apimodels.HTTPCredential
 
 	// Timeout is the timeout for requests.
 	Timeout time.Duration
@@ -107,13 +102,6 @@ func WithAppID(appID string) OptionFn {
 func WithHTTPClient(client *http.Client) OptionFn {
 	return func(o *Config) {
 		o.HTTPClient = client
-	}
-}
-
-// WithHTTPAuth sets the auth info to use for http access.
-func WithHTTPAuth(credential *apimodels.HTTPCredential) OptionFn {
-	return func(o *Config) {
-		o.HTTPAuth = credential
 	}
 }
 

--- a/pkg/publicapi/client/v2/util.go
+++ b/pkg/publicapi/client/v2/util.go
@@ -101,7 +101,7 @@ func autoUnzip(resp *http.Response) error {
 	return nil
 }
 
-func webSocketDialer[T any](ctx context.Context, c *Client, endpoint string, in apimodels.GetRequest) (
+func webSocketDialer[T any](ctx context.Context, c *httpClient, endpoint string, in apimodels.GetRequest) (
 	<-chan *concurrency.AsyncResult[T], error) {
 	r := in.ToHTTPRequest()
 	httpR, err := c.toHTTP(ctx, http.MethodGet, endpoint, r)

--- a/pkg/publicapi/middleware/authz.go
+++ b/pkg/publicapi/middleware/authz.go
@@ -14,8 +14,10 @@ func Authorize(authorizer authz.Authorizer) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			if result, err := authorizer.Authorize(c.Request()); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-			} else if !result.Approved {
-				return echo.NewHTTPError(http.StatusForbidden, "unauthorized. "+result.Reason)
+			} else if !result.Approved && result.TokenValid {
+				return echo.NewHTTPError(http.StatusForbidden, "Access denied. "+result.Reason)
+			} else if !result.Approved && !result.TokenValid {
+				return echo.NewHTTPError(http.StatusUnauthorized, "Invalid token. "+result.Reason)
 			} else {
 				return next(c)
 			}

--- a/pkg/publicapi/test/setup_test.go
+++ b/pkg/publicapi/test/setup_test.go
@@ -20,11 +20,11 @@ import (
 type ServerSuite struct {
 	suite.Suite
 	server        *publicapi.Server
-	client        *client.Client
+	client        client.API
 	requesterNode *node.Node
 
 	computeNode   *node.Node
-	computeClient *client.Client
+	computeClient client.API
 }
 
 func (s *ServerSuite) SetupSuite() {

--- a/pkg/publicapi/test/tools.go
+++ b/pkg/publicapi/test/tools.go
@@ -14,7 +14,7 @@ import (
 const TimeToWaitForServerReply = 10 * time.Second
 const TimeToWaitForHealthy = 50 * time.Millisecond
 
-func WaitFor(ctx context.Context, c *client.Client, condition func(context.Context, *client.Client) bool) error {
+func WaitFor(ctx context.Context, c client.API, condition func(context.Context, client.API) bool) error {
 	ch := make(chan bool)
 	go func() {
 		for {
@@ -37,8 +37,8 @@ func WaitFor(ctx context.Context, c *client.Client, condition func(context.Conte
 }
 
 // WaitForAlive waits for the server to be alive
-func WaitForAlive(ctx context.Context, c *client.Client) error {
-	return WaitFor(ctx, c, func(ctx context.Context, apiClient *client.Client) bool {
+func WaitForAlive(ctx context.Context, c client.API) error {
+	return WaitFor(ctx, c, func(ctx context.Context, apiClient client.API) bool {
 		res, err := apiClient.Agent().Alive(ctx)
 		if err != nil {
 			log.Warn().Err(err).Msg("failed to check if server is alive")
@@ -49,8 +49,8 @@ func WaitForAlive(ctx context.Context, c *client.Client) error {
 }
 
 // WaitForNodes waits for the server to be alive and for the node to discover itself
-func WaitForNodes(ctx context.Context, c *client.Client) error {
-	return WaitFor(ctx, c, func(ctx context.Context, apiClient *client.Client) bool {
+func WaitForNodes(ctx context.Context, c client.API) error {
+	return WaitFor(ctx, c, func(ctx context.Context, apiClient client.API) bool {
 		res, err := apiClient.Nodes().List(ctx, &apimodels.ListNodesRequest{})
 		if err != nil {
 			log.Warn().Err(err).Msg("failed to list nodes. retrying...")

--- a/pkg/publicapi/test/util_test.go
+++ b/pkg/publicapi/test/util_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
-func setupNodeForTest(t *testing.T) (*node.Node, *client.Client) {
+func setupNodeForTest(t *testing.T) (*node.Node, client.API) {
 	// blank config should result in using defaults in node.Node constructor
 	return setupNodeForTestWithConfig(t, publicapi.Config{})
 }
 
-func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.Node, *client.Client) {
+func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.Node, client.API) {
 	repo := setup.SetupBacalhauRepoForTesting(t)
 	ctx := context.Background()
 

--- a/pkg/test/utils/utils.go
+++ b/pkg/test/utils/utils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
-func GetJobFromTestOutput(ctx context.Context, t *testing.T, c *clientv2.Client, out string) *models.Job {
+func GetJobFromTestOutput(ctx context.Context, t *testing.T, c clientv2.API, out string) *models.Job {
 	jobID := system.FindJobIDInTestOutput(out)
 	uuidRegex := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 	require.Regexp(t, uuidRegex, jobID, "Job ID should be a UUID")

--- a/test/bin/bacalhau.sh
+++ b/test/bin/bacalhau.sh
@@ -2,6 +2,7 @@ export IFS=$'\n\t'
 
 new_repo() {
     export BACALHAU_DIR=$(mktemp -d)
+    export BACALHAU_UPDATE_SKIPCHECKS=true
     bacalhau id >/dev/null 2>&1
 }
 

--- a/test/secret_auth.sh
+++ b/test/secret_auth.sh
@@ -8,6 +8,9 @@ setup() {
     bacalhau config set auth.accesspolicypath "$ROOT/pkg/authz/policies/policy_ns_anon.rego"
     } >/dev/null
 
+    subject 'bacalhau config list | grep auth.methods'
+    assert_match 'shared_secret' $stdout
+
     create_node requester
 
     subject ls $BACALHAU_DIR/tokens.json
@@ -38,5 +41,24 @@ testcase_invalid_token_is_rejected_and_not_persisted() {
     assert_not_equal '[]' $stdout
 
     subject cat $BACALHAU_DIR/tokens.json
-    assert_equal '' $stdout
+    assert_equal '{}' $stdout
+}
+
+testcase_invalid_or_expired_token_is_removed() {
+    setup
+    testcase_valid_token_is_accepted
+
+    subject cat $BACALHAU_DIR/tokens.json
+    assert_not_equal '' $stdout
+
+    INVALID_TOKEN='eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxNTE2MjM5MDIyLCJpYXQiOjE1MTYyMzkwMjIsIm5zIjp7IioiOjd9fQ.lNkaXliBT2wmnG95ZnI2jq7P4SEgBQlb23XeSa9Ds9DRjHDYi8-Bt99vmh8TVGCx9RMBLu8b1EXRcZI0iuR7XwuCXmRaW9vKjDClpHSnkSyQL3vWpw9zVKIf3OLt5dsqXkxOn3BfUwf3XmMqWfrrDM8MGGk5Zn5jPP3O0eMjFKteI8mwXjaZJlOnmbIjrKAeg9-Vvyswgme4OFioM9g1Lgz81tqoZzJWMmx6uwwM2Uv1FLV9bHhUcl4eRr3Es_SBOvRkVoU_cIh24TitxD_kBabof_PCjvpdzVkuZzOMvD3BNuvgpO6tbRJaqnPl9iks65Fn0Q56mC33Q18ijVw5bQ'
+    jq -rc "{(keys[0]): \"$INVALID_TOKEN\"}" <$BACALHAU_DIR/tokens.json >$BACALHAU_DIR/tokens.temp
+    mv $BACALHAU_DIR/tokens.temp $BACALHAU_DIR/tokens.json
+
+    subject 'bacalhau job list --output=json </dev/null'
+    assert_not_equal 0 $status
+    assert_not_equal '[]' $stdout
+
+    subject cat $BACALHAU_DIR/tokens.json
+    assert_equal '{}' $stdout
 }


### PR DESCRIPTION
This PR allows the Bacalhau CLI (and optionally users of the SDK) to automatically remove tokens that the server says are not valid, e.g. because they have expired or because the server no longer recognises the signing authority.

In particular, this process is transparent to the rest of the system - the authentication happens as part of a normal API call, and the API call doesn't complete until the authentication flow is done. Naturally this is an opt-in for anyone using the Bacalhau codebase as a library because this might not be desired.

This involved splitting the transport parts of the API out from the domain-specific parts so that the authentication code could monitor for invalid auth tokens and invoke the authentication flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the authentication flow across the application for better security and user experience.
	- Streamlined API client usage with improved token management.
- **New Features**
	- Implemented a more robust authorization mechanism, including checks for token validity.
- **Bug Fixes**
	- Fixed an issue to ensure expired or invalid tokens are correctly removed, enhancing security.
- **Tests**
	- Added new test cases to validate the improved authentication and authorization mechanisms.
- **Chores**
	- Updated internal utilities and dependencies for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->