### PR TITLE
Upgrade docker and fix deprecations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/davecgh/go-spew v1.1.1
-	github.com/docker/docker v24.0.7+incompatible
+	github.com/docker/docker v25.0.4+incompatible
 	github.com/dylibso/observe-sdk/go v0.0.0-20231201014635-141351c24659
 	github.com/fatih/structs v1.1.0
 	github.com/ghodss/yaml v1.0.0
@@ -203,7 +203,6 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dgraph-io/badger v1.6.2 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
-	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elastic/gosigar v0.14.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,7 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
+github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -234,10 +235,8 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
-github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
-github.com/docker/docker v24.0.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.4+incompatible h1:XITZTrq+52tZyZxUOtFIahUf3aH367FLxJzt9vZeAF8=
+github.com/docker/docker v25.0.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
 	dockerclient "github.com/docker/docker/client"
@@ -71,7 +72,7 @@ func (c *Client) HostGatewayIP(ctx context.Context) (net.IP, error) {
 }
 
 func (c *Client) removeContainers(ctx context.Context, filterz filters.Args) error {
-	containers, err := c.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filterz})
+	containers, err := c.ContainerList(ctx, container.ListOptions{All: true, Filters: filterz})
 	if err != nil {
 		return err
 	}
@@ -114,7 +115,7 @@ func (c *Client) RemoveObjectsWithLabel(ctx context.Context, labelName, labelVal
 }
 
 func (c *Client) FindContainer(ctx context.Context, label string, value string) (string, error) {
-	containers, err := c.ContainerList(ctx, types.ContainerListOptions{All: true})
+	containers, err := c.ContainerList(ctx, container.ListOptions{All: true})
 	if err != nil {
 		return "", err
 	}
@@ -134,7 +135,7 @@ func (c *Client) FollowLogs(ctx context.Context, id string) (stdout, stderr io.R
 		return nil, nil, errors.Wrap(err, "failed to get container")
 	}
 
-	logOptions := types.ContainerLogsOptions{
+	logOptions := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     true,
@@ -176,7 +177,7 @@ func (c *Client) GetOutputStream(ctx context.Context, id string, since string, f
 		return nil, errors.Wrap(err, "cannot get logs when container is not running")
 	}
 
-	logOptions := types.ContainerLogsOptions{
+	logOptions := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     follow,
@@ -197,7 +198,7 @@ func (c *Client) GetOutputStream(ctx context.Context, id string, since string, f
 func (c *Client) RemoveContainer(ctx context.Context, id string) error {
 	log.Ctx(ctx).Debug().Str("id", id).Msgf("Container Stop")
 	// ContainerRemove kills and removes a container from the docker host.
-	err := c.ContainerRemove(ctx, id, types.ContainerRemoveOptions{
+	err := c.ContainerRemove(ctx, id, container.RemoveOptions{
 		RemoveVolumes: true,
 		Force:         true,
 	})

--- a/pkg/docker/tracing/traced.go
+++ b/pkg/docker/tracing/traced.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
+	docker_sys "github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -61,28 +62,28 @@ func (c TracedClient) ContainerInspect(ctx context.Context, containerID string) 
 	return telemetry.RecordErrorOnSpanTwo[types.ContainerJSON](span)(c.client.ContainerInspect(ctx, containerID))
 }
 
-func (c TracedClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+func (c TracedClient) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
 	ctx, span := c.span(ctx, "container.list")
 	defer span.End()
 
 	return telemetry.RecordErrorOnSpanTwo[[]types.Container](span)(c.client.ContainerList(ctx, options))
 }
 
-func (c TracedClient) ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+func (c TracedClient) ContainerLogs(ctx context.Context, container string, options container.LogsOptions) (io.ReadCloser, error) {
 	ctx, span := c.span(ctx, "container.logs")
 	// span ends when the io.ReadCloser is closed
 
 	return telemetry.RecordErrorOnSpanReadCloserAndClose(span)(c.client.ContainerLogs(ctx, container, options))
 }
 
-func (c TracedClient) ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error {
+func (c TracedClient) ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error {
 	ctx, span := c.span(ctx, "container.rm")
 	defer span.End()
 
 	return telemetry.RecordErrorOnSpan(span)(c.client.ContainerRemove(ctx, containerID, options))
 }
 
-func (c TracedClient) ContainerStart(ctx context.Context, id string, options types.ContainerStartOptions) error {
+func (c TracedClient) ContainerStart(ctx context.Context, id string, options container.StartOptions) error {
 	ctx, span := c.span(ctx, "container.start")
 	defer span.End()
 
@@ -181,11 +182,11 @@ func (c TracedClient) NetworkRemove(ctx context.Context, networkID string) error
 	return telemetry.RecordErrorOnSpan(span)(c.client.NetworkRemove(ctx, networkID))
 }
 
-func (c TracedClient) Info(ctx context.Context) (types.Info, error) {
+func (c TracedClient) Info(ctx context.Context) (docker_sys.Info, error) {
 	ctx, span := c.span(ctx, "info")
 	defer span.End()
 
-	return telemetry.RecordErrorOnSpanTwo[types.Info](span)(c.client.Info(ctx))
+	return telemetry.RecordErrorOnSpanTwo[docker_sys.Info](span)(c.client.Info(ctx))
 }
 
 func (c TracedClient) ServerVersion(ctx context.Context) (types.Version, error) {

--- a/pkg/executor/docker/handler.go
+++ b/pkg/executor/docker/handler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -66,7 +65,7 @@ func (h *executionHandler) run(ctx context.Context) {
 	}()
 	// start the container
 	h.logger.Info().Msg("starting container execution")
-	if err := h.client.ContainerStart(ctx, h.containerID, dockertypes.ContainerStartOptions{}); err != nil {
+	if err := h.client.ContainerStart(ctx, h.containerID, container.StartOptions{}); err != nil {
 		// Special error to alert people about bad executable
 		internalContainerStartErrorMsg := "failed to start container"
 		if strings.Contains(err.Error(), "executable file not found") {

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -166,7 +166,7 @@ func (e *Executor) createHTTPGateway(
 	}
 
 	// Start the container and wait for it to come up
-	err = e.client.ContainerStart(ctx, gatewayContainer.ID, types.ContainerStartOptions{})
+	err = e.client.ContainerStart(ctx, gatewayContainer.ID, container.StartOptions{})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to start network gateway container")
 	}

--- a/pkg/test/executor/docker_entrypoint_test.go
+++ b/pkg/test/executor/docker_entrypoint_test.go
@@ -117,7 +117,7 @@ func (suite *DockerEntrypointTestSuite) TearDownSuite() {
 				err := cli.ContainerStop(ctx, runningContainer.ID, container.StopOptions{})
 				require.NoError(suite.T(), err, fmt.Sprintf("Error stopping container %q", runningContainer.ID))
 
-				err = cli.ContainerRemove(ctx, runningContainer.ID, types.ContainerRemoveOptions{})
+				err = cli.ContainerRemove(ctx, runningContainer.ID, container.RemoveOptions{})
 				require.NoError(suite.T(), err, fmt.Sprintf("Error removing container %q", runningContainer.ID))
 			}
 		}


### PR DESCRIPTION

Although https://github.com/bacalhau-project/bacalhau/pull/3575 passes tests, it fails lints with deprecation warnings. 
This PR upgrades docker and fixes the warning.  #3575 can be abandoned once this is merged.