### PR TITLE
Manually cleanup repo directory to work around flaky window test.

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func SetupBacalhauRepo(repoDir string) (*repo.FsRepo, error) {
 func SetupBacalhauRepoForTesting(t testing.TB) *repo.FsRepo {
 	viper.Reset()
 
-	path := filepath.Join(os.TempDir(), fmt.Sprint(time.Now().UnixNano()))
+	path := filepath.Join(t.TempDir(), fmt.Sprint(time.Now().UnixNano()))
 	t.Logf("creating repo for testing at: %s", path)
 	t.Setenv("BACALHAU_ENVIRONMENT", "local")
 	t.Setenv("BACALHAU_DIR", path)


### PR DESCRIPTION
On windows we've been seeing failing tests with directories already existing, presumably from previous/parallel runs. This PR switches to using a tempdir provided by the test framework so that it is cleaned up when the test completes.

Edit: It appears this is a common problem on windows when removing directories under certain conditions.  We've not moved to manually cleaning up the folder.