### PR TITLE
Make it easier to build _just_ the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,8 @@ build-webui:
 ################################################################################
 # Target: build-bacalhau
 ################################################################################
+${BINARY_PATH}: build-bacalhau build-plugins
+
 .PHONY: build-bacalhau
 build-bacalhau: binary-web binary
 

--- a/Makefile
+++ b/Makefile
@@ -175,13 +175,17 @@ build-webui:
 # Target: build-bacalhau
 ################################################################################
 .PHONY: build-bacalhau
-build-bacalhau: ${BINARY_PATH}
+build-bacalhau: binary-web binary
 
 CMD_FILES := $(shell bash -c 'comm -23 <(git ls-files cmd | sort) <(git ls-files cmd --deleted | sort)')
 PKG_FILES := $(shell bash -c 'comm -23 <(git ls-files pkg | sort) <(git ls-files pkg --deleted | sort)')
 
-${BINARY_PATH}: ${CMD_FILES} ${PKG_FILES} build-webui ${WEB_GO_FILES} main.go
+.PHONY: binary
+
+binary: ${CMD_FILES} ${PKG_FILES} main.go
 	${GO} build -ldflags "${BUILD_FLAGS}" -trimpath -o ${BINARY_PATH} .
+
+binary-web: build-webui ${WEB_GO_FILES}
 
 ################################################################################
 # Target: build-docker-images


### PR DESCRIPTION
Currently if you want to build the bacalhau binary, you also have to build the webui and plugins as well, even if you've no intention of using them.

This change adds:

### make binary 

Just builds the bacalhau binary (assuming webui is available already for embedding).

### make binary-web
 
Builds the webui ready for embedding in the binary

### make build-bacalhau 

The existing step now calls binary-web and then binary.

### make build 

Does the same as always