### PR TITLE
Adds a node approval state to the node info

### DIFF
--- a/pkg/models/node_approval.go
+++ b/pkg/models/node_approval.go
@@ -1,0 +1,39 @@
+package models
+
+import "fmt"
+
+// NodeApproval is used to denote the approval status of a given
+// node. These values are set based on the approval process for
+// nodes which will auto-approve some, rely on human approval for
+// others as well as rejecting some nodes as inelligible.
+type NodeApproval string
+
+const (
+	NodeApprovalUnknown  NodeApproval = "unknown"
+	NodeApprovalPending  NodeApproval = "pending"
+	NodeApprovalApproved NodeApproval = "approved"
+	NodeApprovalRejected NodeApproval = "rejected"
+)
+
+// ParseApproval accepts a string representation of a NodeApproval
+// and returns the matching NodeApproval value, or an error if
+// the string cannot be matched to a NodeApproval value.
+func ParseApproval(s string) (NodeApproval, error) {
+	switch s {
+	case "pending":
+		return NodeApprovalPending, nil
+	case "approved":
+		return NodeApprovalApproved, nil
+	case "rejected":
+		return NodeApprovalRejected, nil
+	case "unknown":
+		return NodeApprovalUnknown, nil
+	default:
+		return NodeApprovalUnknown, fmt.Errorf("invalid approval status: %s", s)
+	}
+}
+
+// String returns the string representation of the NodeApproval
+func (e NodeApproval) String() string {
+	return string(e)
+}

--- a/pkg/models/node_info.go
+++ b/pkg/models/node_info.go
@@ -83,6 +83,7 @@ type NodeInfo struct {
 	Labels          map[string]string `json:"Labels"`
 	ComputeNodeInfo *ComputeNodeInfo  `json:"ComputeNodeInfo,omitempty" yaml:",omitempty"`
 	BacalhauVersion BuildVersionInfo  `json:"BacalhauVersion"`
+	Approval        NodeApproval      `json:"Approval"`
 }
 
 // ID returns the node ID

--- a/pkg/routing/node_info_provider.go
+++ b/pkg/routing/node_info_provider.go
@@ -39,6 +39,7 @@ func (n *NodeInfoProvider) GetNodeInfo(ctx context.Context) models.NodeInfo {
 		BacalhauVersion: n.bacalhauVersion,
 		Labels:          n.labelsProvider.GetLabels(ctx),
 		NodeType:        models.NodeTypeRequester,
+		Approval:        models.NodeApprovalUnknown,
 	}
 	for _, decorator := range n.nodeInfoDecorators {
 		res = decorator.DecorateNodeInfo(ctx, res)

--- a/pkg/routing/node_info_provider.go
+++ b/pkg/routing/node_info_provider.go
@@ -39,7 +39,7 @@ func (n *NodeInfoProvider) GetNodeInfo(ctx context.Context) models.NodeInfo {
 		BacalhauVersion: n.bacalhauVersion,
 		Labels:          n.labelsProvider.GetLabels(ctx),
 		NodeType:        models.NodeTypeRequester,
-		Approval:        models.NodeApprovalUnknown,
+		Approval:        models.NodeApprovals.PENDING,
 	}
 	for _, decorator := range n.nodeInfoDecorators {
 		res = decorator.DecorateNodeInfo(ctx, res)


### PR DESCRIPTION
Adds a new node approval field to the node_info structure where we currently track information about nodes in the cluster.
The approval field currently defaults to unknown, and is not yet used for anything.  This will be used after:

* Persistent node store can pass filters to list()
* There is a registration endpoint
* The CLI can list/approve/reject nodes.