### PR TITLE
Allow nodes to call register on startup, even if previously registered

### DIFF
--- a/pkg/compute/management_client.go
+++ b/pkg/compute/management_client.go
@@ -61,18 +61,12 @@ func (m *ManagementClient) getNodeInfo(ctx context.Context) models.NodeInfo {
 	})
 }
 
-// RegisterNode sends a registration request to the requester node iff
-// we have not got evidence (a local sentinel file) that we have already
-// registered.  Should we fail to register, we will return an error and
-// expect the caller to exit.
+// RegisterNode sends a registration request to the requester node. We will do this
+// even if we know we have previously registered. This will allow us to not worry
+// about split state (some local sentinel object and the remote state) and potential
+// issues. The requester node will handle the case of a duplicate registration by
+// accepting it but replying with a message to that effect.
 func (m *ManagementClient) RegisterNode(ctx context.Context) error {
-	// We only want to register this node if we haven't already
-	// been registered.
-	if m.registrationFile.Exists() {
-		log.Ctx(ctx).Debug().Msg("not registering with requester, already registered")
-		return nil
-	}
-
 	nodeInfo := m.getNodeInfo(ctx)
 	response, err := m.managementProxy.Register(ctx, requests.RegisterRequest{
 		Info: nodeInfo,
@@ -83,9 +77,6 @@ func (m *ManagementClient) RegisterNode(ctx context.Context) error {
 
 	if response.Accepted {
 		log.Ctx(ctx).Debug().Msg("register request accepted")
-		if err := m.registrationFile.Set(); err != nil {
-			return errors.Wrap(err, "failed to record local registration status")
-		}
 	} else {
 		// Might be an error, or might be rejected because it is in a pending
 		// state instead

--- a/pkg/node/manager/node_manager.go
+++ b/pkg/node/manager/node_manager.go
@@ -57,8 +57,10 @@ func (n *NodeManager) Register(ctx context.Context, request requests.RegisterReq
 			}, nil
 		}
 
+		// Otherwise we'll allow the registration, but let the compute node
+		// that it has already been registered on a previous occasion.
 		return &requests.RegisterResponse{
-			Accepted: false,
+			Accepted: true,
 			Reason:   "node already registered",
 		}, nil
 	}


### PR DESCRIPTION
More gracefully handles registration flow for compute nodes that are already registered.  Allows for re-registration of nodes by removing the sentinel file (if any)