### PR TITLE
Adds support for filtering of the List command in NodeInfoStores

### DIFF
--- a/pkg/routing/inmemory/inmemory_test.go
+++ b/pkg/routing/inmemory/inmemory_test.go
@@ -4,6 +4,7 @@ package inmemory_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,6 +117,39 @@ func (s *InMemoryNodeStoreSuite) Test_List() {
 	allNodeInfos, err := s.store.List(ctx)
 	s.NoError(err)
 	s.ElementsMatch([]models.NodeInfo{nodeInfo0, nodeInfo1}, allNodeInfos)
+}
+
+func (s *InMemoryNodeStoreSuite) Test_ListWithFilters() {
+	ctx := context.Background()
+	nodeInfo0 := generateNodeInfo(s.T(), nodeIDs[0], models.EngineDocker)
+	nodeInfo1 := generateNodeInfo(s.T(), nodeIDs[1], models.EngineWasm)
+	s.NoError(s.store.Add(ctx, nodeInfo0))
+	s.NoError(s.store.Add(ctx, nodeInfo1))
+
+	// Match one record
+	filterPartialID := func(node models.NodeInfo) bool {
+		return strings.HasPrefix(node.ID(), string(nodeIDs[0][0:8]))
+	}
+	nodes, err := s.store.List(ctx, filterPartialID)
+	s.NoError(err)
+	s.Equal(1, len(nodes))
+	s.Equal(nodeIDs[0], nodes[0].ID())
+
+	// Match all records
+	filterPartialID = func(node models.NodeInfo) bool {
+		return strings.HasPrefix(node.ID(), "Qm")
+	}
+	nodes, err = s.store.List(ctx, filterPartialID)
+	s.NoError(err)
+	s.Equal(2, len(nodes))
+
+	// Match no records
+	filterPartialID = func(node models.NodeInfo) bool {
+		return strings.HasPrefix(node.ID(), "XYZ")
+	}
+	nodes, err = s.store.List(ctx, filterPartialID)
+	s.NoError(err)
+	s.Equal(0, len(nodes))
 }
 
 func (s *InMemoryNodeStoreSuite) Test_Delete() {

--- a/pkg/routing/tracing/tracing.go
+++ b/pkg/routing/tracing/tracing.go
@@ -74,7 +74,7 @@ func (r *NodeStore) FindPeer(ctx context.Context, peerID peer.ID) (peer.AddrInfo
 	return r.delegate.FindPeer(ctx, peerID)
 }
 
-func (r *NodeStore) List(ctx context.Context) ([]models.NodeInfo, error) {
+func (r *NodeStore) List(ctx context.Context, filters ...routing.NodeInfoFilter) ([]models.NodeInfo, error) {
 	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoStore.List") //nolint:govet
 	defer span.End()
 
@@ -86,7 +86,7 @@ func (r *NodeStore) List(ctx context.Context) ([]models.NodeInfo, error) {
 			Msg("node listed")
 	}()
 
-	return r.delegate.List(ctx)
+	return r.delegate.List(ctx, filters...)
 }
 
 func (r *NodeStore) Delete(ctx context.Context, nodeID string) error {

--- a/pkg/routing/types.go
+++ b/pkg/routing/types.go
@@ -22,8 +22,14 @@ type NodeInfoStore interface {
 	GetByPrefix(ctx context.Context, prefix string) (models.NodeInfo, error)
 
 	// List returns a list of nodes
-	List(ctx context.Context) ([]models.NodeInfo, error)
+	List(ctx context.Context, filters ...NodeInfoFilter) ([]models.NodeInfo, error)
 
 	// Delete deletes a node info from the repo.
 	Delete(ctx context.Context, nodeID string) error
 }
+
+// NodeInfoFilter is a function that filters node info
+// when listing nodes. It returns true if the node info
+// should be returned, and false if the node info should
+// be ignored.
+type NodeInfoFilter func(models.NodeInfo) bool


### PR DESCRIPTION
Currently when listing node info in the NodeInfoStores, it is all or nothing, and there is no way to narrow down the list.

This PR adds support for passing varargs of filter functions so that we can do things like easily filter by approval state, or GPU count, or specific labels.  It is expected that these filter functions will be pre-defined rather than expecting them to be constructed as required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced node information retrieval with advanced filtering capabilities.
- **Tests**
	- Added tests for the new filtering functionality in node listing.
- **Refactor**
	- Updated interfaces and methods to support advanced node information filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->