### PR TITLE
Clarifies error message when bacalhau encounters a newer repo version

### DIFF
--- a/pkg/repo/errors.go
+++ b/pkg/repo/errors.go
@@ -13,3 +13,8 @@ func (e ErrUnknownRepoVersion) Error() string {
 		"\nBacalhau does not know how to read this configuration format and" +
 		"\nyou will need to upgrade to a newer version to upgrade this repository."
 }
+
+func IsUnknownVersion(err error) bool {
+	_, ok := err.(ErrUnknownRepoVersion)
+	return ok
+}

--- a/pkg/repo/errors.go
+++ b/pkg/repo/errors.go
@@ -1,0 +1,15 @@
+package repo
+
+import "fmt"
+
+type ErrUnknownRepoVersion int
+
+func NewUnknownRepoVersionError(version int) ErrUnknownRepoVersion {
+	return ErrUnknownRepoVersion(version)
+}
+
+func (e ErrUnknownRepoVersion) Error() string {
+	return fmt.Sprintf("\nUnsupported repository version %d.", e) +
+		"\nBacalhau does not know how to read this configuration format and" +
+		"\nyou will need to upgrade to a newer version to upgrade this repository."
+}

--- a/pkg/repo/fs.go
+++ b/pkg/repo/fs.go
@@ -73,7 +73,7 @@ func (fsr *FsRepo) Exists() (bool, error) {
 		return false, err
 	}
 	if !IsValidVersion(version) {
-		return false, fmt.Errorf("unknown repo version %d", version)
+		return false, NewUnknownRepoVersionError(version)
 	}
 	return true, nil
 }

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -35,12 +35,11 @@ func SetupBacalhauRepo(repoDir string) (*repo.FsRepo, error) {
 		return nil, fmt.Errorf("failed to create repo: %w", err)
 	}
 	if exists, err := fsRepo.Exists(); err != nil {
-		switch err.(type) {
-		case repo.ErrUnknownRepoVersion:
+		if repo.IsUnknownVersion(err) {
 			return nil, err
-		default:
-			return nil, fmt.Errorf("failed to check if repo exists: %w", err)
 		}
+
+		return nil, fmt.Errorf("failed to check if repo exists: %w", err)
 	} else if !exists {
 		if err := fsRepo.Init(); err != nil {
 			return nil, fmt.Errorf("failed to initialize repo: %w", err)

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -35,7 +35,12 @@ func SetupBacalhauRepo(repoDir string) (*repo.FsRepo, error) {
 		return nil, fmt.Errorf("failed to create repo: %w", err)
 	}
 	if exists, err := fsRepo.Exists(); err != nil {
-		return nil, fmt.Errorf("failed to check if repo exists: %w", err)
+		switch err.(type) {
+		case repo.ErrUnknownRepoVersion:
+			return nil, err
+		default:
+			return nil, fmt.Errorf("failed to check if repo exists: %w", err)
+		}
 	} else if !exists {
 		if err := fsRepo.Init(); err != nil {
 			return nil, fmt.Errorf("failed to initialize repo: %w", err)


### PR DESCRIPTION
When using an older version of bacalhau, in an environment with a repo version that is higher than that supported by that version (e.g. launching bacalhau 1.2.1 where the repo version has been upgrade to 3) the error message is:

```
failed to initialize bacalhau repo at '/Users/ross/.bacalhau':
failed to check if repo exists: unknown repo version 3
```

The error message is now:

```
failed to initialize bacalhau repo at '/Users/ross/.bacalhau':
Unsupported repository version 3.
Bacalhau does not know how to read this configuration format and
you will need to upgrade to a newer version to upgrade this repository.
```