### PR TITLE
Replace use of multierror libraries with now standardised errors.Join

### DIFF
--- a/cmd/cli/serve/util.go
+++ b/cmd/cli/serve/util.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -11,11 +12,10 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	boltjobstore "github.com/bacalhau-project/bacalhau/pkg/jobstore/boltdb"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"github.com/spf13/viper"
-	"go.uber.org/multierr"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
@@ -38,7 +38,7 @@ func GetComputeConfig(ctx context.Context, createExecutionStore bool) (node.Comp
 	queueResources, queueErr := cfg.Capacity.QueueResourceLimits.ToResources()
 	jobResources, jobErr := cfg.Capacity.JobResourceLimits.ToResources()
 	defaultResources, defaultErr := cfg.Capacity.DefaultJobResourceLimits.ToResources()
-	if err := multierr.Combine(totalErr, queueErr, jobErr, defaultErr); err != nil {
+	if err := errors.Join(totalErr, queueErr, jobErr, defaultErr); err != nil {
 		return node.ComputeConfig{}, err
 	}
 
@@ -48,7 +48,7 @@ func GetComputeConfig(ctx context.Context, createExecutionStore bool) (node.Comp
 	if createExecutionStore {
 		executionStore, err = getExecutionStore(ctx, cfg.ExecutionStore)
 		if err != nil {
-			return node.ComputeConfig{}, errors.Wrapf(err, "failed to create execution store")
+			return node.ComputeConfig{}, pkgerrors.Wrapf(err, "failed to create execution store")
 		}
 	}
 
@@ -88,7 +88,7 @@ func GetRequesterConfig(ctx context.Context, createJobStore bool) (node.Requeste
 	if createJobStore {
 		jobStore, err = getJobStore(ctx, cfg.JobStore)
 		if err != nil {
-			return node.RequesterConfig{}, errors.Wrapf(err, "failed to create job store")
+			return node.RequesterConfig{}, pkgerrors.Wrapf(err, "failed to create job store")
 		}
 	}
 	return node.NewRequesterConfigWith(node.RequesterConfigParams{

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/hashicorp/go-hclog v1.6.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/imdario/mergo v0.3.16
@@ -81,7 +80,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.23.1
 	go.ptx.dk/multierrgroup v0.0.3
 	go.uber.org/mock v0.4.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.21.0
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
@@ -136,6 +134,7 @@ require (
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab // indirect
 	github.com/ipfs-shipyard/nopfs v0.0.12 // indirect
@@ -192,6 +191,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	gonum.org/v1/gonum v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240108191215-35c7eff3a6b1 // indirect

--- a/pkg/authz/policy.go
+++ b/pkg/authz/policy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/lib/policy"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
 )
 
 // The name of the rule that must be `true` for the authorization provider to
@@ -126,7 +125,7 @@ func (authorizer *policyAuthorizer) Authorize(req *http.Request) (Authorization,
 
 	approved, aErr := authorizer.allowQuery(req.Context(), in)
 	tokenValid, tvErr := authorizer.tokenValidQuery(req.Context(), in)
-	return Authorization{Approved: approved, TokenValid: tokenValid}, multierr.Append(aErr, tvErr)
+	return Authorization{Approved: approved, TokenValid: tokenValid}, errors.Join(aErr, tvErr)
 }
 
 // AlwaysAllowPolicy is a policy that will always permit access, irrespective of

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog/log"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -193,14 +192,14 @@ func PrepareRunArguments(
 			},
 		}, func(ctx context.Context) error {
 			log.Ctx(ctx).Info().Str("execution", execution.ID).Msg("cleaning up execution")
-			cleanupErr := new(multierror.Error)
+			var cleanupErr error
 			for _, cleanupFunc := range cleanupFuncs {
 				if err := cleanupFunc(ctx); err != nil {
 					log.Ctx(ctx).Error().Err(err).Str("execution", execution.ID).Msg("cleaning up execution")
-					cleanupErr = multierror.Append(cleanupErr, err)
+					cleanupErr = errors.Join(cleanupErr, err)
 				}
 			}
-			return cleanupErr.ErrorOrNil()
+			return cleanupErr
 		}, nil
 }
 

--- a/pkg/config/types/storagetype.go
+++ b/pkg/config/types/storagetype.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"go.uber.org/multierr"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,11 +16,11 @@ type JobStoreConfig struct {
 func (cfg JobStoreConfig) Validate() error {
 	var err error
 	if cfg.Type <= UnknownStorage || cfg.Type > BoltDB {
-		err = multierr.Append(err, fmt.Errorf("unknown execution store type: %q", cfg.Type.String()))
+		err = errors.Join(err, fmt.Errorf("unknown execution store type: %q", cfg.Type.String()))
 	}
 
 	if cfg.Path == "" {
-		err = multierr.Append(err, fmt.Errorf("execution store path is missing"))
+		err = errors.Join(err, fmt.Errorf("execution store path is missing"))
 	}
 
 	return err

--- a/pkg/devstack/option.go
+++ b/pkg/devstack/option.go
@@ -1,10 +1,10 @@
 package devstack
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
 
 	"github.com/bacalhau-project/bacalhau/pkg/node"
@@ -97,28 +97,28 @@ func (o *DevStackConfig) MarshalZerologObject(e *zerolog.Event) {
 }
 
 func (o *DevStackConfig) Validate() error {
-	errs := new(multierror.Error)
+	var errs error
 	totalNodeCount := o.NumberOfHybridNodes + o.NumberOfRequesterOnlyNodes + o.NumberOfComputeOnlyNodes
 
 	if totalNodeCount == 0 {
-		errs = multierror.Append(errs, fmt.Errorf("you cannot create a devstack with zero nodes"))
+		errs = errors.Join(errs, fmt.Errorf("you cannot create a devstack with zero nodes"))
 	}
 
 	totalComputeNodes := o.NumberOfComputeOnlyNodes + o.NumberOfHybridNodes
 	if o.NumberOfBadComputeActors > totalComputeNodes {
-		errs = multierror.Append(errs,
+		errs = errors.Join(errs,
 			fmt.Errorf("you cannot have more bad compute actors (%d) than there are nodes (%d)",
 				o.NumberOfBadComputeActors, totalComputeNodes))
 	}
 
 	totalRequesterNodes := o.NumberOfRequesterOnlyNodes + o.NumberOfHybridNodes
 	if o.NumberOfBadRequesterActors > totalRequesterNodes {
-		errs = multierror.Append(errs,
+		errs = errors.Join(errs,
 			fmt.Errorf("you cannot have more bad requester actors (%d) than there are nodes (%d)",
 				o.NumberOfBadRequesterActors, totalRequesterNodes))
 	}
 
-	return errs.ErrorOrNil()
+	return errs
 }
 
 func WithNodeOverrides(overrides ...node.NodeConfig) ConfigOption {

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform.go
@@ -2,9 +2,8 @@ package semantic
 
 import (
 	"context"
+	"errors"
 	"sync"
-
-	"go.uber.org/multierr"
 
 	dockermodels "github.com/bacalhau-project/bacalhau/pkg/executor/docker/models"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -95,7 +94,7 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 		log.Ctx(ctx).Debug().Str("Image", dockerEngine.Image).Msg("Image found in manifest cache")
 	}
 
-	errs := multierr.Combine(serr, ierr)
+	errs := errors.Join(serr, ierr)
 	if errs != nil {
 		return bidstrategy.BidStrategyResponse{
 			ShouldBid: false,

--- a/pkg/executor/results.go
+++ b/pkg/executor/results.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/rs/zerolog/log"
 	"go.ptx.dk/multierrgroup"
-	"go.uber.org/multierr"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 
@@ -137,7 +137,7 @@ func WriteJobResults(
 		})
 	}
 
-	err = multierr.Append(err, wg.Wait())
+	err = errors.Join(err, wg.Wait())
 	if err != nil {
 		result.ErrorMsg = err.Error()
 	}

--- a/pkg/libp2p/transport/libp2p.go
+++ b/pkg/libp2p/transport/libp2p.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	core_transport "github.com/bacalhau-project/bacalhau/pkg/transport"
 	"github.com/bacalhau-project/bacalhau/pkg/transport/bprotocol"
-	"github.com/hashicorp/go-multierror"
 	libp2p_pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
@@ -36,10 +36,10 @@ type Libp2pTransportConfig struct {
 }
 
 func (c *Libp2pTransportConfig) Validate() error {
-	var mErr *multierror.Error
-	mErr = multierror.Append(mErr, validate.IsNotNil(c.Host, "libp2p host cannot be nil"))
-	mErr = multierror.Append(mErr, validate.IsNotNil(c.CleanupManager, "cleanupManager cannot be nil"))
-	return mErr.ErrorOrNil()
+	return errors.Join(
+		validate.IsNotNil(c.Host, "libp2p host cannot be nil"),
+		validate.IsNotNil(c.CleanupManager, "cleanupManager cannot be nil"),
+	)
 }
 
 type Libp2pTransport struct {
@@ -197,10 +197,10 @@ func (t *Libp2pTransport) DebugInfoProviders() []model.DebugInfoProvider {
 
 // Close closes the transport layer.
 func (t *Libp2pTransport) Close(ctx context.Context) error {
-	var errors *multierror.Error
-	errors = multierror.Append(errors, t.nodeInfoPubSub.Close(ctx))
-	errors = multierror.Append(errors, t.Host.Close())
-	return errors.ErrorOrNil()
+	return errors.Join(
+		t.nodeInfoPubSub.Close(ctx),
+		t.Host.Close(),
+	)
 }
 
 func newLibp2pPubSub(ctx context.Context, host host.Host) (*libp2p_pubsub.PubSub, error) {

--- a/pkg/logger/buffering.go
+++ b/pkg/logger/buffering.go
@@ -1,10 +1,10 @@
 package logger
 
 import (
+	"errors"
 	"io"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/exp/slices"
 )
@@ -59,7 +59,7 @@ func (b *bufferingLogWriter) writeLogs(w io.Writer) error {
 	var errs error
 	for _, line := range b.buffer {
 		if _, err := w.Write(line); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 	return errs

--- a/pkg/model/job.go
+++ b/pkg/model/job.go
@@ -1,13 +1,13 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/imdario/mergo"
 	"github.com/rs/zerolog/log"
-	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
@@ -153,11 +153,11 @@ func (d Deal) IsValid() error {
 		if d.Concurrency > 1 {
 			// Although the requirement is stated as == 0, the default value is
 			// 1, so we just ignore both 1 or 0 for convenience.
-			err = multierr.Append(err, fmt.Errorf("concurrency ignored for target all mode, must be == 0"))
+			err = errors.Join(err, fmt.Errorf("concurrency ignored for target all mode, must be == 0"))
 		}
 	case TargetAny:
 		if d.Concurrency <= 0 {
-			err = multierr.Append(err, fmt.Errorf("concurrency must be >= 1"))
+			err = errors.Join(err, fmt.Errorf("concurrency must be >= 1"))
 		}
 	}
 

--- a/pkg/model/network.go
+++ b/pkg/model/network.go
@@ -1,13 +1,13 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
 	"strings"
 
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
 	"golang.org/x/exp/slices"
 )
 
@@ -90,7 +90,7 @@ func (n NetworkConfig) Disabled() bool {
 // otherwise.
 func (n NetworkConfig) IsValid() (err error) {
 	if n.Type < NetworkNone || n.Type > NetworkHTTP {
-		err = multierr.Append(err, fmt.Errorf("invalid networking type %q", n.Type))
+		err = errors.Join(err, fmt.Errorf("invalid networking type %q", n.Type))
 	}
 
 	for _, domain := range n.Domains {
@@ -100,7 +100,7 @@ func (n NetworkConfig) IsValid() (err error) {
 		if net.ParseIP(domain) != nil {
 			continue
 		}
-		err = multierr.Append(err, fmt.Errorf("invalid domain %q", domain))
+		err = errors.Join(err, fmt.Errorf("invalid domain %q", domain))
 	}
 
 	return

--- a/pkg/models/execution.go
+++ b/pkg/models/execution.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
 )
 
@@ -162,21 +160,21 @@ func (e *Execution) Copy() *Execution {
 
 // Validate is used to check a job for reasonable configuration
 func (e *Execution) Validate() error {
-	var mErr multierror.Error
+	var mErr error
 	if validate.IsBlank(e.ID) {
-		mErr.Errors = append(mErr.Errors, errors.New("missing execution ID"))
+		mErr = errors.Join(mErr, errors.New("missing execution ID"))
 	} else if validate.ContainsSpaces(e.ID) {
-		mErr.Errors = append(mErr.Errors, errors.New("job ID contains a space"))
+		mErr = errors.Join(mErr, errors.New("job ID contains a space"))
 	} else if validate.ContainsNull(e.ID) {
-		mErr.Errors = append(mErr.Errors, errors.New("job ID contains a null character"))
+		mErr = errors.Join(mErr, errors.New("job ID contains a null character"))
 	}
 	if validate.IsBlank(e.Namespace) {
-		mErr.Errors = append(mErr.Errors, errors.New("execution must be in a namespace"))
+		mErr = errors.Join(mErr, errors.New("execution must be in a namespace"))
 	}
 	if validate.IsBlank(e.JobID) {
-		mErr.Errors = append(mErr.Errors, errors.New("missing execution job ID"))
+		mErr = errors.Join(mErr, errors.New("missing execution job ID"))
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }
 
 // IsTerminalState returns true if the execution desired of observed state is terminal

--- a/pkg/models/input_source.go
+++ b/pkg/models/input_source.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
@@ -56,12 +55,12 @@ func (a *InputSource) Validate() error {
 	if a == nil {
 		return nil
 	}
-	var mErr multierror.Error
+	var mErr error
 	if err := a.Source.Validate(); err != nil {
-		mErr.Errors = append(mErr.Errors, fmt.Errorf("invalid artifact source: %w", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid artifact source: %w", err))
 	}
 	if validate.IsBlank(a.Target) {
-		mErr.Errors = append(mErr.Errors, errors.New("missing artifact target"))
+		mErr = errors.Join(mErr, errors.New("missing artifact target"))
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }

--- a/pkg/models/network.go
+++ b/pkg/models/network.go
@@ -2,13 +2,13 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
 	"strings"
 
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
 	"golang.org/x/exp/slices"
 )
 
@@ -115,7 +115,7 @@ func (n *NetworkConfig) Copy() *NetworkConfig {
 // otherwise.
 func (n *NetworkConfig) Validate() (err error) {
 	if n.Type < NetworkNone || n.Type > NetworkHTTP {
-		err = multierr.Append(err, fmt.Errorf("invalid networking type %q", n.Type))
+		err = errors.Join(err, fmt.Errorf("invalid networking type %q", n.Type))
 	}
 
 	for _, domain := range n.Domains {
@@ -125,7 +125,7 @@ func (n *NetworkConfig) Validate() (err error) {
 		if net.ParseIP(domain) != nil {
 			continue
 		}
-		err = multierr.Append(err, fmt.Errorf("invalid domain %q", domain))
+		err = errors.Join(err, fmt.Errorf("invalid domain %q", domain))
 	}
 
 	return

--- a/pkg/models/path.go
+++ b/pkg/models/path.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
-	"github.com/hashicorp/go-multierror"
 )
 
 type ResultPath struct {
@@ -40,12 +39,12 @@ func (p *ResultPath) Validate() error {
 	if p == nil {
 		return errors.New("path is nil")
 	}
-	var mErr multierror.Error
+	var mErr error
 	if validate.IsBlank(p.Path) {
-		mErr.Errors = append(mErr.Errors, errors.New("path is blank"))
+		mErr = errors.Join(mErr, errors.New("path is blank"))
 	}
 	if validate.IsBlank(p.Name) {
-		mErr.Errors = append(mErr.Errors, errors.New("resultpath name is blank"))
+		mErr = errors.Join(mErr, errors.New("resultpath name is blank"))
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }

--- a/pkg/models/selector.go
+++ b/pkg/models/selector.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
-	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 )
@@ -43,25 +42,25 @@ func (r *LabelSelectorRequirement) Copy() *LabelSelectorRequirement {
 }
 
 func (r *LabelSelectorRequirement) Validate() error {
-	var mErr multierror.Error
+	var mErr error
 	if validate.IsBlank(r.Key) {
-		mErr.Errors = append(mErr.Errors, errors.New("selector key cannot be blank"))
+		mErr = errors.Join(mErr, errors.New("selector key cannot be blank"))
 	}
 	switch r.Operator {
 	case selection.In, selection.NotIn:
 		if validate.IsEmpty(r.Values) {
-			mErr.Errors = append(mErr.Errors, errors.New("selector values cannot be empty for In or NotIn operators"))
+			mErr = errors.Join(mErr, errors.New("selector values cannot be empty for In or NotIn operators"))
 		}
 	case selection.Exists, selection.DoesNotExist:
 		if !validate.IsEmpty(r.Values) {
-			mErr.Errors = append(mErr.Errors, errors.New("selector values must be empty for Exists or DoesNotExist operators"))
+			mErr = errors.Join(mErr, errors.New("selector values must be empty for Exists or DoesNotExist operators"))
 		}
 	default:
 		if len(r.Values) != 1 {
-			mErr.Errors = append(mErr.Errors, errors.New("selector values must have exactly one value for other operators"))
+			mErr = errors.Join(mErr, errors.New("selector values must have exactly one value for other operators"))
 		}
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }
 
 func ToLabelSelectorRequirements(requirements ...labels.Requirement) []LabelSelectorRequirement {

--- a/pkg/models/timeout.go
+++ b/pkg/models/timeout.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // TimeoutConfig is the configuration for timeout related settings,
@@ -35,9 +33,9 @@ func (t *TimeoutConfig) Validate() error {
 	if t == nil {
 		return errors.New("missing timeout config")
 	}
-	var mErr multierror.Error
+	var mErr error
 	if t.ExecutionTimeout < 0 {
-		mErr.Errors = append(mErr.Errors, fmt.Errorf("invalid execution timeout value: %s", t.GetExecutionTimeout()))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid execution timeout value: %s", t.GetExecutionTimeout()))
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }

--- a/pkg/node/config_network.go
+++ b/pkg/node/config_network.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/hashicorp/go-multierror"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/samber/lo"
 )
@@ -47,11 +46,11 @@ type NetworkConfig struct {
 }
 
 func (c *NetworkConfig) Validate() error {
-	var mErr *multierror.Error
+	var mErr error
 	if validate.IsBlank(c.Type) {
-		mErr = multierror.Append(mErr, errors.New("missing network type"))
+		mErr = errors.Join(mErr, errors.New("missing network type"))
 	} else if !lo.Contains(supportedNetworks, c.Type) {
-		mErr = multierror.Append(mErr, fmt.Errorf("network type %s not in supported values %s", c.Type, supportedNetworks))
+		mErr = errors.Join(mErr, fmt.Errorf("network type %s not in supported values %s", c.Type, supportedNetworks))
 	}
-	return mErr.ErrorOrNil()
+	return mErr
 }

--- a/pkg/node/factories.go
+++ b/pkg/node/factories.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/bacalhau-project/bacalhau/pkg/authn"
@@ -16,7 +17,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
 	publisher_util "github.com/bacalhau-project/bacalhau/pkg/publisher/util"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
-	"go.uber.org/multierr"
 )
 
 // Interfaces to inject dependencies into the stack
@@ -149,7 +149,7 @@ func NewStandardAuthenticatorsFactory() AuthenticatorsFactory {
 				case authn.MethodTypeChallenge:
 					methodPolicy, err := policy.FromPathOrDefault(authnConfig.PolicyPath, challenge.AnonymousModePolicy)
 					if err != nil {
-						allErr = multierr.Append(allErr, err)
+						allErr = errors.Join(allErr, err)
 						continue
 					}
 
@@ -162,7 +162,7 @@ func NewStandardAuthenticatorsFactory() AuthenticatorsFactory {
 				case authn.MethodTypeAsk:
 					methodPolicy, err := policy.FromPath(authnConfig.PolicyPath)
 					if err != nil {
-						allErr = multierr.Append(allErr, err)
+						allErr = errors.Join(allErr, err)
 						continue
 					}
 
@@ -172,7 +172,7 @@ func NewStandardAuthenticatorsFactory() AuthenticatorsFactory {
 						nodeConfig.NodeID,
 					)
 				default:
-					allErr = multierr.Append(allErr, fmt.Errorf("unknown authentication type: %q", authnConfig.Type))
+					allErr = errors.Join(allErr, fmt.Errorf("unknown authentication type: %q", authnConfig.Type))
 				}
 			}
 

--- a/pkg/orchestrator/selection/discovery/chained.go
+++ b/pkg/orchestrator/selection/discovery/chained.go
@@ -2,12 +2,12 @@ package discovery
 
 import (
 	"context"
+	"errors"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"go.uber.org/multierr"
 	"golang.org/x/exp/maps"
 )
 
@@ -41,7 +41,7 @@ func (c *Chain) chainDiscovery(
 	uniqueNodes := make(map[string]models.NodeInfo, 0)
 	for _, discoverer := range c.discoverers {
 		nodeInfos, discoverErr := getNodes(discoverer)
-		err = multierr.Append(err, errors.Wrapf(discoverErr, "error finding nodes from %T", discoverer))
+		err = errors.Join(err, pkgerrors.Wrapf(discoverErr, "error finding nodes from %T", discoverer))
 		currentNodesCount := len(uniqueNodes)
 		for _, nodeInfo := range nodeInfos {
 			if _, ok := uniqueNodes[nodeInfo.ID()]; !ok {

--- a/pkg/publicapi/apimodels/job.go
+++ b/pkg/publicapi/apimodels/job.go
@@ -1,11 +1,9 @@
 package apimodels
 
 import (
-	"errors"
 	"strconv"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -23,15 +21,7 @@ func (r *PutJobRequest) Normalize() {
 
 // Validate is used to validate fields in the PutJobRequest.
 func (r *PutJobRequest) Validate() error {
-	mErr := new(multierror.Error)
-	if r.Job == nil {
-		mErr = multierror.Append(mErr, errors.New("job is required"))
-	}
-	jobErrs := r.Job.ValidateSubmission()
-	if jobErrs != nil {
-		mErr = multierror.Append(mErr, jobErrs)
-	}
-	return mErr.ErrorOrNil()
+	return r.Job.ValidateSubmission()
 }
 
 type PutJobResponse struct {

--- a/pkg/publicapi/client/v2/util.go
+++ b/pkg/publicapi/client/v2/util.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	"go.uber.org/multierr"
 )
 
 // encodeBody prepares the reader to serve as the request body.
@@ -121,7 +120,7 @@ func DialAsyncResult[In apimodels.Request, Out any](
 			outResult := new(concurrency.AsyncResult[Out])
 			if result.Value != nil {
 				decodeErr := json.NewDecoder(bytes.NewReader(result.Value)).Decode(outResult)
-				outResult.Err = multierr.Combine(outResult.Err, result.Err, decodeErr)
+				outResult.Err = errors.Join(outResult.Err, result.Err, decodeErr)
 			} else {
 				outResult.Err = result.Err
 			}

--- a/pkg/publisher/fanout/publisher.go
+++ b/pkg/publisher/fanout/publisher.go
@@ -2,13 +2,13 @@ package fanout
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/rs/zerolog/log"
-	"go.uber.org/multierr"
 
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
 )
@@ -76,7 +76,7 @@ func fanout[T any, P any](ctx context.Context, publishers []P, method func(P) (T
 		close(internalErrorChannel)
 		var multi error
 		for err := range internalErrorChannel {
-			multi = multierr.Append(multi, err)
+			multi = errors.Join(multi, err)
 		}
 		externalErrorChannel <- multi
 		close(externalErrorChannel)

--- a/pkg/routing/kvstore/kvstore.go
+++ b/pkg/routing/kvstore/kvstore.go
@@ -3,13 +3,13 @@ package kvstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/samber/lo"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -33,18 +33,18 @@ type NodeStore struct {
 func NewNodeStore(ctx context.Context, params NodeStoreParams) (*NodeStore, error) {
 	js, err := jetstream.New(params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to connect to jetstream")
+		return nil, pkgerrors.Wrap(err, "failed to connect to jetstream")
 	}
 
 	bucketName := strings.ToLower(params.BucketName)
 	if bucketName == "" {
-		return nil, errors.New("bucket name is required")
+		return nil, pkgerrors.New("bucket name is required")
 	}
 	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket: bucketName,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create key-value store")
+		return nil, pkgerrors.Wrap(err, "failed to create key-value store")
 	}
 
 	return &NodeStore{
@@ -70,12 +70,12 @@ func (n *NodeStore) FindPeer(ctx context.Context, peerID peer.ID) (peer.AddrInfo
 func (n *NodeStore) Add(ctx context.Context, nodeInfo models.NodeInfo) error {
 	data, err := json.Marshal(nodeInfo)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal node info adding to node store")
+		return pkgerrors.Wrap(err, "failed to marshal node info adding to node store")
 	}
 
 	_, err = n.kv.Put(ctx, nodeInfo.ID(), data)
 	if err != nil {
-		return errors.Wrap(err, "failed to write node info to node store")
+		return pkgerrors.Wrap(err, "failed to write node info to node store")
 	}
 
 	return nil
@@ -85,17 +85,17 @@ func (n *NodeStore) Add(ctx context.Context, nodeInfo models.NodeInfo) error {
 func (n *NodeStore) Get(ctx context.Context, nodeID string) (models.NodeInfo, error) {
 	entry, err := n.kv.Get(ctx, nodeID)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
+		if pkgerrors.Is(err, jetstream.ErrKeyNotFound) {
 			return models.NodeInfo{}, routing.NewErrNodeNotFound(nodeID)
 		}
 
-		return models.NodeInfo{}, errors.Wrap(err, "failed to get node info from node store")
+		return models.NodeInfo{}, pkgerrors.Wrap(err, "failed to get node info from node store")
 	}
 
 	var node models.NodeInfo
 	err = json.Unmarshal(entry.Value(), &node)
 	if err != nil {
-		return models.NodeInfo{}, errors.Wrap(err, "failed to unmarshal node info from node store")
+		return models.NodeInfo{}, pkgerrors.Wrap(err, "failed to unmarshal node info from node store")
 	}
 
 	return node, nil
@@ -107,10 +107,10 @@ func (n *NodeStore) Get(ctx context.Context, nodeID string) (models.NodeInfo, er
 func (n *NodeStore) GetByPrefix(ctx context.Context, prefix string) (models.NodeInfo, error) {
 	keys, err := n.kv.Keys(ctx)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
+		if pkgerrors.Is(err, jetstream.ErrNoKeysFound) {
 			return models.NodeInfo{}, routing.NewErrNodeNotFound(prefix)
 		}
-		return models.NodeInfo{}, errors.Wrap(err, "failed to get by prefix when listing keys")
+		return models.NodeInfo{}, pkgerrors.Wrap(err, "failed to get by prefix when listing keys")
 	}
 
 	// Filter the list down to just the matching keys
@@ -132,13 +132,13 @@ func (n *NodeStore) List(ctx context.Context, filters ...routing.NodeInfoFilter)
 	keys, err := n.kv.Keys(ctx)
 	if err != nil {
 		// Return an empty list rather than an error if there are no keys in the bucket
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
+		if pkgerrors.Is(err, jetstream.ErrNoKeysFound) {
 			return []models.NodeInfo{}, nil
 		}
-		return nil, errors.Wrap(err, "failed to list node info from node store")
+		return nil, pkgerrors.Wrap(err, "failed to list node info from node store")
 	}
 
-	var errors *multierror.Error
+	var mErr error
 
 	// Create a mega filter that combines all the filters into one
 	megaFilter := func(info models.NodeInfo) bool {
@@ -154,7 +154,7 @@ func (n *NodeStore) List(ctx context.Context, filters ...routing.NodeInfoFilter)
 	for _, key := range keys {
 		node, err := n.Get(ctx, key)
 		if err != nil {
-			errors = multierror.Append(errors, err)
+			mErr = errors.Join(mErr, err)
 		}
 
 		if megaFilter(node) {
@@ -162,13 +162,13 @@ func (n *NodeStore) List(ctx context.Context, filters ...routing.NodeInfoFilter)
 		}
 	}
 
-	return nodes, errors.ErrorOrNil()
+	return nodes, mErr
 }
 
 // Delete deletes a node info from the repo.
 func (n *NodeStore) Delete(ctx context.Context, nodeID string) error {
 	if err := n.kv.Purge(ctx, nodeID); err != nil {
-		return errors.Wrap(err, "failed to purge node info from node store")
+		return pkgerrors.Wrap(err, "failed to purge node info from node store")
 	}
 
 	return nil

--- a/pkg/storage/inline/storage.go
+++ b/pkg/storage/inline/storage.go
@@ -29,6 +29,7 @@ package inline
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -37,7 +38,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/util/targzip"
 	"github.com/c2h5oh/datasize"
 	"github.com/vincent-petithory/dataurl"
-	"go.uber.org/multierr"
 )
 
 // The maximum size that will be stored inline without gzip compression.
@@ -134,7 +134,7 @@ func (i *InlineStorage) PrepareStorage(_ context.Context, storageDirectory strin
 			Type:   storage.StorageVolumeConnectorBind,
 			Source: tempfile.Name(),
 			Target: spec.Target,
-		}, multierr.Combine(werr, cerr)
+		}, errors.Join(werr, cerr)
 	}
 }
 


### PR DESCRIPTION
`errors.Join` preserves the tree of errors by producing structures with `Unwrap() []error` calls available whereas multierr{or} only produces a linear chain of errors using `Unwrap() error` calls. This is a largely mechanical change using find/replace.

This is necessary for subsequent work to returned properly structured errors from the API and show them in the CLI.