### PR TITLE
Ensure compute node does not open jobstore

### DIFF
--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -208,11 +208,12 @@ func runDevstack(cmd *cobra.Command, ODs *devstack.DevStackOptions, IsNoop bool)
 		}
 	}
 
-	computeConfig, err := serve.GetComputeConfig(ctx)
+	computeConfig, err := serve.GetComputeConfig(ctx, true)
 	if err != nil {
 		return err
 	}
-	requesterConfig, err := serve.GetRequesterConfig(ctx)
+
+	requesterConfig, err := serve.GetRequesterConfig(ctx, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -215,12 +215,12 @@ func serve(cmd *cobra.Command) error {
 		networkConfig.ClusterPeers = peers
 	}
 
-	computeConfig, err := GetComputeConfig(ctx)
+	computeConfig, err := GetComputeConfig(ctx, isComputeNode)
 	if err != nil {
 		return err
 	}
 
-	requesterConfig, err := GetRequesterConfig(ctx)
+	requesterConfig, err := GetRequesterConfig(ctx, isRequesterNode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
During startup of a compute only node (using serve) the requester config is retrieved, and as part of that a reference to the jobstore is created.  This means that if we run a separate requester and compute, the compute won't start because of the jobstore is already locked. The bash-scripts avoid this by creating a new repo for the second node.

This PR is a short-term measure to only create the stores (compute and execution) when explicitly asked to, and this is determined by the node type when retrieving the config.

It is expected that this will be fixed in the node setup refactor.

Temporarily resolves #3564 