### PR TITLE
Revert "Store registration sentinel file alongside executions db"

### DIFF
--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -54,10 +54,6 @@ func GetComputeConfig(ctx context.Context, createExecutionStore bool) (node.Comp
 		}
 	}
 
-	// We will store the registration file alongside the executions database. We don't need to
-	// make this configurable.
-	registrationFilePath := filepath.Dir(cfg.ExecutionStore.Path)
-
 	return node.NewComputeConfigWith(node.ComputeConfigParams{
 		TotalResourceLimits:                   *totalResources,
 		QueueResourceLimits:                   *queueResources,
@@ -80,7 +76,6 @@ func GetComputeConfig(ctx context.Context, createExecutionStore bool) (node.Comp
 		LogStreamBufferSize:          cfg.LogStreamConfig.ChannelBufferSize,
 		ExecutionStore:               executionStore,
 		LocalPublisher:               cfg.LocalPublisher,
-		RegistrationFilePath:         registrationFilePath,
 	})
 }
 

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/sensors"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	pkgconfig "github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	executor_util "github.com/bacalhau-project/bacalhau/pkg/executor/util"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
@@ -235,7 +236,9 @@ func NewComputeNode(
 	// TODO: When we no longer use libP2P for management, we should remove this
 	// as the managementProxy will always be set.
 	if managementProxy != nil {
-		regFilename := filepath.Join(config.RegistrationFilePath, fmt.Sprintf("%s.registration.lock", nodeID))
+		repo, _ := pkgconfig.Get[string]("repo")
+		regFilename := fmt.Sprintf("%s.registration.lock", nodeID)
+		regFilename = filepath.Join(repo, pkgconfig.ComputeStorePath, regFilename)
 
 		// Set up the management client which will attempt to register this node
 		// with the requester node, and then if successful will send regular node

--- a/pkg/node/config_compute.go
+++ b/pkg/node/config_compute.go
@@ -75,8 +75,6 @@ type ComputeConfigParams struct {
 	ExecutionStore store.ExecutionStore
 
 	LocalPublisher types.LocalPublisherConfig
-
-	RegistrationFilePath string
 }
 
 type ComputeConfig struct {
@@ -121,8 +119,6 @@ type ComputeConfig struct {
 	ExecutionStore store.ExecutionStore
 
 	LocalPublisher types.LocalPublisherConfig
-
-	RegistrationFilePath string
 }
 
 func NewComputeConfigWithDefaults() (ComputeConfig, error) {
@@ -208,7 +204,6 @@ func NewComputeConfigWith(params ComputeConfigParams) (ComputeConfig, error) {
 		BidResourceStrategy:          params.BidResourceStrategy,
 		ExecutionStore:               params.ExecutionStore,
 		LocalPublisher:               params.LocalPublisher,
-		RegistrationFilePath:         params.RegistrationFilePath,
 	}
 
 	if err := validateConfig(config, physicalResources); err != nil {


### PR DESCRIPTION
Reverts bacalhau-project/bacalhau#3596

When running with devstack, a repo was created in a tmp folder, but because we setupbacalhaurepo twice, the value available in node/compute.go was based on the original, pre-temp folder path and so would write there. 

This goes back to the previous behaviour.