### PR TITLE
Store registration sentinel file alongside executions db

### DIFF
--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -54,6 +54,10 @@ func GetComputeConfig(ctx context.Context, createExecutionStore bool) (node.Comp
 		}
 	}
 
+	// We will store the registration file alongside the executions database. We don't need to
+	// make this configurable.
+	registrationFilePath := filepath.Dir(cfg.ExecutionStore.Path)
+
 	return node.NewComputeConfigWith(node.ComputeConfigParams{
 		TotalResourceLimits:                   *totalResources,
 		QueueResourceLimits:                   *queueResources,
@@ -76,6 +80,7 @@ func GetComputeConfig(ctx context.Context, createExecutionStore bool) (node.Comp
 		LogStreamBufferSize:          cfg.LogStreamConfig.ChannelBufferSize,
 		ExecutionStore:               executionStore,
 		LocalPublisher:               cfg.LocalPublisher,
+		RegistrationFilePath:         registrationFilePath,
 	})
 }
 

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/sensors"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
-	pkgconfig "github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	executor_util "github.com/bacalhau-project/bacalhau/pkg/executor/util"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -236,9 +235,7 @@ func NewComputeNode(
 	// TODO: When we no longer use libP2P for management, we should remove this
 	// as the managementProxy will always be set.
 	if managementProxy != nil {
-		repo, _ := pkgconfig.Get[string]("repo")
-		regFilename := fmt.Sprintf("%s.registration.lock", nodeID)
-		regFilename = filepath.Join(repo, pkgconfig.ComputeStorePath, regFilename)
+		regFilename := filepath.Join(config.RegistrationFilePath, fmt.Sprintf("%s.registration.lock", nodeID))
 
 		// Set up the management client which will attempt to register this node
 		// with the requester node, and then if successful will send regular node

--- a/pkg/node/config_compute.go
+++ b/pkg/node/config_compute.go
@@ -75,6 +75,8 @@ type ComputeConfigParams struct {
 	ExecutionStore store.ExecutionStore
 
 	LocalPublisher types.LocalPublisherConfig
+
+	RegistrationFilePath string
 }
 
 type ComputeConfig struct {
@@ -119,6 +121,8 @@ type ComputeConfig struct {
 	ExecutionStore store.ExecutionStore
 
 	LocalPublisher types.LocalPublisherConfig
+
+	RegistrationFilePath string
 }
 
 func NewComputeConfigWithDefaults() (ComputeConfig, error) {
@@ -204,6 +208,7 @@ func NewComputeConfigWith(params ComputeConfigParams) (ComputeConfig, error) {
 		BidResourceStrategy:          params.BidResourceStrategy,
 		ExecutionStore:               params.ExecutionStore,
 		LocalPublisher:               params.LocalPublisher,
+		RegistrationFilePath:         params.RegistrationFilePath,
 	}
 
 	if err := validateConfig(config, physicalResources); err != nil {


### PR DESCRIPTION
Currently the code is asking config for the repo directory to create a file to denote successful registration.  This means that various places (tests, devstack) then need to set this value when they provide their own.

Instead, we will explicitly add a field to ComputeConfig and calculate the value at runtime from the directory where the executions database is stored.

Fixes #3595 