### PR TITLE
Address type resolution in publisher not server

### DIFF
--- a/pkg/publisher/local/server.go
+++ b/pkg/publisher/local/server.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
 	"github.com/rs/zerolog/log"
 )
 
@@ -24,26 +23,9 @@ const (
 func NewLocalPublisherServer(ctx context.Context, directory, address string, port int) *LocalPublisherServer {
 	return &LocalPublisherServer{
 		rootDirectory: directory,
-		address:       resolveAddress(ctx, address),
+		address:       address,
 		port:          port,
 	}
-}
-
-func resolveAddress(ctx context.Context, address string) string {
-	addressType, ok := network.AddressTypeFromString(address)
-	if !ok {
-		return address
-	}
-
-	// If we were provided with an address type and not an address, so we should look up
-	// an address from the type.
-	addrs, err := network.GetNetworkAddress(addressType, network.AllAddresses)
-	if err == nil && len(addrs) > 0 {
-		return addrs[0]
-	}
-
-	log.Ctx(ctx).Error().Err(err).Stringer("AddressType", addressType).Msgf("unable to find address for type, using 127.0.0.1")
-	return "127.0.0.1"
 }
 
 func (s *LocalPublisherServer) Run(ctx context.Context) {


### PR DESCRIPTION
Currently we're doing address type resolution in the (local publisher) server, which means if we were to choose 'public' as the address to bind to, the server would find and use a public address, but the local publisher would report 'http://public:....'.

This PR moves address type resolution to the publisher itself, so that it can compose a URL with the correct IP, and the server is given the correct IP at the beginning.

Fixes #3554