### PR TITLE
Return structured errors from API calls and improve job error display

### DIFF
--- a/cmd/util/errors.go
+++ b/cmd/util/errors.go
@@ -1,21 +1,42 @@
 package util
 
 import (
-	"fmt"
+	"math"
+	"os"
+	"strings"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/bad"
 	"github.com/fatih/color"
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/mitchellh/go-wordwrap"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var red = color.New(color.FgRed)
 
+const errorPrefix = "Error: "
+
+// Print an error in a pretty format, with a prefix and subsequent error text
+// wrapped to the size of the terminal and indented.
 func PrintErr(cmd *cobra.Command, err *bad.Error) {
+	terminalWdith, _, termErr := term.GetSize(int(os.Stderr.Fd()))
+	if termErr != nil || terminalWdith <= 0 {
+		log.Ctx(cmd.Context()).Debug().Err(termErr).Msg("Failed to get terminal size")
+		terminalWdith = math.MaxInt32
+	}
+
+	errorWidth := uint(terminalWdith) - uint(len(errorPrefix))
 	for _, leafErr := range err.Leaves() {
-		red.Fprint(cmd.ErrOrStderr(), "Error: ")
-		fmt.Fprintln(cmd.ErrOrStderr(), leafErr.Type)
+		red.Fprint(cmd.ErrOrStderr(), errorPrefix)
+		for i, line := range strings.Split(wordwrap.WrapString(leafErr.Type, errorWidth), "\n") {
+			if i > 0 {
+				cmd.PrintErr(strings.Repeat(" ", len(errorPrefix)))
+			}
+			cmd.PrintErrln(line)
+		}
 	}
 }
 
@@ -30,6 +51,13 @@ var errorColumns = []output.TableColumn[bad.Error]{
 	},
 }
 
+// Print an error in the specified output format, or regular pretty format if
+// the user is expecting a human-readable table.
+//
+// If users have asked for JSON/YAML/CSV, they are probably best able to process
+// the erorr in those formats as well. But if they asked for a table (the
+// default) they are probably doing human processing, so our regular pretty
+// output will be most helpful.
 func PrintErrFormatted(cmd *cobra.Command, options output.OutputOptions, err *bad.Error) {
 	if options.Format == output.TableFormat {
 		PrintErr(cmd, err)
@@ -37,6 +65,6 @@ func PrintErrFormatted(cmd *cobra.Command, options output.OutputOptions, err *ba
 
 	printErr := output.Output(cmd, errorColumns, options, err.Leaves())
 	if printErr != nil {
-		cmd.PrintErr(printErr)
+		cmd.PrintErrln(printErr)
 	}
 }

--- a/cmd/util/errors.go
+++ b/cmd/util/errors.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/cmd/util/output"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/bad"
+	"github.com/fatih/color"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var red = color.New(color.FgRed)
+
+func PrintErr(cmd *cobra.Command, err *bad.Error) {
+	for _, leafErr := range err.Leaves() {
+		red.Fprint(cmd.ErrOrStderr(), "Error: ")
+		fmt.Fprintln(cmd.ErrOrStderr(), leafErr.Type)
+	}
+}
+
+var errorColumns = []output.TableColumn[bad.Error]{
+	{
+		ColumnConfig: table.ColumnConfig{Name: "Error"},
+		Value:        func(e bad.Error) string { return e.Type },
+	},
+	{
+		ColumnConfig: table.ColumnConfig{Name: "Subject"},
+		Value:        func(e bad.Error) string { return string(e.Subject) },
+	},
+}
+
+func PrintErrFormatted(cmd *cobra.Command, options output.OutputOptions, err *bad.Error) {
+	if options.Format == output.TableFormat {
+		PrintErr(cmd, err)
+	}
+
+	printErr := output.Output(cmd, errorColumns, options, err.Leaves())
+	if printErr != nil {
+		cmd.PrintErr(printErr)
+	}
+}

--- a/cmd/util/fatal.go
+++ b/cmd/util/fatal.go
@@ -1,20 +1,30 @@
 package util
 
 import (
+	"errors"
 	"os"
 	"strings"
 
+	"github.com/bacalhau-project/bacalhau/pkg/lib/bad"
 	"github.com/spf13/cobra"
 )
 
 var Fatal = fatalError
 
 func fatalError(cmd *cobra.Command, err error, code int) {
-	if msg := err.Error(); msg != "" {
+	defer os.Exit(code)
+
+	if err == nil {
+		return
+	}
+
+	apiErr := new(bad.Error)
+	if errors.As(err, &apiErr) {
+		PrintErr(cmd, apiErr)
+	} else if msg := err.Error(); msg != "" {
 		if !strings.HasSuffix(msg, "\n") {
 			msg += "\n"
 		}
 		cmd.PrintErr(msg)
 	}
-	os.Exit(code)
 }

--- a/go.mod
+++ b/go.mod
@@ -230,7 +230,7 @@ require (
 	github.com/elastic/gosigar v0.14.2 // indirect
 	github.com/elgris/jsondiff v0.0.0-20160530203242-765b5c24c302 // indirect
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 // indirect
-	github.com/fatih/color v1.15.0 // indirect
+	github.com/fatih/color v1.15.0
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/pkg/lib/bad/error.go
+++ b/pkg/lib/bad/error.go
@@ -1,0 +1,184 @@
+// Package bad helps you deal with errors.
+package bad
+
+import (
+	"strings"
+)
+
+// ErrorSubject identifies where the error arose according to the component that
+// emitted it.
+type ErrorSubject string
+
+const (
+	// The error arose for an unspecified reason.
+	ErrSubjectNone ErrorSubject = ""
+	// The error arose because user input did not conform to the required
+	// specification. The user will need to modify their request before
+	// submitting it again.
+	ErrSubjectInput ErrorSubject = "input"
+	// The error arose because of an internal logic problem with the component
+	// that created the error, normally signaling a programming issue. The
+	// system developer will need to modify their code to meet this request.
+	ErrSubjectInternal ErrorSubject = "internal"
+	// The error arose because some other service or component that the
+	// component that created the error depends on also returned an error. The
+	// error may be transient, especially if this error is a leaf, or may
+	// require operator intervention (e.g. out of disk space).
+	ErrSubjectDependency ErrorSubject = "dependency"
+)
+
+// Error represents a node in a tree of errors. Error (and thus the whole tree)
+// is JSON marshallable so that a tree of Errors can be sent across HTTP.
+type Error struct {
+	// The type of the error. For native errors, this is just the error text,
+	// but more structured errors this is a unique identifier that clients can
+	// use to display certain types of important errors in specific ways.
+	// Essentially, the "type" identifies the type of thing in the "data" field,
+	// and allows the client to unmarshall the data field appropriately.
+	//
+	// For example, if a client knows how to represent errors about resource
+	// limits being unmet, the type may be "Unmet resource limits" and the data
+	// field may include structured information about what resource limits are
+	// being unmet that the client can choose to display in a number of ways.
+	Type string `json:"type"`
+	Data any    `json:"data"`
+
+	// The subject of the error, which identifies where the problem occurred and
+	// is used to select appropriate status codes and retry information.
+	//
+	// Not every Error needs to have a Subject specified – instead subjects can
+	// be added to tag any error from a certain place. For example, a Validate()
+	// method will almost always be returning an error due to user input, so any
+	// error emitted from this place can be wrapped with a ErrSubjectInput.
+	Subject ErrorSubject `json:"subject"`
+
+	// Any child errors that this error wraps.
+	Errs []Error `json:"errs"`
+}
+
+// Error() is necessary for Error to implement the error interface, which makes
+// it much easier to pass back from functions. We shouldn't actually use this
+// except in internal logging, but it implements a simple printer that will
+// output the entire tree of errors, skipping any blank levels.
+func (err *Error) Error() string {
+	var out strings.Builder
+	if err == nil {
+		return ""
+	}
+
+	indent := ""
+	if len(err.Type) > 0 {
+		out.WriteString("* ")
+		out.WriteString(err.Type)
+		indent = "\t"
+		if len(err.Errs) > 0 {
+			out.WriteString(": ")
+		}
+		out.WriteRune('\n')
+	}
+	for _, subError := range err.Errs {
+		for _, line := range strings.SplitAfter(subError.Error(), "\n") {
+			if line == "" {
+				continue
+			}
+			out.WriteString(indent)
+			out.WriteString(line)
+		}
+	}
+	return out.String()
+}
+
+var _ error = (*Error)(nil)
+
+// Leaves returns just the Errors from the tree that do not have any children.
+// These Errors are normally the ones with the most specific error information.
+// The order in which the leaves are returned is unspecified.
+func (err *Error) Leaves() []Error {
+	if err == nil {
+		return nil
+	}
+
+	if len(err.Errs) == 0 {
+		return []Error{*err}
+	}
+
+	leaves := make([]Error, 0, len(err.Errs))
+	for _, subErr := range err.Errs {
+		leaves = append(leaves, subErr.Leaves()...)
+	}
+	return leaves
+}
+
+// Input transforms the error to report that it was the result of user input not
+// meeting requirements. Data is an optional parameter that should be specified
+// 0 or 1 times and will replace any data in the error if specified.
+func Input(err error, data ...any) error {
+	e := ToError(err)
+	if e == nil {
+		return nil
+	}
+	e.Subject = ErrSubjectInput
+	if len(data) > 1 {
+		panic("too much error data passed to Input()")
+	}
+	if len(data) > 0 {
+		e.Data = data[0]
+	}
+	return e
+}
+
+type singleWrapper interface {
+	error
+	Unwrap() error
+}
+
+type multiWrapper interface {
+	error
+	Unwrap() []error
+}
+
+// ToError converts a Go native error in an Error. If the error is already an
+// Error, it is returned unchanged. If the error is nil, nil is returned. If the
+// error wraps other errors, they are also converted to Errors and the full tree
+// of errors returned.
+func ToError(err error) *Error {
+	if err == nil {
+		return nil
+	}
+
+	if apiError, ok := (err).(*Error); ok {
+		return apiError
+	}
+
+	// If this error could wrap another error, make an error and add its single
+	// wrapped error as an Errs.
+	var subErrs []error
+	if singleErr, ok := (err).(singleWrapper); ok {
+		subErrs = append(subErrs, singleErr.Unwrap())
+	} else if multiErr, ok := (err).(multiWrapper); ok {
+		subErrs = multiErr.Unwrap()
+	}
+
+	apiError := &Error{
+		Type: err.Error(),
+		Errs: make([]Error, 0, len(subErrs)),
+	}
+
+	// Discard this error.Error() if its repeating the wrapped error messages,
+	// but obviously not if it is a leaf error with no sub-errors. The logic
+	// here is that calling Error() on errors that wrap other errors often just
+	// returns the concatenation of the wrapped Error() calls, which is not
+	// useful to have in the Type field.
+	for _, subErr := range subErrs {
+		subAPIErr := ToError(subErr)
+		if subAPIErr == nil {
+			continue
+		}
+
+		apiError.Errs = append(apiError.Errs, *subAPIErr)
+		apiError.Type = strings.Replace(apiError.Type, subErr.Error(), "", 1)
+	}
+	apiError.Type = strings.TrimRight(strings.TrimSpace(apiError.Type), ":")
+
+	return apiError
+}

--- a/pkg/lib/bad/error_test.go
+++ b/pkg/lib/bad/error_test.go
@@ -1,0 +1,108 @@
+//go:build unit || !integration
+
+package bad
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+var errorTree = errors.Join(
+	errors.Join(
+		errors.New("1"),
+		fmt.Errorf("test: %w", errors.New("2")),
+	),
+	errors.New("3"),
+)
+
+var errorTreeOutput = strings.Join([]string{
+	"* 1",
+	"* test: ",
+	"\t* 2",
+	"* 3",
+	"",
+}, "\n")
+
+// Leaves should return only the errors in the tree with no children.
+func TestLeaves(t *testing.T) {
+	leaves := ToError(errorTree).Leaves()
+	types := lo.Map(leaves, func(e Error, _ int) string { return e.Type })
+	require.ElementsMatch(t, types, []string{"1", "2", "3"})
+
+	require.Nil(t, (*Error)(nil).Leaves())
+}
+
+type testSingleUnwrap struct{}
+
+func (testSingleUnwrap) Error() string { return "single" }
+func (testSingleUnwrap) Unwrap() error { return nil }
+
+type testMultiUnwrap struct{}
+
+func (testMultiUnwrap) Error() string   { return "multi" }
+func (testMultiUnwrap) Unwrap() []error { return []error{nil} }
+
+// ToError should return nil for nil errors, the same object for Errors, and a
+// new Error for native errors.
+func TestToError(t *testing.T) {
+	require.Nil(t, ToError(nil))
+
+	x := Error{Type: "x"}
+	require.Same(t, &x, ToError(&x))
+
+	y := errors.New("y")
+	require.Equal(t, "y", ToError(y).Type)
+
+	z := ToError(testSingleUnwrap{})
+	require.Equal(t, "single", z.Type)
+	require.Empty(t, z.Errs)
+
+	a := ToError(testMultiUnwrap{})
+	require.Equal(t, "multi", a.Type)
+	require.Empty(t, a.Errs)
+}
+
+// An error that just outputs the messages of its wrapped errors should not be
+// converted into an Error with a Type.
+func TestConcatenation(t *testing.T) {
+	err := errors.Join(
+		errors.New("test 1"),
+		errors.New("test 2"),
+	)
+	require.Equal(t, "test 1\ntest 2", err.Error())
+
+	badErr := ToError(err)
+	require.Empty(t, badErr.Type)
+	require.Len(t, badErr.Errs, 2)
+}
+
+// Output should display a tree of errors in a simple text view.
+func TestErrorOutput(t *testing.T) {
+	require.Empty(t, ToError(nil).Error())
+	require.Equal(t, errorTreeOutput, ToError(errorTree).Error())
+}
+
+// Input should tag an error as being from an input source, should return nil on
+// nil input, and should panic if more than one data item is passed.
+func TestInput(t *testing.T) {
+	require.Nil(t, Input(nil))
+
+	err := Input(errors.New("err"))
+	badErr, ok := (err).(*Error)
+	require.True(t, ok)
+	require.Equal(t, ErrSubjectInput, badErr.Subject)
+
+	err = Input(errors.New("err"), "things")
+	badErr, ok = (err).(*Error)
+	require.True(t, ok)
+	require.Equal(t, "things", badErr.Data)
+
+	require.Panics(t, func() {
+		Input(errors.New("err"), "1", "2")
+	})
+}

--- a/pkg/publicapi/errors.go
+++ b/pkg/publicapi/errors.go
@@ -1,0 +1,43 @@
+package publicapi
+
+import (
+	"net/http"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/bad"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/math"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/lo"
+)
+
+func toHTTPError(rawErr error) *echo.HTTPError {
+	switch err := rawErr.(type) {
+	case *echo.HTTPError:
+		return err
+	default:
+		badErr := bad.ToError(err)
+		return echo.NewHTTPError(getStatusCode(badErr), *badErr)
+	}
+}
+
+func getStatusCode(err *bad.Error) int {
+	switch err.Subject {
+	case bad.ErrSubjectInput:
+		return http.StatusBadRequest
+	case bad.ErrSubjectDependency:
+		return http.StatusServiceUnavailable
+	case bad.ErrSubjectNone:
+		// This error does not define a status code. Recurse downwards and find
+		// the most appropriate one.
+		return lo.Reduce(err.Errs, func(agg int, err bad.Error, _ int) int {
+			return math.Min(getStatusCode(&err), agg)
+		}, http.StatusInternalServerError)
+	case bad.ErrSubjectInternal:
+		fallthrough
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func handleAPIError(err error, c echo.Context) {
+	c.Echo().DefaultHTTPErrorHandler(toHTTPError(err), c)
+}

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -91,6 +91,8 @@ func NewAPIServer(params ServerParams) (*Server, error) {
 	// TODO: disable debug mode after we implement our own error handler
 	server.Router.Debug = true
 
+	server.Router.HTTPErrorHandler = handleAPIError
+
 	// set middleware
 	logLevel, err := zerolog.ParseLevel(params.Config.LogLevel)
 	if err != nil {

--- a/pkg/publicapi/validator.go
+++ b/pkg/publicapi/validator.go
@@ -1,10 +1,8 @@
 package publicapi
 
 import (
-	"net/http"
-
+	"github.com/bacalhau-project/bacalhau/pkg/lib/bad"
 	"github.com/go-playground/validator/v10"
-	"github.com/labstack/echo/v4"
 )
 
 type validatable interface {
@@ -21,12 +19,12 @@ type CustomValidator struct {
 
 func (cv *CustomValidator) Validate(i interface{}) error {
 	if err := cv.validator.Struct(i); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return bad.Input(err)
 	}
 	if v, ok := i.(validatable); ok {
 		err := v.Validate()
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+			return bad.Input(err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds special handling for a number of common error cases:
* Don't show the full list of nodes if they all output the same error, and if the job error matches one of the execution errors (common case) don't show that separately either.
* Show the number of nodes that were available even if unsuitable, because users often misinterpret "0 available" as meaning there is a connection error with their compute nodes
* Summarise nodes when they all print the same output rather than listing all of them

An example of how execution errors looked previously:
```
% bin/darwin/arm64/bacalhau job run testdata/jobs/docker.yaml 
Job successfully submitted. Job ID: j-6207c87b-d2ce-4458-b55e-1b2efb9d2a91
Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):

	Communicating with the network  ................  done ✅  0.0s
	   Creating job for submission  ................  err  ❌  13.5s

Error submitting job: not enough nodes to run job. requested: 1, available: 0. 
	Node node-1: job rejected
	Node node-2: job rejected
	Node node-3: job rejected
	Node node-4: job rejected
Job Results By Node:
• Node node-3, node-2, node-1, node-4: 
	rejected bid: this node does not Could not inspect image "not-existyyyy:latest" - could be due to repo/image not existing, or registry needing authorization: Error response from daemon: errors:
	denied: requested access to the resource is denied
	unauthorized: authentication required

To get more details about the run, execute:
	bacalhau job describe j-6207c87b-d2ce-4458-b55e-1b2efb9d2a91

To get more details about the run executions, execute:
	bacalhau job executions j-6207c87b-d2ce-4458-b55e-1b2efb9d2a91
```

An example of how execution errors look now:
![carbon](https://github.com/bacalhau-project/bacalhau/assets/4951176/6265d334-401b-4cbe-8c5d-0408fe7b06f0)

So this doesn't fix all of the long ugly go errors which need to be dealt with on a case-by-case basis, but it at least simplifies the output and allows users to focus on the information that is pertinent.

Resolves https://github.com/bacalhau-project/expanso-planning/issues/693.