### PR TITLE
Improve error reporting when job resources exceed capacity

### DIFF
--- a/pkg/orchestrator/selection/ranking/max_usage.go
+++ b/pkg/orchestrator/selection/ranking/max_usage.go
@@ -3,9 +3,11 @@ package ranking
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
+	"github.com/dustin/go-humanize"
 	"github.com/rs/zerolog/log"
 )
 
@@ -36,11 +38,7 @@ func (s *MaxUsageNodeRanker) RankNodes(ctx context.Context, job models.Job, node
 				reason = "job requires less resources than are available"
 			} else {
 				rank = orchestrator.RankUnsuitable
-				reason = fmt.Sprintf(
-					"job requires more resources %s than are available per job %s",
-					jobResourceUsage.String(),
-					node.ComputeNodeInfo.MaxJobRequirements.String(),
-				)
+				reason = s.formatReason(*jobResourceUsage, node.ComputeNodeInfo.MaxJobRequirements)
 			}
 		}
 		ranks[i] = orchestrator.NodeRank{
@@ -51,4 +49,35 @@ func (s *MaxUsageNodeRanker) RankNodes(ctx context.Context, job models.Job, node
 		log.Ctx(ctx).Trace().Object("Rank", ranks[i]).Msg("Ranked node")
 	}
 	return ranks, nil
+}
+
+const perResourceReason = "more %s (%s) than the maximum available (%s)"
+
+func (s *MaxUsageNodeRanker) formatReason(requested, maximum models.Resources) string {
+	reasons := make([]string, 0, 4) //nolint:gomnd  // number of resources
+	if requested.CPU > maximum.CPU {
+		reasons = append(reasons, fmt.Sprintf(perResourceReason, "CPU",
+			fmt.Sprint(requested.CPU),
+			fmt.Sprint(maximum.CPU),
+		))
+	}
+	if requested.Memory > maximum.Memory {
+		reasons = append(reasons, fmt.Sprintf(perResourceReason, "memory",
+			humanize.Bytes(requested.Memory),
+			humanize.Bytes(maximum.Memory),
+		))
+	}
+	if requested.Disk > maximum.Disk {
+		reasons = append(reasons, fmt.Sprintf(perResourceReason, "disk",
+			humanize.Bytes(requested.Disk),
+			humanize.Bytes(maximum.Disk),
+		))
+	}
+	if requested.GPU > maximum.GPU {
+		reasons = append(reasons, fmt.Sprintf(perResourceReason, "GPUs",
+			fmt.Sprint(requested.GPU),
+			fmt.Sprint(maximum.GPU),
+		))
+	}
+	return fmt.Sprintf("job requires %s", strings.Join(reasons, " and "))
 }

--- a/pkg/orchestrator/selection/ranking/utils_test.go
+++ b/pkg/orchestrator/selection/ranking/utils_test.go
@@ -1,16 +1,20 @@
 package ranking
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 )
 
-func assertEquals(t *testing.T, ranks []orchestrator.NodeRank, nodeID string, expectedRank int) {
+func assertEquals(t *testing.T, ranks []orchestrator.NodeRank, nodeID string, expectedRank int, expectedReason ...string) {
 	for _, rank := range ranks {
 		if rank.NodeInfo.ID() == nodeID {
 			if rank.Rank != expectedRank {
 				t.Errorf("expected rank %d for node %s, got %d", expectedRank, nodeID, rank.Rank)
+			}
+			if len(expectedReason) > 0 && !slices.Contains(expectedReason, rank.Reason) {
+				t.Errorf("expected reason %q for node %s, got %q", expectedReason[0], nodeID, rank.Reason)
 			}
 			return
 		}


### PR DESCRIPTION
These messages are now:
- specific about which resource(s) is/are over the limit
- do not include resources that are not problematic
- print numbers to a sensible level of precision
- also fix capacity string output

Resolves #3351.
Resolves https://github.com/bacalhau-project/expanso-planning/issues/692.