### PR TITLE
Approve/Reject node membership from CLI

### DIFF
--- a/cmd/cli/node/action.go
+++ b/cmd/cli/node/action.go
@@ -1,0 +1,54 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/cmd/util"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+	"github.com/spf13/cobra"
+)
+
+type NodeActionCmd struct {
+	action  string
+	message string
+}
+
+func NewActionCmd(action apimodels.NodeAction) *cobra.Command {
+	actionCmd := &NodeActionCmd{
+		action:  string(action),
+		message: "",
+	}
+
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s [id]", action),
+		Short: action.Description(),
+		Args:  cobra.ExactArgs(1),
+		RunE:  actionCmd.run,
+	}
+
+	cmd.Flags().StringVarP(&actionCmd.message, "message", "m", "", "Message to include with the action")
+	return cmd
+}
+
+func (n *NodeActionCmd) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	nodeID := args[0]
+
+	response, err := util.GetAPIClientV2(cmd).Nodes().Put(ctx, &apimodels.PutNodeRequest{
+		NodeID:  nodeID,
+		Action:  n.action,
+		Message: n.message,
+	})
+	if err != nil {
+		util.Fatal(cmd, fmt.Errorf("could not %s node %s: %w", n.action, nodeID, err), 1)
+	}
+
+	if response.Success {
+		cmd.Println("Ok")
+	} else {
+		cmd.PrintErrf("Failed to %s node %s: %s\n", n.action, nodeID, response.Error)
+	}
+
+	return nil
+}

--- a/cmd/cli/node/action_test.go
+++ b/cmd/cli/node/action_test.go
@@ -1,0 +1,84 @@
+//go:build unit || !integration
+
+package node_test
+
+import (
+	"strings"
+	"testing"
+
+	cmdtesting "github.com/bacalhau-project/bacalhau/cmd/testing"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/setup"
+	"github.com/stretchr/testify/suite"
+)
+
+type NodeActionSuite struct {
+	cmdtesting.BaseNATSSuite
+}
+
+func TestNodeActionSuite(t *testing.T) {
+	suite.Run(t, new(NodeActionSuite))
+}
+
+func (s *NodeActionSuite) SetupSuite() {
+	logger.ConfigureTestLogging(s.T())
+	setup.SetupBacalhauRepoForTesting(s.T())
+}
+
+func (s *NodeActionSuite) TestListNodes() {
+	// Get default states for the test node
+	_, out, err := s.ExecuteTestCobraCommand(
+		"node",
+		"list",
+		"--output", "csv",
+	)
+	s.Require().NoError(err)
+
+	cells := getCells(out, 1)
+	s.Require().Equal("APPROVED", cells[2], "Expected the node to be approved")
+
+	nodeID := cells[0]
+
+	// Try to approve, expect failure
+	_, out, err = s.ExecuteTestCobraCommand(
+		"node",
+		"approve",
+		nodeID,
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(out, "node already approved")
+	s.Require().Contains(out, nodeID)
+
+	// Now reject the node
+	_, out, err = s.ExecuteTestCobraCommand(
+		"node",
+		"reject",
+		nodeID,
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(out, "Ok")
+
+	// Try to reject again - expect failure
+	_, out, err = s.ExecuteTestCobraCommand(
+		"node",
+		"reject",
+		nodeID,
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(out, "node already rejected")
+
+	// Set it to approve again
+	_, out, err = s.ExecuteTestCobraCommand(
+		"node",
+		"approve",
+		nodeID,
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(out, "Ok")
+}
+
+func getCells(output string, lineNo int) []string {
+	lines := strings.Split(output, "\n")
+	line := lines[lineNo]
+	return strings.Split(line, ",")
+}

--- a/cmd/cli/node/root.go
+++ b/cmd/cli/node/root.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/spf13/cobra"
 )
 
@@ -15,5 +16,12 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(NewDescribeCmd())
 	cmd.AddCommand(NewListCmd())
+
+	// Approve Action
+	cmd.AddCommand(NewActionCmd(apimodels.NodeActionApprove))
+
+	// Reject Action
+	cmd.AddCommand(NewActionCmd(apimodels.NodeActionReject))
+
 	return cmd
 }

--- a/cmd/testing/basenats.go
+++ b/cmd/testing/basenats.go
@@ -1,0 +1,131 @@
+package cmdtesting
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+
+	"github.com/bacalhau-project/bacalhau/cmd/cli"
+	"github.com/bacalhau-project/bacalhau/cmd/util"
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/bacalhau-project/bacalhau/pkg/devstack"
+	noop_executor "github.com/bacalhau-project/bacalhau/pkg/executor/noop"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
+	"github.com/bacalhau-project/bacalhau/pkg/node"
+	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/test/teststack"
+	"github.com/stretchr/testify/suite"
+)
+
+type BaseNATSSuite struct {
+	suite.Suite
+	Node     *node.Node
+	ClientV2 clientv2.API
+	Host     string
+	Port     uint16
+}
+
+// before each test
+func (s *BaseNATSSuite) SetupTest() {
+	logger.ConfigureTestLogging(s.T())
+	util.Fatal = util.FakeFatalErrorHandler
+
+	computeConfig, err := node.NewComputeConfigWith(node.ComputeConfigParams{
+		JobSelectionPolicy: node.JobSelectionPolicy{
+			Locality: semantic.Anywhere,
+		},
+		LocalPublisher: types.LocalPublisherConfig{
+			Address: "127.0.0.1",
+		},
+	})
+	s.Require().NoError(err)
+	ctx := context.Background()
+	requesterConfig, err := node.NewRequesterConfigWith(
+		node.RequesterConfigParams{
+			HousekeepingBackgroundTaskInterval: 1 * time.Second,
+		},
+	)
+
+	s.Require().NoError(err)
+	stack := teststack.Setup(ctx, s.T(),
+		devstack.WithNumberOfHybridNodes(1),
+		devstack.WithComputeConfig(computeConfig),
+		devstack.WithRequesterConfig(requesterConfig),
+		devstack.WithNetworkType("nats"),
+		teststack.WithNoopExecutor(noop_executor.ExecutorConfig{}),
+	)
+	s.Node = stack.Nodes[0]
+	s.Host = s.Node.APIServer.Address
+	s.Port = s.Node.APIServer.Port
+	s.ClientV2 = clientv2.New(fmt.Sprintf("http://%s:%d", s.Host, s.Port))
+
+	fmt.Println(s.Host, s.Port)
+}
+
+// After each test
+func (s *BaseNATSSuite) TearDownTest() {
+	util.Fatal = util.FakeFatalErrorHandler
+	if s.Node != nil {
+		s.Node.CleanupManager.Cleanup(context.Background())
+	}
+}
+
+// ExecuteTestCobraCommand executes a cobra command with the given arguments. The api-host and api-port
+// flags are automatically added if they are not provided in `args`. They are set to the values of
+// `s.Host` and `s.Port` respectively.
+func (s *BaseNATSSuite) ExecuteTestCobraCommand(args ...string) (c *cobra.Command, output string, err error) {
+	return s.ExecuteTestCobraCommandWithStdin(nil, args...)
+}
+
+// ExecuteTestCobraCommandWithStdin executes a cobra command with the given arguments and with a specific
+// stdin. The api-host and api-port flags are automatically added if they are not provided in `args`. They
+// are set to the values of `s.Host` and `s.Port` respectively.
+func (s *BaseNATSSuite) ExecuteTestCobraCommandWithStdin(stdin io.Reader, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	root := cli.NewRootCmd()
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetIn(stdin)
+
+	arguments := []string{}
+	if !slices.Contains(args, "--api-host") {
+		arguments = append(arguments, "--api-host", s.Host)
+	}
+
+	if !slices.Contains(args, "--api-port") {
+		arguments = append(arguments, "--api-port", fmt.Sprintf("%d", s.Port))
+	}
+	arguments = append(arguments, args...)
+
+	root.SetArgs(arguments)
+
+	// Need to check if we're running in debug mode for VSCode
+	// Empty them if they exist
+	if (len(os.Args) > 2) && (os.Args[1] == "-test.run") {
+		os.Args[1] = ""
+		os.Args[2] = ""
+	}
+
+	s.T().Logf("Command to execute: %v", arguments)
+
+	util.TestError = nil
+	c, err = root.ExecuteC()
+	if err == nil {
+		err = util.TestError
+	}
+	return c, buf.String(), err
+}
+
+// ExecuteTestCobraCommandWithStdinBytes executes a cobra command with the given arguments and with a specific
+// stdin bytes. The api-host and api-port flags are automatically added if they are not provided in `args`. They
+// are set to the values of `s.Host` and `s.Port` respectively.
+func (s *BaseNATSSuite) ExecuteTestCobraCommandWithStdinBytes(stdin []byte, args ...string) (c *cobra.Command, output string, err error) {
+	return s.ExecuteTestCobraCommandWithStdin(bytes.NewReader(stdin), args...)
+}

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -238,6 +238,8 @@ func NewComputeNode(
 	// TODO: When we no longer use libP2P for management, we should remove this
 	// as the managementProxy will always be set.
 	if managementProxy != nil {
+		// TODO: Make the registration lock folder a config option so that we have it
+		// available and don't have to depend on getting the repo folder.
 		repo, _ := pkgconfig.Get[string]("repo")
 		regFilename := fmt.Sprintf("%s.registration.lock", nodeID)
 		regFilename = filepath.Join(repo, pkgconfig.ComputeStorePath, regFilename)

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -272,7 +272,7 @@ func NewRequesterNode(
 		Router:       apiServer.Router,
 		Orchestrator: endpointV2,
 		JobStore:     jobStore,
-		NodeStore:    nodeInfoStore,
+		NodeManager:  nodeManager,
 	})
 
 	auth_endpoint.BindEndpoint(ctx, apiServer.Router, authnProvider)

--- a/pkg/publicapi/apimodels/base.go
+++ b/pkg/publicapi/apimodels/base.go
@@ -11,6 +11,10 @@ type PutRequest interface {
 	Request
 }
 
+type PostRequest interface {
+	Request
+}
+
 type GetRequest interface {
 	Request
 }
@@ -25,6 +29,10 @@ type Response interface {
 }
 
 type PutResponse interface {
+	Response
+}
+
+type PostResponse interface {
 	Response
 }
 

--- a/pkg/publicapi/apimodels/base_requests.go
+++ b/pkg/publicapi/apimodels/base_requests.go
@@ -83,8 +83,25 @@ func (o *BaseListRequest) ToHTTPRequest() *HTTPRequest {
 	return r
 }
 
+// BasePostRequest is the base request used for all POST requests
+type BasePostRequest struct {
+	BaseRequest
+	IdempotencyToken string `query:"idempotency_token"`
+}
+
+// ToHTTPRequest is used to convert the request to an HTTP request
+func (o *BasePostRequest) ToHTTPRequest() *HTTPRequest {
+	r := o.BaseRequest.ToHTTPRequest()
+
+	if o.IdempotencyToken != "" {
+		r.Params.Set("idempotency_token", o.IdempotencyToken)
+	}
+	return r
+}
+
 // compile time check for interface implementation
 var _ Request = (*BaseRequest)(nil)
 var _ PutRequest = (*BasePutRequest)(nil)
+var _ PostRequest = (*BasePostRequest)(nil)
 var _ GetRequest = (*BaseGetRequest)(nil)
 var _ ListRequest = (*BaseListRequest)(nil)

--- a/pkg/publicapi/apimodels/base_responses.go
+++ b/pkg/publicapi/apimodels/base_responses.go
@@ -12,6 +12,10 @@ type BasePutResponse struct {
 	BaseResponse `json:",omitempty,inline" yaml:",omitempty,inline"`
 }
 
+type BasePostResponse struct {
+	BaseResponse `json:",omitempty,inline" yaml:",omitempty,inline"`
+}
+
 type BaseGetResponse struct {
 	BaseResponse `json:",omitempty,inline" yaml:",omitempty,inline"`
 }
@@ -26,5 +30,6 @@ func (o *BaseListResponse) GetNextToken() string { return o.NextToken }
 // compile time check for interface implementation
 var _ Response = (*BaseResponse)(nil)
 var _ PutResponse = (*BasePutResponse)(nil)
+var _ PostResponse = (*BasePostResponse)(nil)
 var _ GetResponse = (*BaseGetResponse)(nil)
 var _ ListResponse = (*BaseListResponse)(nil)

--- a/pkg/publicapi/apimodels/node.go
+++ b/pkg/publicapi/apimodels/node.go
@@ -34,3 +34,37 @@ type ListNodesResponse struct {
 	BaseListResponse
 	Nodes []*models.NodeInfo
 }
+
+type PutNodeRequest struct {
+	BasePutRequest
+	Action  string
+	Message string
+	NodeID  string
+}
+
+type PutNodeResponse struct {
+	BasePutResponse
+	Success bool
+	Error   string
+}
+
+type NodeAction string
+
+const (
+	NodeActionApprove NodeAction = "approve"
+	NodeActionReject  NodeAction = "reject"
+)
+
+func (n NodeAction) Description() string {
+	switch n {
+	case NodeActionApprove:
+		return "Approve a node whose membership is pending"
+	case NodeActionReject:
+		return "Reject a node whose membership is pending"
+	}
+	return ""
+}
+
+func (n NodeAction) IsValid() bool {
+	return n == NodeActionApprove || n == NodeActionReject
+}

--- a/pkg/publicapi/client/v2/api_nodes.go
+++ b/pkg/publicapi/client/v2/api_nodes.go
@@ -29,3 +29,12 @@ func (c *Nodes) List(ctx context.Context, r *apimodels.ListNodesRequest) (*apimo
 	}
 	return &resp, nil
 }
+
+// Put is used to update a node's state with a node action (pause, drain, approve etc)
+func (c *Nodes) Put(ctx context.Context, r *apimodels.PutNodeRequest) (*apimodels.PutNodeResponse, error) {
+	var resp apimodels.PutNodeResponse
+	if err := c.client.Put(ctx, nodesPath+"/"+r.NodeID, r, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/pkg/publicapi/client/v2/client.go
+++ b/pkg/publicapi/client/v2/client.go
@@ -324,13 +324,13 @@ func (t *AuthenticatingClient) Post(ctx context.Context, path string, in apimode
 
 func (t *AuthenticatingClient) Put(ctx context.Context, path string, in apimodels.PutRequest, out apimodels.PutResponse) error {
 	return doRequest(t, in, func(req apimodels.PutRequest) error {
-		return t.Client.Post(ctx, path, req, out)
+		return t.Client.Put(ctx, path, req, out)
 	})
 }
 
 func (t *AuthenticatingClient) Delete(ctx context.Context, path string, in apimodels.PutRequest, out apimodels.Response) error {
 	return doRequest(t, in, func(req apimodels.PutRequest) error {
-		return t.Client.Post(ctx, path, req, out)
+		return t.Client.Delete(ctx, path, req, out)
 	})
 }
 

--- a/pkg/publicapi/endpoint/orchestrator/endpoint.go
+++ b/pkg/publicapi/endpoint/orchestrator/endpoint.go
@@ -46,5 +46,6 @@ func NewEndpoint(params EndpointParams) *Endpoint {
 	g.GET("/jobs/:id/logs", e.logs)
 	g.GET("/nodes", e.listNodes)
 	g.GET("/nodes/:id", e.getNode)
+	g.PUT("/nodes/:id", e.updateNode)
 	return e
 }

--- a/pkg/publicapi/endpoint/orchestrator/endpoint.go
+++ b/pkg/publicapi/endpoint/orchestrator/endpoint.go
@@ -2,9 +2,9 @@ package orchestrator
 
 import (
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	"github.com/bacalhau-project/bacalhau/pkg/node/manager"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/middleware"
-	"github.com/bacalhau-project/bacalhau/pkg/routing"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 )
@@ -13,14 +13,14 @@ type EndpointParams struct {
 	Router       *echo.Echo
 	Orchestrator *orchestrator.BaseEndpoint
 	JobStore     jobstore.Store
-	NodeStore    routing.NodeInfoStore
+	NodeManager  *manager.NodeManager
 }
 
 type Endpoint struct {
 	router       *echo.Echo
 	orchestrator *orchestrator.BaseEndpoint
 	store        jobstore.Store
-	nodeStore    routing.NodeInfoStore
+	nodeManager  *manager.NodeManager
 }
 
 func NewEndpoint(params EndpointParams) *Endpoint {
@@ -28,7 +28,7 @@ func NewEndpoint(params EndpointParams) *Endpoint {
 		router:       params.Router,
 		orchestrator: params.Orchestrator,
 		store:        params.JobStore,
-		nodeStore:    params.NodeStore,
+		nodeManager:  params.NodeManager,
 	}
 
 	// JSON group

--- a/pkg/publicapi/endpoint/orchestrator/node.go
+++ b/pkg/publicapi/endpoint/orchestrator/node.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -115,5 +116,28 @@ func (e *Endpoint) listNodes(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, &apimodels.ListNodesResponse{
 		Nodes: res,
+	})
+}
+
+func (e *Endpoint) updateNode(c echo.Context) error {
+	//ctx := c.Request().Context()
+
+	if c.Param("id") == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "missing node id")
+	}
+
+	var args apimodels.PutNodeRequest
+	if err := c.Bind(&args); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if err := c.Validate(&args); err != nil {
+		return err
+	}
+
+	fmt.Println("PERFORMING", args.Action)
+
+	return c.JSON(http.StatusOK, apimodels.PutNodeResponse{
+		Success: false,
+		Error:   "not yet implemented",
 	})
 }

--- a/pkg/test/teststack/stack.go
+++ b/pkg/test/teststack/stack.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
@@ -62,9 +63,14 @@ func Setup(
 		if err := fsRepo.Open(); err != nil {
 			t.Fatal(err)
 		}
+
+		// TODO(ross) - Remove this once compute node registration lock does not rely on
+		// this config for finding it's storage path.
+		config.SetValue("repo", repoPath)
 	} else {
 		fsRepo = setup.SetupBacalhauRepoForTesting(t)
 	}
+
 	cm := system.NewCleanupManager()
 	t.Cleanup(func() {
 		cm.Cleanup(ctx)


### PR DESCRIPTION
This PR adds the ability to approve/reject node membership to the cluster, based on each node's approval state.  The approve/reject commands are similar and implemented using the same principle.  

```
bacalhau node approve [nodeid] <-m message>

bacalhau node reject [nodeid] <-m message>
```

it is expected that this same approach can be used for `node pause` and `node drain` etc.  
Currently the system does nothing to react to the change of state, a future PR will add pubsub for node events so that jobs can be scheduled etc based on approval/rejection/join/leave events. 

Additionally this PR resolves a small issue in AuthenticatingClient which was proxying calls with the wrong methods, and adds a basenats test suite for testing against a nats enabled devstack.

TODO: 

* [ ] Clarify who is allowed to do this.