### PR TITLE
Enable dark mode system-pref and switcher for docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -58,7 +58,8 @@ const config = {
     ({
       colorMode: {
         defaultMode: "light",
-        disableSwitch: true,
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
       },
       image: "/static/img/logo/Bacalhau-icon.svg",
       navbar: {


### PR DESCRIPTION
Currently we support light mode. This is rather bright for someone who has their system set to dark mode.

This PR re-enables the light/dark switcher, but also defaults to any system configured default (e.g. if your OS is setup in dark mode, you get dark docs).

To try this out, checkout the code, cd into ./docs and `npm start`. You may need to `npm i`.

![Installation___Bacalhau_Docs](https://github.com/bacalhau-project/bacalhau/assets/118063/e1cc8c1c-8172-4291-9e3f-5ed17a4e39da)
