### PR TITLE
Add error output to job selection exec hooks

### DIFF
--- a/ops/terraform/remote_files/scripts/apply-http-allowlist.sh
+++ b/ops/terraform/remote_files/scripts/apply-http-allowlist.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 # Script to be used with --job-selection-probe-exec that will:
 # - reject jobs with --network=Full
@@ -8,12 +8,19 @@ set -euxo pipefail
 
 ALLOWLIST=./http-domain-allowlist.txt
 
-TYPE=$(echo "$BACALHAU_JOB_SELECTION_PROBE_DATA" | jq -r '.Job.Tasks[0].Network.Type')
-test "$TYPE" = 'HTTP' || test "$TYPE" = 'None'
+TYPE=$(echo "$BACALHAU_JOB_SELECTION_PROBE_DATA" | jq -r '.Job.Tasks[] | .Network.Type')
+if ! (test "$TYPE" = 'HTTP' || test "$TYPE" = 'None'); then
+    echo "only accept jobs using Network.Type of HTTP or None" 1>&2
+    exit 1
+fi
 
 cd "$(dirname $0)"
 MISSING=$(comm -13 \
     <(cat "$ALLOWLIST" | grep -v '#' | sort) \
-    <(echo "$BACALHAU_JOB_SELECTION_PROBE_DATA" | jq -r '.Job.Tasks[0].Network.Domains[]' | sort))
+    <(echo "$BACALHAU_JOB_SELECTION_PROBE_DATA" | jq -r '.Job.Tasks[] | .Network.Domains[]?' | sort))
 
-test -z "$MISSING"
+if ! (test -z "$MISSING"); then
+    echo "do not accept jobs which require domains $(echo $MISSING). " 1>&2
+    echo "see https://github.com/bacalhau-project/bacalhau/blob/main/ops/terraform/remote_files/scripts/http-domain-allowlist.txt for the allowable list" 1>&2
+    exit 1
+fi

--- a/pkg/bidstrategy/semantic/external_exec.go
+++ b/pkg/bidstrategy/semantic/external_exec.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
-	"github.com/bacalhau-project/bacalhau/pkg/logger"
 )
 
 type ExternalCommandStrategyParams struct {
@@ -34,11 +33,13 @@ func NewExternalCommandStrategy(params ExternalCommandStrategyParams) *ExternalC
 
 const (
 	exitCodeReason = "accept jobs where external command %q returns exit code %d"
+	genericReason  = "accept this job: "
 )
 
 func (s *ExternalCommandStrategy) ShouldBid(
 	ctx context.Context,
-	request bidstrategy.BidStrategyRequest) (bidstrategy.BidStrategyResponse, error) {
+	request bidstrategy.BidStrategyRequest,
+) (bidstrategy.BidStrategyResponse, error) {
 	if s.command == "" {
 		return bidstrategy.NewBidResponse(true, notConfiguredReason), nil
 	}
@@ -64,10 +65,13 @@ func (s *ExternalCommandStrategy) ShouldBid(
 	err = cmd.Run()
 	if err != nil {
 		// we ignore this error because it might be the script exiting 1 on purpose
-		logger.LogStream(ctx, &buf)
 		log.Ctx(ctx).Debug().Err(err).Str("Command", s.command).Msg("We got an error back from a job selection probe exec")
 	}
 
 	exitCode := cmd.ProcessState.ExitCode()
-	return bidstrategy.NewBidResponse(exitCode == 0, exitCodeReason, s.command, exitCode), nil
+	reason := fmt.Sprintf(exitCodeReason, s.command, exitCode)
+	if buf.Len() > 0 {
+		reason = genericReason + strings.TrimSpace(buf.String())
+	}
+	return bidstrategy.NewBidResponse(exitCode == 0, reason), nil
 }

--- a/pkg/bidstrategy/semantic/external_exec_test.go
+++ b/pkg/bidstrategy/semantic/external_exec_test.go
@@ -30,6 +30,12 @@ func TestJobSelectionExec(t *testing.T) {
 			true,
 			"this node does accept jobs where external command \"exit 0\" returns exit code 0",
 		},
+		{
+			"fail the response and print the output",
+			"echo bad job 1>&2; exit 1",
+			false,
+			"this node does not accept this job: bad job",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Bacalhau compute nodes can be configured to call a script whenever they receive a new job. If the script returns a non-zero error code, the job is rejected.

Previously, the error message returned when one of these scripts rejects a job is not helpful because it doesn't give much indication of why the job was rejected.

Now, any text the script outputs onto STDERR to explain why it has rejected the job will be passed back to the user in an error message.

This also updates the HTTP allowlist hook to do this.

Resolves https://github.com/bacalhau-project/expanso-planning/issues/691.