### PR TITLE
fix: update bacalhau install script to use go v1.21.8

### DIFF
--- a/ops/marketplace-tf/modules/instance_files/install-bacalhau.sh
+++ b/ops/marketplace-tf/modules/instance_files/install-bacalhau.sh
@@ -111,6 +111,7 @@ function install-bacalhau-dependencies() {
   echo "Installing Bacalhau dependencies..."
   apt-update
   install-apt-dependencies
+  install-golang
   install-earthly
 }
 
@@ -137,6 +138,20 @@ function install-earthly() {
     echo "Failed to install Earthly." >&2
     return 1
   }
+}
+
+function install-golang() {
+  # Install go
+  export HOME=/root
+  export GOCACHE="$HOME/.cache/go-build"
+  export GOPATH="/root/go"
+  export PATH="$PATH:$GOPATH/bin:/usr/local/go/bin"
+  sudo mkdir -p "$GOPATH"
+
+  sudo rm -fr /usr/local/go /usr/local/bin/go
+  curl --silent --show-error --location --fail 'https://go.dev/dl/go1.21.8.linux-amd64.tar.gz' | sudo tar --extract --gzip --file=- --directory=/usr/local
+  sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+  go version
 }
 
 install-bacalhau "$@"

--- a/ops/marketplace-tf/vars.tfvars
+++ b/ops/marketplace-tf/vars.tfvars
@@ -4,7 +4,7 @@ requester_machine_type ="e2-standard-8"
 compute_machine_type = "e2-standard-8"
 compute_count = 2
 
-gcp_boot_image = "projects/forrest-dev-407420/global/images/bacalhau-ubuntu-2204-lts-test-latest"
+gcp_boot_image = "projects/bacalhau-dev/global/images/bacalhau-v1-2-2-ubuntu-2204-lts"
 gcp_project_id = "forrest-dev-407420"
 gcp_region = "us-west1"
 gcp_zone = "us-west1-b"


### PR DESCRIPTION
update marketplace terraform to install golang v1.21.8 as required for build specific versions of bacalhau. Also update terraform VMI image to latest release.
required due to: https://github.com/bacalhau-project/bacalhau/commit/592497232c104a3301aee1476a4df1bdcfedd000