### PR TITLE
Default local publisher to binding to all addresses

### DIFF
--- a/pkg/publisher/local/publisher.go
+++ b/pkg/publisher/local/publisher.go
@@ -96,8 +96,8 @@ var _ publisher.Publisher = (*Publisher)(nil)
 func resolveAddress(ctx context.Context, address string) string {
 	addressType, ok := network.AddressTypeFromString(address)
 	if !ok {
-		log.Ctx(ctx).Debug().Stringer("AddressType", addressType).Msgf("unable to find address type: %s, using 127.0.0.1", address)
-		return address
+		log.Ctx(ctx).Debug().Stringer("AddressType", addressType).Msgf("unable to find address type: %s, binding to 0.0.0.0", address)
+		return "0.0.0.0"
 	}
 
 	// If we were provided with an address type and not an address, so we should look up


### PR DESCRIPTION
Code appears to suggest we'd use 127 and then returned the original address (🤦🏻) but now we've changed it to bind to all addresses if we can't resolve the type.  