### PR TITLE
[Documentation] add declarative example to R-Prophet page

### DIFF
--- a/docs/docs/setting-up/workload-onboarding/r-custom-docker-prophet/index.md
+++ b/docs/docs/setting-up/workload-onboarding/r-custom-docker-prophet/index.md
@@ -216,6 +216,44 @@ When a job is submitted, Bacalhau prints out the related `job_id`. We store that
 ```python
 %env JOB_ID={job_id}
 ```
+### Declarative job description
+
+The same job can be presented in the [declarative](../../../setting-up/jobs/job-specification/job.md) format. In this case, the description will look like this:
+
+```yaml
+name: Building and Running your Custom R Containers
+type: batch
+count: 1
+tasks:
+  - name: My main task
+    Engine:
+      type: docker
+      params:
+        Image: "ghcr.io/bacalhau-project/examples/r-prophet:0.0.2" 
+        Entrypoint:
+          - /bin/bash
+        Parameters:
+          - -c
+          - Rscript Saturating-Forecasts.R "/inputs/example_wp_log_R.csv" "/outputs/output0.pdf" "/outputs/output1.pdf"
+    Publisher:
+      Type: ipfs
+    ResultPaths:
+      - Name: outputs
+        Path: /outputs      
+    InputSources:
+      - Source:
+          Type: "s3"
+          Params:
+            Bucket: "r-custom-docker-prophet"
+            Key: "*"
+            Region: "us-east-1"
+        Target: "/inputs"
+```
+
+The job description should be saved in `.yaml` format, e.g. `job.yaml`, and then run with the command:
+```bash
+bacalhau job run job.yaml
+```
 
 ## 5. Checking the State of your Jobs
 

--- a/docs/docs/setting-up/workload-onboarding/r-custom-docker-prophet/index.md
+++ b/docs/docs/setting-up/workload-onboarding/r-custom-docker-prophet/index.md
@@ -242,12 +242,10 @@ tasks:
         Path: /outputs      
     InputSources:
       - Source:
-          Type: "s3"
+          Type: "ipfs"
           Params:
-            Bucket: "r-custom-docker-prophet"
-            Key: "*"
-            Region: "us-east-1"
-        Target: "/inputs"
+            CID: "QmY8BAftd48wWRYDf5XnZGkhwqgjpzjyUG3hN1se6SYaFt"
+        Target: "/inputs/example_wp_log_R.csv"
 ```
 
 The job description should be saved in `.yaml` format, e.g. `job.yaml`, and then run with the command:


### PR DESCRIPTION
add declarative example from https://github.com/bacalhau-project/example-jobs-v2/tree/main/example-jobs-v2/workload-onboarding