### PR TITLE
Fix low cleanup frequency in cache tests

### DIFF
--- a/pkg/cache/basic/cache.go
+++ b/pkg/cache/basic/cache.go
@@ -1,6 +1,7 @@
 package basic
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/cache"
@@ -11,6 +12,7 @@ import (
 const (
 	DefaultTTLSeconds = int64(3600)
 	DefaultMaxCost    = uint64(1000)
+	DefaultFrequency  = time.Hour
 )
 
 type BasicCache[T any] struct {
@@ -31,7 +33,7 @@ func NewCache[T any](options ...Option) (*BasicCache[T], error) {
 	// initialize config with default values (these could be constants).
 	config := &Config{
 		maxCost:          DefaultMaxCost,
-		cleanupFrequency: time.Hour,
+		cleanupFrequency: DefaultFrequency,
 		evictionFunction: func(key string, cost uint64, expiresAt int64, now int64) bool {
 			return expiresAt != 0 && expiresAt <= now
 		},
@@ -48,6 +50,12 @@ func NewCache[T any](options ...Option) (*BasicCache[T], error) {
 		cost:             counter.NewCounter(config.maxCost),
 		evictionFunction: config.evictionFunction,
 		defaultTTL:       config.defaultTTL,
+	}
+
+	fmt.Println("Cache frequency is", config.cleanupFrequency)
+
+	if config.cleanupFrequency == 0 {
+		config.cleanupFrequency = DefaultFrequency
 	}
 
 	go c.cleanup(config.cleanupFrequency)

--- a/pkg/cache/basic/cache.go
+++ b/pkg/cache/basic/cache.go
@@ -1,7 +1,6 @@
 package basic
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/cache"
@@ -51,8 +50,6 @@ func NewCache[T any](options ...Option) (*BasicCache[T], error) {
 		evictionFunction: config.evictionFunction,
 		defaultTTL:       config.defaultTTL,
 	}
-
-	fmt.Println("Cache frequency is", config.cleanupFrequency)
 
 	if config.cleanupFrequency == 0 {
 		config.cleanupFrequency = DefaultFrequency

--- a/pkg/cache/basic/cache_test.go
+++ b/pkg/cache/basic/cache_test.go
@@ -110,7 +110,7 @@ func (s *BasicCacheSuite) TestExpiry() {
 		return willEvict
 	}
 
-	c, err := s.createTestCache("TestExpiry", 1, 1, f)
+	c, err := s.createTestCache("TestExpiry", 1, 100*time.Millisecond, f)
 	require.NoError(s.T(), err)
 	defer c.Close()
 
@@ -138,7 +138,7 @@ func (s *BasicCacheSuite) TestExpiryDefaultTTL() {
 		return false
 	}
 
-	c, err := s.createTestCacheWithDefaultTTL("TestExpiry", 1, 1, 1*time.Second, f)
+	c, err := s.createTestCacheWithDefaultTTL("TestExpiry", 1, 100*time.Millisecond, 1*time.Second, f)
 	require.NoError(s.T(), err)
 	defer c.Close()
 


### PR DESCRIPTION
ticker was firing too frequently, and occassionally resulting in a too-low duration causing flaky tests.

Fixes #3635