### PR TITLE
Show node approval status in CLI

### DIFF
--- a/cmd/cli/node/columns.go
+++ b/cmd/cli/node/columns.go
@@ -25,7 +25,7 @@ var alwaysColumns = []output.TableColumn[*models.NodeInfo]{
 		Value:        func(ni *models.NodeInfo) string { return ni.NodeType.String() },
 	},
 	{
-		ColumnConfig: table.ColumnConfig{Name: "approval"},
+		ColumnConfig: table.ColumnConfig{Name: "status"},
 		Value:        func(ni *models.NodeInfo) string { return ni.Approval.String() },
 	},
 }

--- a/cmd/cli/node/columns.go
+++ b/cmd/cli/node/columns.go
@@ -24,6 +24,10 @@ var alwaysColumns = []output.TableColumn[*models.NodeInfo]{
 		ColumnConfig: table.ColumnConfig{Name: "type"},
 		Value:        func(ni *models.NodeInfo) string { return ni.NodeType.String() },
 	},
+	{
+		ColumnConfig: table.ColumnConfig{Name: "approval"},
+		Value:        func(ni *models.NodeInfo) string { return ni.Approval.String() },
+	},
 }
 
 var toggleColumns = map[string][]output.TableColumn[*models.NodeInfo]{

--- a/pkg/models/node_approval.go
+++ b/pkg/models/node_approval.go
@@ -89,6 +89,16 @@ func (t NodeApproval) MarshalJSON() ([]byte, error) {
 }
 
 func (t *NodeApproval) UnmarshalJSON(b []byte) error {
-	*t = Parse(string(b))
+	val := string(trimQuotes(b))
+	*t = Parse(val)
 	return nil
+}
+
+func trimQuotes(b []byte) []byte {
+	if len(b) >= 2 {
+		if b[0] == '"' && b[len(b)-1] == '"' {
+			return b[1 : len(b)-1]
+		}
+	}
+	return b
 }

--- a/pkg/models/node_approval.go
+++ b/pkg/models/node_approval.go
@@ -1,6 +1,8 @@
 package models
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type NodeApproval struct {
 	approval

--- a/pkg/models/node_approval_test.go
+++ b/pkg/models/node_approval_test.go
@@ -1,0 +1,55 @@
+//go:build unit || !integration
+
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTrimQuotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "with surrounding quotes",
+			input:    []byte(`"example"`),
+			expected: []byte(`example`),
+		},
+		{
+			name:     "with escaped quotes inside",
+			input:    []byte(`"ex\"ample"`),
+			expected: []byte(`ex\"ample`),
+		},
+		{
+			name:     "without surrounding quotes",
+			input:    []byte(`example`),
+			expected: []byte(`example`),
+		},
+		{
+			name:     "with only one quote at the beginning",
+			input:    []byte(`"example`),
+			expected: []byte(`"example`),
+		},
+		{
+			name:     "with only one quote at the end",
+			input:    []byte(`example"`),
+			expected: []byte(`example"`),
+		},
+		{
+			name:     "empty byte slice",
+			input:    []byte(``),
+			expected: []byte(``),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimQuotes(tt.input); !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("trimQuotes() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/node/manager/node_manager.go
+++ b/pkg/node/manager/node_manager.go
@@ -55,6 +55,10 @@ func (n *NodeManager) Register(ctx context.Context, request requests.RegisterReq
 		}, nil
 	}
 
+	// TODO: We will default to PENDING, but once we start filtering on NodeApprovals.APPROVED we will need to
+	// make a decision on how this is determined.
+	request.Info.Approval = models.NodeApprovals.PENDING
+
 	if err := n.nodeInfo.Add(ctx, request.Info); err != nil {
 		return nil, errors.Wrap(err, "failed to save nodeinfo during node registration")
 	}
@@ -100,7 +104,6 @@ func (n *NodeManager) UpdateResources(ctx context.Context,
 	}
 
 	log.Ctx(ctx).Debug().Msg("updating resources availability for node")
-	fmt.Println("UPDATE FROM", request.NodeID, "RESOURCES", request.Resources)
 
 	// Update the resources for the node in the stripedmap. This is a thread-safe operation as locking
 	// is handled by the stripedmap on a per-bucket basis.
@@ -143,7 +146,6 @@ func (n *NodeManager) GetByPrefix(ctx context.Context, prefix string) (models.No
 }
 
 func (n *NodeManager) List(ctx context.Context, filters ...routing.NodeInfoFilter) ([]models.NodeInfo, error) {
-	fmt.Println("NODE MANAGER LIST!!!!")
 	items, err := n.nodeInfo.List(ctx, filters...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Shows the node approval status when running the `node list` command. This will currently show as APPROVED for requester nodes, and PENDING for compute nodes, but as these values are not currently used in filtering this is okay.  Once we start filtering nodes based on their approval status being APPROVED then we will need to decide on how we auto-approve compute nodes.

Also contains a couple of Printf's not caught in previous PR which fixes #3591 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an "approval" column to the node table display to show the approval status.
- **Bug Fixes**
	- Fixed an issue in processing node approval status.
- **Chores**
	- Improved node registration by defaulting the approval status to "PENDING".
	- Removed unnecessary debug outputs in node management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->