### PR TITLE
Publisher processing for exec command

### DIFF
--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -222,6 +222,11 @@ func PrepareJob(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, opti
 			Type:   publisherSpec.Type.String(),
 			Params: publisherSpec.Params,
 		}
+	} else {
+		job.Tasks[0].Publisher = &models.SpecConfig{
+			Type:   "ipfs",
+			Params: map[string]interface{}{},
+		}
 	}
 
 	// Handle ResultPaths by using the legacy parser and converting.
@@ -307,6 +312,10 @@ func prepareJobOutputs(ctx context.Context, options *ExecOptions, job *models.Jo
 	legacyOutputs, err := parse.JobOutputs(ctx, options.SpecSettings.OutputVolumes)
 	if err != nil {
 		return err
+	}
+
+	if len(legacyOutputs) == 0 {
+		return nil
 	}
 
 	job.Tasks[0].ResultPaths = make([]*models.ResultPath, 0, len(legacyOutputs))

--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -222,11 +222,6 @@ func PrepareJob(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, opti
 			Type:   publisherSpec.Type.String(),
 			Params: publisherSpec.Params,
 		}
-	} else {
-		job.Tasks[0].Publisher = &models.SpecConfig{
-			Type:   "ipfs",
-			Params: map[string]interface{}{},
-		}
 	}
 
 	// Handle ResultPaths by using the legacy parser and converting.
@@ -316,6 +311,14 @@ func prepareJobOutputs(ctx context.Context, options *ExecOptions, job *models.Jo
 
 	if len(legacyOutputs) == 0 {
 		return nil
+	}
+
+	// If we only have the single legacy default output then we will only use it if we have a publisher
+	// configured. If no publisher then we can just return early.
+	if len(legacyOutputs) == 1 && legacyOutputs[0].Name == "outputs" && legacyOutputs[0].Path == "/outputs" {
+		if job.Tasks[0].Publisher == nil {
+			return nil
+		}
 	}
 
 	job.Tasks[0].ResultPaths = make([]*models.ResultPath, 0, len(legacyOutputs))


### PR DESCRIPTION
Publishers are no longer required for submitting jobs, but the original processing of the legacy -o flag always presents a resultpath to the exec command.  

This PR now checks the default outputs, and 

* if there is no publisher specified, will ignore the default. 
* If there is a publisher then it will continue to process the default (or any -o flag)
* If there is no publisher but the user specifies -o, then it will correctly fail validation.