### PR TITLE
Print ranking failures in the CLI

### DIFF
--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -84,14 +84,19 @@ func PrintJobExecution(
 		if err != nil {
 			return fmt.Errorf("failed getting job executions: %w", err)
 		}
-		cmd.Println("\nJob Results By Node:")
-		for message, nodes := range summariseExecutions(executions.Executions) {
-			cmd.Printf("• Node %s: ", strings.Join(nodes, ", "))
-			if strings.ContainsRune(message, '\n') {
-				cmd.Printf("\n\t%s\n", strings.Join(strings.Split(message, "\n"), "\n\t"))
-			} else {
-				cmd.Println(message)
+		summary := summariseExecutions(executions.Executions)
+		if len(summary) > 0 {
+			cmd.Println("\nJob Results By Node:")
+			for message, nodes := range summary {
+				cmd.Printf("• Node %s: ", strings.Join(nodes, ", "))
+				if strings.ContainsRune(message, '\n') {
+					cmd.Printf("\n\t%s\n", strings.Join(strings.Split(message, "\n"), "\n\t"))
+				} else {
+					cmd.Println(message)
+				}
 			}
+		} else {
+			cmd.Println()
 		}
 	}
 	if !quiet {

--- a/pkg/jobstore/boltdb/store.go
+++ b/pkg/jobstore/boltdb/store.go
@@ -815,6 +815,7 @@ func (b *BoltJobStore) updateJobState(tx *bolt.Tx, request jobstore.UpdateJobSta
 	// update the job state
 	previousState := job.State.StateType
 	job.State.StateType = request.NewState
+	job.State.Message = request.Comment
 	job.Revision++
 	job.ModifyTime = b.clock.Now().UTC().UnixNano()
 

--- a/test/errors.sh
+++ b/test/errors.sh
@@ -1,0 +1,10 @@
+#!bin/bashtub
+
+source bin/bacalhau.sh
+
+testcase_ranking_failures_are_printed() {
+    create_node compute,requester
+
+    subject bacalhau job run $ROOT/testdata/jobs/custom-task-type.yaml
+    assert_match 'does not support flibble' $(echo $stderr)
+}

--- a/testdata/jobs/custom-task-type.yaml
+++ b/testdata/jobs/custom-task-type.yaml
@@ -1,0 +1,10 @@
+Name: Custom Job Type
+Type: batch
+Namespace: default
+Count: 1
+Tasks:
+  - Name: main
+    Engine:
+      Type: flibble
+      Params:
+        Some: data


### PR DESCRIPTION
Currently, ranking failures are once again not visible in the CLI:
```
% bin/darwin/arm64/bacalhau --api-host=localhost job run testdata/jobs/docker.yaml
Job successfully submitted. Job ID: j-954d00df-c59f-4c65-8663-da8f112ec9cb
Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

	Communicating with the network  ................  done ✅  2.7s
	   Creating job for submission  ................  err  ❌  01m00.8s

Error submitting job: 
Job Results By Node:

To get more details about the run, execute:
	bacalhau job describe j-954d00df-c59f-4c65-8663-da8f112ec9cb

To get more details about the run executions, execute:
	bacalhau job executions j-954d00df-c59f-4c65-8663-da8f112ec9cb
```
The "Error submitting job" and "Job Results By Node" lines should be displaying a ranking failure.

A bug in the BoltDB job store implementation meant that any non-execution comments were not stored. This commit stores the error from the scheduler in the job state as it used to be so that it can be printed on the CLI.

It also only prints "Job Results by Node" if the job was actually successfully placed on any node, and adds a test.