### PR TITLE
fix nodeIDs when using libp2p

### DIFF
--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -199,6 +199,14 @@ func getAllowListedLocalPathsConfig() []string {
 	return viper.GetStringSlice(types.NodeAllowListedLocalPaths)
 }
 
+func getTransportType() (string, error) {
+	var networkCfg types.NetworkConfig
+	if err := config.ForKey(types.NodeNetwork, &networkCfg); err != nil {
+		return "", err
+	}
+	return networkCfg.Type, nil
+}
+
 func getNetworkConfig(nodeID string) (node.NetworkConfig, error) {
 	var networkCfg types.NetworkConfig
 	if err := config.ForKey(types.NodeNetwork, &networkCfg); err != nil {


### PR DESCRIPTION
Fix peer lookup when using libp2p by ignoring nodeID providers and just use the libp2p peerID as the nodeID

### Testing
```
#!/bin/bash

export BACALHAU_DIR=$(mktemp -d)
bacalhau config set node.network.type libp2p
bacalhau serve --node-type=requester,compute --peer=none &
source $BACALHAU_DIR/bacalhau.run
bacalhau docker run ubuntu date
```