### PR TITLE
Simplify labels for compute node

### DIFF
--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -57,6 +57,7 @@ func NewComputeNode(
 	publishers publisher.PublisherProvider,
 	computeCallback compute.Callback,
 	managementProxy compute.ManagementEndpoint,
+	configuredLabels map[string]string,
 ) (*Compute, error) {
 	executionStore := config.ExecutionStore
 
@@ -227,6 +228,7 @@ func NewComputeNode(
 
 	// Node labels
 	labelsProvider := models.MergeLabelsInOrder(
+		&ConfigLabelsProvider{staticLabels: configuredLabels},
 		&RuntimeLabelsProvider{},
 		capacity.NewGPULabelsProvider(config.TotalResourceLimits),
 		repo_storage.NewLabelsProvider(),

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -370,10 +370,13 @@ func NewNode(
 		debugInfoProviders = append(debugInfoProviders, computeNode.debugInfoProviders...)
 	}
 
+	// Create a node info provider for LibP2P, and specify the default node approval state
+	// of Approved to avoid confusion as approval state is not used for this transport type.
 	nodeInfoProvider := routing.NewNodeInfoProvider(routing.NodeInfoProviderParams{
-		NodeID:          config.NodeID,
-		LabelsProvider:  labelsProvider,
-		BacalhauVersion: *version.Get(),
+		NodeID:              config.NodeID,
+		LabelsProvider:      labelsProvider,
+		BacalhauVersion:     *version.Get(),
+		DefaultNodeApproval: models.NodeApprovals.APPROVED,
 	})
 	nodeInfoProvider.RegisterNodeInfoDecorator(transportLayer.NodeInfoDecorator())
 	if computeNode != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -261,7 +261,10 @@ func NewNode(
 
 	var requesterNode *Requester
 	var computeNode *Compute
-	var labelsProvider models.LabelsProvider = &ConfigLabelsProvider{staticLabels: config.Labels}
+	labelsProvider := models.MergeLabelsInOrder(
+		&ConfigLabelsProvider{staticLabels: config.Labels},
+		&RuntimeLabelsProvider{},
+	)
 
 	// setup requester node
 	if config.IsRequesterNode {
@@ -353,6 +356,7 @@ func NewNode(
 			publishers,
 			transportLayer.CallbackProxy(),
 			transportLayer.ManagementProxy(),
+			config.Labels,
 		)
 		if err != nil {
 			return nil, err
@@ -363,10 +367,6 @@ func NewNode(
 			return nil, err
 		}
 
-		labelsProvider = models.MergeLabelsInOrder(
-			computeNode.autoLabelsProvider,
-			labelsProvider,
-		)
 		debugInfoProviders = append(debugInfoProviders, computeNode.debugInfoProviders...)
 	}
 

--- a/pkg/routing/node_info_provider.go
+++ b/pkg/routing/node_info_provider.go
@@ -7,25 +7,35 @@ import (
 )
 
 type NodeInfoProviderParams struct {
-	NodeID          string
-	LabelsProvider  models.LabelsProvider
-	BacalhauVersion models.BuildVersionInfo
+	NodeID              string
+	LabelsProvider      models.LabelsProvider
+	BacalhauVersion     models.BuildVersionInfo
+	DefaultNodeApproval models.NodeApproval
 }
 
 type NodeInfoProvider struct {
-	nodeID             string
-	labelsProvider     models.LabelsProvider
-	bacalhauVersion    models.BuildVersionInfo
-	nodeInfoDecorators []models.NodeInfoDecorator
+	nodeID              string
+	labelsProvider      models.LabelsProvider
+	bacalhauVersion     models.BuildVersionInfo
+	nodeInfoDecorators  []models.NodeInfoDecorator
+	defaultNodeApproval models.NodeApproval
 }
 
 func NewNodeInfoProvider(params NodeInfoProviderParams) *NodeInfoProvider {
-	return &NodeInfoProvider{
-		nodeID:             params.NodeID,
-		labelsProvider:     params.LabelsProvider,
-		bacalhauVersion:    params.BacalhauVersion,
-		nodeInfoDecorators: make([]models.NodeInfoDecorator, 0),
+	provider := &NodeInfoProvider{
+		nodeID:              params.NodeID,
+		labelsProvider:      params.LabelsProvider,
+		bacalhauVersion:     params.BacalhauVersion,
+		nodeInfoDecorators:  make([]models.NodeInfoDecorator, 0),
+		defaultNodeApproval: params.DefaultNodeApproval,
 	}
+
+	// If we were not given a default approval, we default to PENDING
+	if !provider.defaultNodeApproval.IsValid() {
+		provider.defaultNodeApproval = models.NodeApprovals.PENDING
+	}
+
+	return provider
 }
 
 // RegisterNodeInfoDecorator registers a node info decorator with the node info provider.
@@ -39,11 +49,16 @@ func (n *NodeInfoProvider) GetNodeInfo(ctx context.Context) models.NodeInfo {
 		BacalhauVersion: n.bacalhauVersion,
 		Labels:          n.labelsProvider.GetLabels(ctx),
 		NodeType:        models.NodeTypeRequester,
-		Approval:        models.NodeApprovals.PENDING,
+		Approval:        n.defaultNodeApproval,
 	}
 	for _, decorator := range n.nodeInfoDecorators {
 		res = decorator.DecorateNodeInfo(ctx, res)
 	}
+
+	if !res.Approval.IsValid() {
+		res.Approval = models.NodeApprovals.PENDING
+	}
+
 	return res
 }
 

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -116,7 +116,8 @@ func (s *ComputeSuite) setupNode() {
 		provider.NewNoopProvider[executor.Executor](s.executor),
 		provider.NewNoopProvider[publisher.Publisher](s.publisher),
 		callback,
-		nil, // until we switch to testing with NATS
+		nil,                 // until we switch to testing with NATS
+		map[string]string{}, // empty configured labels
 	)
 	s.NoError(err)
 	s.stateResolver = *resolver.NewStateResolver(resolver.StateResolverParams{


### PR DESCRIPTION
Provides compute node with the configured labels and lets it manage its own labels.  Simplifies the label management in the Node{} and ensure that both node types get Runtime labels and configured labels, with Compute nodes having the usual extra labels (e.g. GPU)

At the same time (and as it affects the node list output) we default libp2p nodes to APPROVED to avoid confusion.

Fixes #3630 