### PR TITLE
Hide NATS auth token if the user supplied it

### DIFF
--- a/test/bin/bashtub
+++ b/test/bin/bashtub
@@ -52,6 +52,11 @@ assert_match_matcher() {
   [[ "$2" =~ "$1" ]]
 }
 
+assert_not_match_matcher() {
+  echo "\`$2' was not expected to match \`$1'"
+  [[ ! "$2" =~ "$1" ]]
+}
+
 assert_true_matcher() {
   echo "\`$*' was expected to return true"
   subject "$@"

--- a/test/node_auth.sh
+++ b/test/node_auth.sh
@@ -16,7 +16,23 @@ testcase_node_can_connect_with_correct_token() {
     # If this returns successfully, the node started and authenticated.
 }
 
+testcase_preconfigured_token_not_printed() {
+    subject bacalhau config set node.network.type nats
+    subject bacalhau config set node.network.authsecret kerfuffle
+    assert_equal 0 $status
+    create_node requester
+
+    subject grep BACALHAU_NODE_NETWORK_ORCHESTRATORS $BACALHAU_DIR/out.log
+    assert_equal 0 $status
+    assert_not_match kerfuffle $stdout
+
+    subject grep BACALHAU_NODE_NETWORK_ORCHESTRATORS $BACALHAU_DIR/bacalhau.run
+    assert_equal 0 $status
+    assert_not_match kerfuffle $stdout
+}
+
 testcase_node_connects_with_preconfigured_token() {
+    subject bacalhau config set node.network.type nats
     subject bacalhau config set node.network.authsecret kerfuffle
     assert_match 0 $status
     create_node requester
@@ -25,6 +41,7 @@ testcase_node_connects_with_preconfigured_token() {
     export BACALHAU_NODE_NETWORK_ORCHESTRATORS=$(echo $BACALHAU_NODE_NETWORK_ORCHESTRATORS | sed "s:[^\/]*@::")
     new_repo
     subject bacalhau config set node.network.authsecret kerfuffle
+    subject bacalhau config set node.network.type nats
     create_node compute
     # If this returns successfully, the node started and authenticated.
 }


### PR DESCRIPTION
We shouldn't print auth tokens unless absolutely necessary. Now the system will hide the auth token if the user supplied it explicitly.

Resolves #3490.