### PR TITLE
Local publisher address tf

### DIFF
--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -75,6 +75,8 @@ export BACALHAU_NODE_NETWORK_TYPE=${var.network_type}
 export BACALHAU_NODE_NETWORK_ORCHESTRATORS="${var.internal_ip_addresses[0]}:4222"
 export BACALHAU_NODE_NETWORK_ADVERTISEDADDRESS="${var.public_ip_addresses[count.index]}:4222"
 export BACALHAU_NODE_NETWORK_CLUSTER_PEERS=""
+export BACALHAU_NODE_COMPUTE_LOCAL_PUBLISHER_ADDRESS="${var.public_ip_addresses[count.index]}"
+
 
 ### secrets are installed in the install-node.sh script
 export SECRETS_GRAFANA_CLOUD_PROMETHEUS_API_KEY="${var.grafana_cloud_prometheus_api_key}"
@@ -204,8 +206,8 @@ EOF
 
 resource "google_compute_address" "ipv4_address" {
   region = var.region
-  name  = "bacalhau-ipv4-address-${terraform.workspace}-${count.index}"
-  count = var.protect_resources ? var.instance_count : 0
+  name   = "bacalhau-ipv4-address-${terraform.workspace}-${count.index}"
+  count  = var.protect_resources ? var.instance_count : 0
   lifecycle {
     prevent_destroy = true
   }
@@ -308,8 +310,8 @@ resource "google_compute_firewall" "bacalhau_ingress_firewall" {
   allow {
     protocol = "udp"
     ports = [
-      "4001",  // ipfs swarm
-      "1235",  // bacalhau swarm
+      "4001", // ipfs swarm
+      "1235", // bacalhau swarm
     ]
   }
 
@@ -325,18 +327,18 @@ resource "google_compute_firewall" "bacalhau_egress_firewall" {
   allow {
     protocol = "tcp"
     ports = [
-      "4001",  // ipfs swarm
-      "1235",  // bacalhau swarm
-      "4222",  // nats
-      "6222",  // nats cluster
+      "4001", // ipfs swarm
+      "1235", // bacalhau swarm
+      "4222", // nats
+      "6222", // nats cluster
     ]
   }
 
   allow {
     protocol = "udp"
     ports = [
-      "4001",  // ipfs swarm
-      "1235",  // bacalhau swarm
+      "4001", // ipfs swarm
+      "1235", // bacalhau swarm
     ]
   }
 

--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -75,7 +75,7 @@ export BACALHAU_NODE_NETWORK_TYPE=${var.network_type}
 export BACALHAU_NODE_NETWORK_ORCHESTRATORS="${var.internal_ip_addresses[0]}:4222"
 export BACALHAU_NODE_NETWORK_ADVERTISEDADDRESS="${var.public_ip_addresses[count.index]}:4222"
 export BACALHAU_NODE_NETWORK_CLUSTER_PEERS=""
-export BACALHAU_NODE_COMPUTE_LOCAL_PUBLISHER_ADDRESS="${var.public_ip_addresses[count.index]}"
+export BACALHAU_LOCAL_PUBLISHER_ADDRESS="${var.public_ip_addresses[count.index]}"
 
 
 ### secrets are installed in the install-node.sh script

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -43,7 +43,8 @@ if [[ "${BACALHAU_NODE_NETWORK_TYPE}" == "nats" ]]; then
     --web-ui-port 80 \
     --labels owner=bacalhau \
     --requester-job-translation-enabled \
-    --default-publisher ipfs
+    --default-publisher local
+    --local-publisher-address "${BACALHAU_NODE_COMPUTE_LOCAL_PUBLISHER_ADDRESS}"
 
 else
   function getMultiaddress() {
@@ -97,5 +98,6 @@ else
     --web-ui-port 80 \
     --labels owner=bacalhau \
     --requester-job-translation-enabled \
-    --default-publisher ipfs
+    --default-publisher local
+    --local-publisher-address "${BACALHAU_NODE_COMPUTE_LOCAL_PUBLISHER_ADDRESS}"
 fi

--- a/ops/terraform/remote_files/scripts/start-bacalhau.sh
+++ b/ops/terraform/remote_files/scripts/start-bacalhau.sh
@@ -43,8 +43,8 @@ if [[ "${BACALHAU_NODE_NETWORK_TYPE}" == "nats" ]]; then
     --web-ui-port 80 \
     --labels owner=bacalhau \
     --requester-job-translation-enabled \
-    --default-publisher local
-    --local-publisher-address "${BACALHAU_NODE_COMPUTE_LOCAL_PUBLISHER_ADDRESS}"
+    --default-publisher local \
+    --local-publisher-address "${BACALHAU_LOCAL_PUBLISHER_ADDRESS}"
 
 else
   function getMultiaddress() {
@@ -98,6 +98,6 @@ else
     --web-ui-port 80 \
     --labels owner=bacalhau \
     --requester-job-translation-enabled \
-    --default-publisher local
-    --local-publisher-address "${BACALHAU_NODE_COMPUTE_LOCAL_PUBLISHER_ADDRESS}"
+    --default-publisher local \
+    --local-publisher-address "${BACALHAU_LOCAL_PUBLISHER_ADDRESS}"
 fi

--- a/pkg/publisher/local/publisher.go
+++ b/pkg/publisher/local/publisher.go
@@ -99,6 +99,9 @@ func ResolveAddress(ctx context.Context, address string) string {
 		addrs, err := network.GetNetworkAddress(addressType, network.AllAddresses)
 		if err == nil && len(addrs) > 0 {
 			return addrs[0]
+		} else {
+			log.Ctx(ctx).Error().Err(err).Msg("failed to resolve network address by type, using 127.0.0.1")
+			return "127.0.0.1"
 		}
 	}
 

--- a/pkg/publisher/local/publisher.go
+++ b/pkg/publisher/local/publisher.go
@@ -33,7 +33,7 @@ func NewLocalPublisher(ctx context.Context, directory string, host string, port 
 		urlPrefix:     fmt.Sprintf("http://%s:%d", host, port),
 	}
 
-	p.server = NewLocalPublisherServer(ctx, p.baseDirectory, p.host, p.port)
+	p.server = NewLocalPublisherServer(ctx, p.baseDirectory, p.port)
 	go p.server.Run(ctx)
 
 	return p

--- a/pkg/publisher/local/publisher.go
+++ b/pkg/publisher/local/publisher.go
@@ -28,7 +28,7 @@ type Publisher struct {
 func NewLocalPublisher(ctx context.Context, directory string, host string, port int) *Publisher {
 	p := &Publisher{
 		baseDirectory: directory,
-		host:          resolveAddress(ctx, host),
+		host:          ResolveAddress(ctx, host),
 		port:          port,
 		urlPrefix:     fmt.Sprintf("http://%s:%d", host, port),
 	}
@@ -93,20 +93,14 @@ func (p *Publisher) PublishResult(
 
 var _ publisher.Publisher = (*Publisher)(nil)
 
-func resolveAddress(ctx context.Context, address string) string {
+func ResolveAddress(ctx context.Context, address string) string {
 	addressType, ok := network.AddressTypeFromString(address)
-	if !ok {
-		log.Ctx(ctx).Debug().Stringer("AddressType", addressType).Msgf("unable to find address type: %s, binding to 0.0.0.0", address)
-		return "0.0.0.0"
+	if ok {
+		addrs, err := network.GetNetworkAddress(addressType, network.AllAddresses)
+		if err == nil && len(addrs) > 0 {
+			return addrs[0]
+		}
 	}
 
-	// If we were provided with an address type and not an address, so we should look up
-	// an address from the type.
-	addrs, err := network.GetNetworkAddress(addressType, network.AllAddresses)
-	if err == nil && len(addrs) > 0 {
-		return addrs[0]
-	}
-
-	log.Ctx(ctx).Error().Err(err).Stringer("AddressType", addressType).Msgf("unable to find address for type, using 127.0.0.1")
-	return "127.0.0.1"
+	return address
 }

--- a/pkg/publisher/local/publisher_test.go
+++ b/pkg/publisher/local/publisher_test.go
@@ -34,6 +34,14 @@ func (s *PublisherTestSuite) SetupTest() {
 	s.pub = local.NewLocalPublisher(s.ctx, s.baseDir, defaultHost, defaultPort)
 }
 
+func (s *PublisherTestSuite) TestAddressResolving() {
+	ctx := context.Background()
+
+	s.Require().Equal("127.0.0.1", local.ResolveAddress(ctx, "127.0.0.1"), "address did not resolve to itself")
+	s.Require().Equal("192.168.1.100", local.ResolveAddress(ctx, "192.168.1.100"), "address did not resolve to itself")
+	s.Require().Equal("127.0.0.1", local.ResolveAddress(ctx, "local"))
+}
+
 func (s *PublisherTestSuite) TestPublishFolder() {
 	source := s.T().TempDir()
 

--- a/pkg/publisher/local/server.go
+++ b/pkg/publisher/local/server.go
@@ -18,12 +18,13 @@ type LocalPublisherServer struct {
 const (
 	readHeaderTimeout = 3 * time.Second
 	readTimeout       = 3 * time.Second
+	allAddresses      = "0.0.0.0"
 )
 
-func NewLocalPublisherServer(ctx context.Context, directory, address string, port int) *LocalPublisherServer {
+func NewLocalPublisherServer(ctx context.Context, directory string, port int) *LocalPublisherServer {
 	return &LocalPublisherServer{
 		rootDirectory: directory,
-		address:       address,
+		address:       allAddresses, // we listen on all addresses
 		port:          port,
 	}
 }


### PR DESCRIPTION
Set the address to use for the local publisher explicitly as a command line parameter, and this is used for the link that is generated in the response.  The actual publisher server will bind to all interfaces as we don't know which (if any) are actually the public address.