### PR TITLE
Cancel authn input if the user presses Ctrl+C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 export GO111MODULE = on
 export CGO_ENABLED = 0
 export PRECOMMIT = poetry run pre-commit
-export EARTHLY = $(shell which earthly)
+export EARTHLY ?= $(shell which earthly)
 
 BUILD_DIR = bacalhau
 BINARY_NAME = bacalhau


### PR DESCRIPTION
Previously the system would wait for the user's input and not cancel input if the user pressed Ctrl+C. This is because the signal was intercepted and used to cancel the root context, but this context isn't used by the terminal reading code and so had no effect.

The solution is to run the input in a separate goroutine and select on the routine's output or the context cancellation.

Alas, there's no way to give the same power to Ctrl+D, because interpreting EOF input is very much the purview of the standard library package we're using. But users can still just press Enter to submit empty input.

Resolves #3411.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved secure handling of user input in authentication processes.
- **Tests**
	- Enhanced node management in testing scripts.
	- Added tests to verify user input can be safely cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->