### PR TITLE
Return failed bid when image does not exist

### DIFF
--- a/pkg/executor/docker/bidstrategy/semantic/image_platform.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform.go
@@ -69,6 +69,10 @@ func (s *ImagePlatformBidStrategy) ShouldBid(
 
 		var m *docker.ImageManifest
 		m, ierr = s.client.ImageDistribution(ctx, dockerEngine.Image, config.GetDockerCredentials())
+		if ierr != nil {
+			return bidstrategy.NewBidResponse(false, ierr.Error()), nil
+		}
+
 		if m != nil {
 			manifest = *m
 		}


### PR DESCRIPTION
Currently the error raised by looking in the cache for a non-existent image was ignored. This led to the second request for a non-existent image to complain about missing arch. It is now processed correctly.

Resolves #3754 