### PR TITLE
Live compute-node resource tracking

### DIFF
--- a/pkg/compute/types.go
+++ b/pkg/compute/types.go
@@ -51,6 +51,8 @@ type ManagementEndpoint interface {
 	Register(context.Context, requests.RegisterRequest) (*requests.RegisterResponse, error)
 	// UpdateInfo sends an update of node info to the requester node
 	UpdateInfo(context.Context, requests.UpdateInfoRequest) (*requests.UpdateInfoResponse, error)
+	// UpdateResources updates the resources currently in use by a specific node
+	UpdateResources(context.Context, requests.UpdateResourcesRequest) (*requests.UpdateResourcesResponse, error)
 }
 
 ///////////////////////////////////

--- a/pkg/lib/concurrency/striped_map.go
+++ b/pkg/lib/concurrency/striped_map.go
@@ -1,0 +1,91 @@
+package concurrency
+
+import (
+	"hash/crc32"
+	"sync"
+)
+
+const (
+	defaultStripeCount int = 16
+)
+
+type StripedMap[T any] struct {
+	stripeCount int
+	maps        []map[string]T
+	locks       []sync.RWMutex
+}
+
+func NewStripedMap[T any](numStripes int) *StripedMap[T] {
+	count := numStripes
+	if count == 0 {
+		count = defaultStripeCount
+	}
+
+	s := &StripedMap[T]{
+		stripeCount: count,
+	}
+
+	for i := 0; i < count; i++ {
+		s.maps = append(s.maps, make(map[string]T))
+		s.locks = append(s.locks, sync.RWMutex{})
+	}
+
+	return s
+}
+
+func (s *StripedMap[T]) Put(key string, value T) {
+	idx := s.hash(key)
+
+	s.locks[idx].Lock()
+	s.maps[idx][key] = value
+	s.locks[idx].Unlock()
+}
+
+func (s *StripedMap[T]) Get(key string) (T, bool) {
+	idx := s.hash(key)
+
+	s.locks[idx].RLock()
+	defer s.locks[idx].RUnlock()
+
+	v, ok := s.maps[idx][key]
+	return v, ok
+}
+
+func (s *StripedMap[T]) Delete(key string) {
+	idx := s.hash(key)
+
+	s.locks[idx].Lock()
+	defer s.locks[idx].Unlock()
+
+	delete(s.maps[idx], key)
+}
+
+func (s *StripedMap[T]) Len() int {
+	count := 0
+
+	for i := 0; i < s.stripeCount; i++ {
+		s.locks[i].RLock()
+		defer s.locks[i].RUnlock()
+		count += len(s.maps[i])
+	}
+
+	return count
+}
+
+func (s *StripedMap[T]) LengthsPerStripe() map[int]int {
+	m := make(map[int]int)
+
+	for i := 0; i < s.stripeCount; i++ {
+		s.locks[i].RLock()
+		defer s.locks[i].RUnlock()
+
+		m[i] = len(s.maps[i])
+	}
+
+	return m
+}
+
+func (s *StripedMap[T]) hash(key string) int {
+	hashSum := crc32.ChecksumIEEE([]byte(key))
+	return int(hashSum) % s.stripeCount
+}

--- a/pkg/lib/concurrency/striped_map_test.go
+++ b/pkg/lib/concurrency/striped_map_test.go
@@ -1,0 +1,112 @@
+//go:build unit || !integration
+
+package concurrency_test
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	cc "github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
+	"github.com/stretchr/testify/suite"
+)
+
+type StripedMapSuite struct {
+	suite.Suite
+}
+
+func TestStripedMapSuite(t *testing.T) {
+	suite.Run(t, new(StripedMapSuite))
+}
+
+func (s *StripedMapSuite) TestNewStripedMap() {
+	m := cc.NewStripedMap[int](0)
+	s.Require().NotNil(m)
+	s.Require().Equal(16, len(m.LengthsPerStripe()))
+
+	m = cc.NewStripedMap[int](32)
+	s.Require().NotNil(m)
+	s.Require().Equal(32, len(m.LengthsPerStripe()))
+}
+
+func (s *StripedMapSuite) TestBasic() {
+	m := cc.NewStripedMap[int](16)
+	s.Require().NotNil(m)
+
+	m.Put("a", 1)
+	m.Put("b", 2)
+	m.Put("c", 3)
+
+	v, ok := m.Get("a")
+	s.Require().True(ok)
+	s.Require().Equal(1, v)
+
+	v, ok = m.Get("d")
+	s.Require().False(ok)
+	s.Require().Equal(0, v)
+
+	// This should never change unless we change the
+	// hash function that we use to allocate buckets.
+	mm := m.LengthsPerStripe()
+	s.Require().Equal(1, mm[3])
+	s.Require().Equal(1, mm[9])
+	s.Require().Equal(1, mm[15])
+
+	s.Require().Equal(3, m.Len())
+	m.Delete("a")
+	s.Require().Equal(2, m.Len())
+}
+
+func subtest(m *cc.StripedMap[int]) {
+	// No longer necessary in Go 1.2 to call Seed
+	// rand.Seed(time.Now().UnixNano())
+
+	min, max := 20, 200
+	iters := rand.Intn(max-min+1) + min
+
+	min, max = 0, 1000
+	for i := 0; i < iters; i++ {
+		putVal := rand.Intn(max-min+1) + min
+		getVal := rand.Intn(max-min+1) + min
+
+		m.Put(strconv.Itoa(i), putVal)
+		_, _ = m.Get(strconv.Itoa(getVal))
+
+		// Occassionally delete some stuff
+		pc := rand.Int31n(100)
+		if pc > 90 {
+			m.Delete(strconv.Itoa(getVal))
+		}
+	}
+}
+
+func (s *StripedMapSuite) TestConcurrent() {
+	wg := sync.WaitGroup{}
+	m := cc.NewStripedMap[int](16)
+
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			subtest(m)
+			wg.Done()
+		}()
+	}
+
+	// We don't want to wait forever, so we'll wait for
+	// at max a few seconds
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+
+	select {
+	case <-c:
+		return
+	case <-time.After(3 * time.Second):
+		s.Fail("striped map concurrency test took too long to complete, is it blocked?")
+	}
+}

--- a/pkg/lib/concurrency/striped_map_test.go
+++ b/pkg/lib/concurrency/striped_map_test.go
@@ -59,6 +59,29 @@ func (s *StripedMapSuite) TestBasic() {
 	s.Require().Equal(2, m.Len())
 }
 
+func (s *StripedMapSuite) TestEdgeCases() {
+	m := cc.NewStripedMap[int](16)
+	s.Require().NotNil(m)
+
+	m.Put("a", 1)
+	m.Put("a", 1)
+	m.Put("b", 2)
+	m.Put("c", 3)
+	m.Put("c", 3)
+
+	v, ok := m.Get("a")
+	s.Require().True(ok)
+	s.Require().Equal(1, v)
+
+	v, ok = m.Get("d")
+	s.Require().False(ok)
+	s.Require().Equal(0, v)
+
+	s.Require().Equal(3, m.Len())
+	m.Delete("d")
+	s.Require().Equal(3, m.Len())
+}
+
 func subtest(m *cc.StripedMap[int]) {
 	// No longer necessary in Go 1.2 to call Seed
 	// rand.Seed(time.Now().UnixNano())

--- a/pkg/lib/concurrency/striped_map_test.go
+++ b/pkg/lib/concurrency/striped_map_test.go
@@ -82,30 +82,9 @@ func (s *StripedMapSuite) TestEdgeCases() {
 	s.Require().Equal(3, m.Len())
 }
 
-func subtest(m *cc.StripedMap[int]) {
-	// No longer necessary in Go 1.2 to call Seed
-	// rand.Seed(time.Now().UnixNano())
-
-	min, max := 20, 200
-	iters := rand.Intn(max-min+1) + min
-
-	min, max = 0, 1000
-	for i := 0; i < iters; i++ {
-		putVal := rand.Intn(max-min+1) + min
-		getVal := rand.Intn(max-min+1) + min
-
-		m.Put(strconv.Itoa(i), putVal)
-		_, _ = m.Get(strconv.Itoa(getVal))
-
-		// Occassionally delete some stuff
-		pc := rand.Int31n(100)
-		if pc > 90 {
-			m.Delete(strconv.Itoa(getVal))
-		}
-	}
-}
-
 func (s *StripedMapSuite) TestConcurrent() {
+	// Run lots of go routines doing hundreds of ops as a fuzz test.
+	// This is more of a fuzz test than a proper unit test.
 	wg := sync.WaitGroup{}
 	m := cc.NewStripedMap[int](16)
 
@@ -131,5 +110,28 @@ func (s *StripedMapSuite) TestConcurrent() {
 		return
 	case <-time.After(3 * time.Second):
 		s.Fail("striped map concurrency test took too long to complete, is it blocked?")
+	}
+}
+
+func subtest(m *cc.StripedMap[int]) {
+	// No longer necessary in Go 1.2 to call Seed
+	// rand.Seed(time.Now().UnixNano())
+
+	min, max := 20, 200
+	iters := rand.Intn(max-min+1) + min
+
+	min, max = 0, 1000
+	for i := 0; i < iters; i++ {
+		putVal := rand.Intn(max-min+1) + min
+		getVal := rand.Intn(max-min+1) + min
+
+		m.Put(strconv.Itoa(i), putVal)
+		_, _ = m.Get(strconv.Itoa(getVal))
+
+		// Occassionally delete some stuff
+		pc := rand.Int31n(100)
+		if pc > 90 {
+			m.Delete(strconv.Itoa(getVal))
+		}
 	}
 }

--- a/pkg/models/requests/management.go
+++ b/pkg/models/requests/management.go
@@ -18,3 +18,10 @@ type UpdateInfoResponse struct {
 	Accepted bool
 	Reason   string
 }
+
+type UpdateResourcesRequest struct {
+	NodeID    string
+	Resources models.Resources
+}
+
+type UpdateResourcesResponse struct{}

--- a/pkg/nats/proxy/constants.go
+++ b/pkg/nats/proxy/constants.go
@@ -18,8 +18,9 @@ const (
 	OnCancelComplete = "OnCancelComplete/v1"
 	OnComputeFailure = "OnComputeFailure/v1"
 
-	RegisterNode   = "RegisterNode/v1"
-	UpdateNodeInfo = "UpdateNodeInfo/v1"
+	RegisterNode    = "RegisterNode/v1"
+	UpdateNodeInfo  = "UpdateNodeInfo/v1"
+	UpdateResources = "UpdateResources/v1"
 )
 
 func computeEndpointPublishSubject(nodeID string, method string) string {

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -249,6 +249,7 @@ func NewComputeNode(
 			ManagementProxy:      managementProxy,
 			NodeInfoDecorator:    nodeInfoDecorator,
 			RegistrationFilePath: regFilename,
+			ResourceTracker:      runningCapacityTracker,
 		})
 		if err := managementClient.RegisterNode(ctx); err != nil {
 			return nil, fmt.Errorf("failed to register node with requester: %s", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -280,6 +280,16 @@ func NewNode(
 			NodeInfo: tracingInfoStore,
 		})
 
+		// NodeManager node wraps the node manager and implements the routing.NodeInfoStore
+		// interface so that it can return nodes and add the most recent resource information
+		// to the node info returned.  When the libp2p transport is no longer necessary, we
+		// can remove the parameter from the NewRequesterNode call and use the nodeManager
+		// instead.
+		legacyInfoStore := tracingInfoStore
+		if config.NetworkConfig.Type == models.NetworkTypeNATS {
+			legacyInfoStore = nodeManager
+		}
+
 		requesterNode, err = NewRequesterNode(
 			ctx,
 			config.NodeID,
@@ -287,7 +297,7 @@ func NewNode(
 			config.RequesterNodeConfig,
 			storageProviders,
 			authenticators,
-			tracingInfoStore,
+			legacyInfoStore,
 			transportLayer.ComputeProxy(),
 			nodeManager,
 		)

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -58,7 +58,7 @@ func NewRequesterNode(
 	requesterConfig RequesterConfig,
 	storageProvider storage.StorageProvider,
 	authnProvider authn.Provider,
-	nodeInfoStore routing.NodeInfoStore,
+	nodeInfoStore routing.NodeInfoStore, // for libp2p store only, once removed remove this in favour of nodeManager
 	computeProxy compute.Endpoint,
 	nodeManager *manager.NodeManager,
 ) (*Requester, error) {


### PR DESCRIPTION
When using NATS, the compute node will now report latest resource
availability every 30 seconds to the requester node.  This info is then
added to any NodeInfo structures returned as part of requests to the
NodeInfoStore.

This is achieved by the NodeManager implementing both the Management API
and the NodeInfoStore API where it delegates to the persistent store and
adds the latest resource info. This resource info is held in a Striped/Partitioned 
map to reduce lock contention issues (e.g. we only have to lock the bucket 
where the key hashes to, not the whole map).

We might in later versions want to timestamp the resources (with a
server only timestamp) so that the server can be away how out of sync
the resource updates are.
