### PR TITLE
stop auto-generating auth tokens

### DIFF
--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -217,7 +217,7 @@ func serve(cmd *cobra.Command) error {
 		return err
 	}
 
-	networkConfig, err := getNetworkConfig(nodeName)
+	networkConfig, err := getNetworkConfig()
 	if err != nil {
 		return err
 	}
@@ -519,13 +519,6 @@ func getPublicNATSOrchestratorURL(nodeConfig *node.NodeConfig) *url.URL {
 	orchestrator := &url.URL{
 		Scheme: "nats",
 		Host:   nodeConfig.NetworkConfig.AdvertisedAddress,
-	}
-
-	// Only display the secret if the user did not set it explicitly.
-	// Else, they should already know it!
-	secret, err := config.Get[string](types.NodeNetworkAuthSecret)
-	if err == nil && secret == "" && nodeConfig.NetworkConfig.AuthSecret != "" {
-		orchestrator.User = url.User(nodeConfig.NetworkConfig.AuthSecret)
 	}
 
 	if nodeConfig.NetworkConfig.AdvertisedAddress == "" {

--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -3,7 +3,6 @@ package serve
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/ipfs"
-	"github.com/bacalhau-project/bacalhau/pkg/nats"
 	"github.com/bacalhau-project/bacalhau/pkg/node"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
@@ -207,36 +205,10 @@ func getTransportType() (string, error) {
 	return networkCfg.Type, nil
 }
 
-func getNetworkConfig(nodeID string) (node.NetworkConfig, error) {
+func getNetworkConfig() (node.NetworkConfig, error) {
 	var networkCfg types.NetworkConfig
 	if err := config.ForKey(types.NodeNetwork, &networkCfg); err != nil {
 		return node.NetworkConfig{}, err
-	}
-
-	if networkCfg.AuthSecret == "" {
-		// Generate an auth token using the user's client key. It should not be
-		// possible to compute this value by anyone other than the NATS server, and
-		// should be stable across restarts of the node.
-		secret, err := nats.CreateAuthSecret(nodeID)
-		if err != nil {
-			return node.NetworkConfig{}, err
-		}
-		networkCfg.AuthSecret = secret //nolint: gosec
-	} else {
-		// If the user supplied an auth secret and some orchestrator(s), assume
-		// they are passing a auth secret to be used as a client. Attach the
-		// secret to the orchestrator urls, ignoring any which have one already.
-		for index, orchestrator := range networkCfg.Orchestrators {
-			orchestratorURL, err := url.Parse(orchestrator)
-			if err != nil {
-				return node.NetworkConfig{}, err
-			}
-
-			if orchestratorURL.User == nil {
-				orchestratorURL.User = url.User(networkCfg.AuthSecret)
-			}
-			networkCfg.Orchestrators[index] = orchestratorURL.String()
-		}
 	}
 
 	return node.NetworkConfig{

--- a/pkg/devstack/option.go
+++ b/pkg/devstack/option.go
@@ -76,6 +76,7 @@ type DevStackConfig struct {
 	NodeInfoStoreTTL           time.Duration
 	TLS                        DevstackTLSSettings
 	NetworkType                string
+	AuthSecret                 string
 }
 
 func (o *DevStackConfig) MarshalZerologObject(e *zerolog.Event) {
@@ -225,6 +226,12 @@ func WithExecutorPlugins(enabled bool) ConfigOption {
 func WithNetworkType(typ string) ConfigOption {
 	return func(cfg *DevStackConfig) {
 		cfg.NetworkType = typ
+	}
+}
+
+func WithAuthSecret(secret string) ConfigOption {
+	return func(c *DevStackConfig) {
+		c.AuthSecret = secret
 	}
 }
 

--- a/pkg/libp2p/transport/libp2p.go
+++ b/pkg/libp2p/transport/libp2p.go
@@ -24,7 +24,6 @@ import (
 	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/rs/zerolog/log"
 )
 
 const NodeInfoTopic = "bacalhau-node-info"
@@ -126,11 +125,6 @@ func NewLibp2pTransport(ctx context.Context,
 		nodeInfoPubSub:    nodeInfoPubSub,
 		nodeInfoDecorator: peerInfoDecorator,
 	}, nil
-}
-
-func (t *Libp2pTransport) GetConnectionInfo(ctx context.Context) interface{} {
-	log.Ctx(ctx).Debug().Msg("libp2p transport get connection info is unsupported")
-	return nil
 }
 
 func (t *Libp2pTransport) RegisterNodeInfoConsumer(ctx context.Context, nodeInfoStore routing.NodeInfoStore) error {

--- a/pkg/nats/client.go
+++ b/pkg/nats/client.go
@@ -7,18 +7,13 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-type ClientManagerParams struct {
-	Name    string
-	Servers string
-}
-
 type ClientManager struct {
 	Client *nats.Conn
 }
 
 // NewClientManager is a helper function to create a NATS client connection with a given name and servers string
-func NewClientManager(ctx context.Context, params ClientManagerParams) (*ClientManager, error) {
-	nc, err := nats.Connect(params.Servers, nats.Name(params.Name))
+func NewClientManager(ctx context.Context, servers string, options ...nats.Option) (*ClientManager, error) {
+	nc, err := nats.Connect(servers, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nats/transport/nats_config_test.go
+++ b/pkg/nats/transport/nats_config_test.go
@@ -113,15 +113,6 @@ func (suite *NATSTransportConfigSuite) TestValidate() {
 			},
 			expectedErrors: []string{"cluster port -1 must be greater than zero"},
 		},
-		{
-			name: "Missing Auth secret in Requester Node",
-			config: NATSTransportConfig{
-				NodeID:          "node3",
-				Port:            4222,
-				IsRequesterNode: true,
-			},
-			expectedErrors: []string{"when using NATS, an auth secret must be provided for each node connecting to the cluster"}, //nolint:lll
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/nats/util.go
+++ b/pkg/nats/util.go
@@ -1,15 +1,12 @@
 package nats
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"net"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
@@ -80,16 +77,4 @@ func removeLocalAddresses(routes []*url.URL) ([]*url.URL, error) {
 		}
 	}
 	return result, nil
-}
-
-// CreateAuthSecret will return a signed hash of the nodeID
-// provided, for use as a secret for NATS authentication.
-func CreateAuthSecret(nodeID string) (string, error) {
-	var keySig string
-	keySig, err := system.SignForClient([]byte(nodeID))
-	if err != nil {
-		return "", err
-	}
-	hash := sha256.Sum256([]byte(keySig))
-	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
 }

--- a/pkg/node/config_network.go
+++ b/pkg/node/config_network.go
@@ -30,9 +30,9 @@ type NetworkConfig struct {
 	// Storage directory for NATS features that require it
 	StoreDir string
 
-	// AuthSecret is a secret string that clients must use to connect. It is
-	// only used by NATS servers; clients should supply the auth secret as the
-	// user part of their Orchestrator URL.
+	// AuthSecret is a secret string that clients must use to connect. NATS servers
+	// must supply this config, while clients can also supply it as the user part
+	// of their Orchestrator URL.
 	AuthSecret string
 
 	// NATS config for requester nodes to connect with each other

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -212,17 +212,22 @@ func NewNode(
 			IsRequesterNode:          config.IsRequesterNode,
 		}
 
-		transportLayer, err = nats_transport.NewNATSTransport(ctx, natsConfig)
+		natsTransportLayer, err := nats_transport.NewNATSTransport(ctx, natsConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create NATS transport layer")
 		}
+		transportLayer = natsTransportLayer
 
 		if config.IsRequesterNode {
 			// KV Node Store requires connection info from the NATS server so that it is able
 			// to create its own connection and then subscribe to the node info topic.
+			natsClient, err := nats_transport.CreateClient(ctx, natsTransportLayer.Config)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create NATS client for node info store")
+			}
 			nodeInfoStore, err := kvstore.NewNodeStore(ctx, kvstore.NodeStoreParams{
-				BucketName:     kvstore.DefaultBucketName,
-				ConnectionInfo: transportLayer.GetConnectionInfo(ctx),
+				BucketName: kvstore.DefaultBucketName,
+				Client:     natsClient.Client,
 			})
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to create node info store using NATS transport connection info")

--- a/pkg/routing/kvstore/kvstore_test.go
+++ b/pkg/routing/kvstore/kvstore_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 	natsserver "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/routing"
@@ -37,11 +38,12 @@ func (s *KVNodeInfoStoreSuite) SetupTest() {
 	opts.StoreDir = s.T().TempDir()
 
 	s.nats = natsserver.RunServer(opts)
-	serverAddress := s.nats.Addr().String()
+	natsClient, err := nats.Connect(s.nats.Addr().String())
+	s.Require().NoError(err)
 
 	s.store, _ = kvstore.NewNodeStore(context.Background(), kvstore.NodeStoreParams{
-		BucketName:     "test_nodes",
-		ConnectionInfo: serverAddress,
+		BucketName: "test_nodes",
+		Client:     natsClient,
 	})
 }
 

--- a/pkg/transport/interfaces.go
+++ b/pkg/transport/interfaces.go
@@ -32,10 +32,6 @@ type TransportLayer interface {
 	// DebugInfoProviders enables transport layer to provide meaningful debug info to operators
 	DebugInfoProviders() []model.DebugInfoProvider
 
-	// GetConnectionInfo retrieves information relevant to the transport layer for those that
-	// require it.
-	GetConnectionInfo(ctx context.Context) interface{}
-
 	// RegisterNodeInfoConsumer registers a node info consumer with the transport layer
 	RegisterNodeInfoConsumer(ctx context.Context, infostore routing.NodeInfoStore) error
 


### PR DESCRIPTION
Today we try to make the networks secure by default by auto-generating an auth token if the user does not provide one. There has been a long discussion about this that you can find [here](https://github.com/bacalhau-project/expanso-planning/issues/518). The summary is:
1. Adds complexity to user onboarding as they will have to go through the logs or console output to figure out and copy the auto-generated token
2. We are printing the generated auth token in plain text in the console
3. I prefer to decouple auto-auth from launching NATS as our transport layer
4. While better than making the network open, token based auth is not secure enough and we don't want to give the impression to the users that their networks are secure be default. Reasons include:
    1. Token based auth doesn't encrypt traffic on transit
    1. We are using a global token and don't identify or authorize the compute nodes differently
    2. No easy way to rotate or expire the token
1. We are planning to add more auth options in the future that are more secure than global tokens, and this shouldn't be the default for our users

This PR enables users to run open networks which will simplify testing out bacalhau, and they will need to provide their auth token to secure their networks instead of us doing magic on their behalf and generating a random one for them. In the future it might make more sense to fail the network from starting if not secure instead of doing some magic