### PR TITLE
Adds a `node delete` command

### DIFF
--- a/cmd/cli/node/action_test.go
+++ b/cmd/cli/node/action_test.go
@@ -75,6 +75,23 @@ func (s *NodeActionSuite) TestListNodes() {
 	)
 	s.Require().NoError(err)
 	s.Require().Contains(out, "Ok")
+
+	// Delete the node
+	_, out, err = s.ExecuteTestCobraCommand(
+		"node",
+		"delete",
+		nodeID,
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(out, "Ok")
+
+	_, out, err = s.ExecuteTestCobraCommand(
+		"node",
+		"list",
+		"--output", "csv",
+	)
+	s.Require().NoError(err)
+	s.Require().NotContains(out, nodeID)
 }
 
 func getCells(output string, lineNo int) []string {

--- a/cmd/cli/node/root.go
+++ b/cmd/cli/node/root.go
@@ -23,5 +23,8 @@ func NewCmd() *cobra.Command {
 	// Reject Action
 	cmd.AddCommand(NewActionCmd(apimodels.NodeActionReject))
 
+	// Reject Action
+	cmd.AddCommand(NewActionCmd(apimodels.NodeActionDelete))
+
 	return cmd
 }

--- a/pkg/node/manager/node_manager.go
+++ b/pkg/node/manager/node_manager.go
@@ -189,7 +189,7 @@ func (n *NodeManager) Delete(ctx context.Context, nodeID string) error {
 // Approve is used to approve a node for joining the cluster along with a specific
 // reason for the approval (for audit). The return values denote success and any
 // failure of the operation as a human readable string.
-func (n *NodeManager) Approve(ctx context.Context, nodeID string, reason string) (bool, string) {
+func (n *NodeManager) ApproveAction(ctx context.Context, nodeID string, reason string) (bool, string) {
 	info, err := n.nodeInfo.GetByPrefix(ctx, nodeID)
 	if err != nil {
 		return false, err.Error()
@@ -212,7 +212,7 @@ func (n *NodeManager) Approve(ctx context.Context, nodeID string, reason string)
 // Reject is used to reject a node from joining the cluster along with a specific
 // reason for the rejection (for audit). The return values denote success and any
 // failure of the operation as a human readable string.
-func (n *NodeManager) Reject(ctx context.Context, nodeID string, reason string) (bool, string) {
+func (n *NodeManager) RejectAction(ctx context.Context, nodeID string, reason string) (bool, string) {
 	info, err := n.nodeInfo.GetByPrefix(ctx, nodeID)
 	if err != nil {
 		return false, err.Error()
@@ -227,6 +227,22 @@ func (n *NodeManager) Reject(ctx context.Context, nodeID string, reason string) 
 
 	if err := n.nodeInfo.Add(ctx, info); err != nil {
 		return false, "failed to save nodeinfo during node rejection"
+	}
+
+	return true, ""
+}
+
+// Reject is used to reject a node from joining the cluster along with a specific
+// reason for the rejection (for audit). The return values denote success and any
+// failure of the operation as a human readable string.
+func (n *NodeManager) DeleteAction(ctx context.Context, nodeID string, reason string) (bool, string) {
+	info, err := n.nodeInfo.GetByPrefix(ctx, nodeID)
+	if err != nil {
+		return false, err.Error()
+	}
+
+	if err := n.nodeInfo.Delete(ctx, info.NodeID); err != nil {
+		return false, fmt.Sprintf("failed to delete nodeinfo: %s", err)
 	}
 
 	return true, ""

--- a/pkg/publicapi/apimodels/node.go
+++ b/pkg/publicapi/apimodels/node.go
@@ -69,7 +69,7 @@ func (n NodeAction) Description() string {
 	case NodeActionReject:
 		return "Reject a node whose membership is pending"
 	case NodeActionDelete:
-		return "Delete a node from the cluster. Note this does not stop them re-connecting."
+		return "Delete a node from the cluster."
 	}
 	return ""
 }

--- a/pkg/publicapi/apimodels/node.go
+++ b/pkg/publicapi/apimodels/node.go
@@ -59,6 +59,7 @@ type NodeAction string
 const (
 	NodeActionApprove NodeAction = "approve"
 	NodeActionReject  NodeAction = "reject"
+	NodeActionDelete  NodeAction = "delete"
 )
 
 func (n NodeAction) Description() string {
@@ -67,10 +68,12 @@ func (n NodeAction) Description() string {
 		return "Approve a node whose membership is pending"
 	case NodeActionReject:
 		return "Reject a node whose membership is pending"
+	case NodeActionDelete:
+		return "Delete a node from the cluster. Note this does not stop them re-connecting."
 	}
 	return ""
 }
 
 func (n NodeAction) IsValid() bool {
-	return n == NodeActionApprove || n == NodeActionReject
+	return n == NodeActionApprove || n == NodeActionReject || n == NodeActionDelete
 }

--- a/pkg/publicapi/endpoint/orchestrator/node.go
+++ b/pkg/publicapi/endpoint/orchestrator/node.go
@@ -148,9 +148,11 @@ func (e *Endpoint) updateNode(c echo.Context) error {
 
 	var action func(context.Context, string, string) (bool, string)
 	if args.Action == string(apimodels.NodeActionApprove) {
-		action = e.nodeManager.Approve
+		action = e.nodeManager.ApproveAction
 	} else if args.Action == string(apimodels.NodeActionReject) {
-		action = e.nodeManager.Reject
+		action = e.nodeManager.RejectAction
+	} else if args.Action == string(apimodels.NodeActionDelete) {
+		action = e.nodeManager.DeleteAction
 	} else {
 		action = func(context.Context, string, string) (bool, string) {
 			return false, "unsupported action"


### PR DESCRIPTION
Allows for nodes to be delete from the node info store. If the node is found in the store, it is deleted, and then will not re-appear when the requester node is re-started.  If however the compute node restarts, it will re-register so this command is only useful if you know that nodes will not be coming back.

In future if we want to block the node-id from ever being an entry, we should add tombstone entries to the node info store that blog it's registration.

Closes #3715 