### PR TITLE
Use local node in Bash tests when starting hybrid node.

### DIFF
--- a/pkg/storage/tracing/tracing.go
+++ b/pkg/storage/tracing/tracing.go
@@ -57,9 +57,9 @@ func (t *tracingStorage) PrepareStorage(
 	defer func() {
 		dur := stopwatch()
 		log.Ctx(ctx).Debug().
-			Dur("duration", dur).
-			Object("spec", &spec).
-			Str("dir", storageDirectory).
+			Dur("Duration", dur).
+			Str("Alias", spec.Alias).
+			Str("Dir", storageDirectory).
 			Msg("storage prepared")
 	}()
 
@@ -74,8 +74,8 @@ func (t *tracingStorage) CleanupStorage(ctx context.Context, spec models.InputSo
 	defer func() {
 		dur := stopwatch()
 		log.Ctx(ctx).Debug().
-			Dur("duration", dur).
-			Object("spec", &spec).
+			Dur("Duration", dur).
+			Str("Alias", spec.Alias).
 			Msg("storage cleanup")
 	}()
 

--- a/test/bin/bacalhau.sh
+++ b/test/bin/bacalhau.sh
@@ -32,7 +32,7 @@ create_node() {
 
     # Ensure subsequent nodes automatically connect to this requester, and pick
     # a random port for the HTTP API to avoid collisions
-    if test "$TYPE" = "requester"; then
+    if [[ "$TYPE" =~ "requester" ]]; then
         source $BACALHAU_DIR/bacalhau.run
         export BACALHAU_NODE_SERVERAPI_PORT=0
     fi


### PR DESCRIPTION
Previously tests accidentally used demo network nodes if the node that
was started was a hybrid.