### PR TITLE
Ensure compute node labels are published over LibP2P connections

### DIFF
--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -41,7 +41,7 @@ type Compute struct {
 	ManagementClient   *compute.ManagementClient
 	cleanupFunc        func(ctx context.Context)
 	nodeInfoDecorator  models.NodeInfoDecorator
-	autoLabelsProvider models.LabelsProvider
+	labelsProvider     models.LabelsProvider
 	debugInfoProviders []model.DebugInfoProvider
 }
 
@@ -240,7 +240,7 @@ func NewComputeNode(
 		Bidder:             bidder,
 		cleanupFunc:        cleanupFunc,
 		nodeInfoDecorator:  nodeInfoDecorator,
-		autoLabelsProvider: labelsProvider,
+		labelsProvider:     labelsProvider,
 		debugInfoProviders: debugInfoProviders,
 		ManagementClient:   managementClient,
 	}, nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -281,10 +281,7 @@ func NewNode(
 
 	var requesterNode *Requester
 	var computeNode *Compute
-	labelsProvider := models.MergeLabelsInOrder(
-		&ConfigLabelsProvider{staticLabels: config.Labels},
-		&RuntimeLabelsProvider{},
-	)
+	var labelsProvider models.LabelsProvider
 
 	// setup requester node
 	if config.IsRequesterNode {
@@ -351,6 +348,10 @@ func NewNode(
 			}
 		}
 
+		labelsProvider = models.MergeLabelsInOrder(
+			&ConfigLabelsProvider{staticLabels: config.Labels},
+			&RuntimeLabelsProvider{},
+		)
 		debugInfoProviders = append(debugInfoProviders, requesterNode.debugInfoProviders...)
 	}
 
@@ -419,6 +420,7 @@ func NewNode(
 			return nil, err
 		}
 
+		labelsProvider = computeNode.labelsProvider
 		debugInfoProviders = append(debugInfoProviders, computeNode.debugInfoProviders...)
 	}
 

--- a/test/labels.sh
+++ b/test/labels.sh
@@ -1,0 +1,49 @@
+#!bin/bashtub
+
+source bin/bacalhau.sh
+
+run_test() {
+    WORD=$RANDOM
+    subject bacalhau config set node.labels key=value "random=$WORD"
+    create_node $1
+
+    # Wait for node to have published information.
+    subject bacalhau node list --output=json
+    while ! jq -e 'length > 0' <<< $stdout 1>/dev/null; do
+        sleep 0.05;
+        subject bacalhau node list --output=json
+    done
+
+    assert_equal 1 $(jq -rcM length <<< $stdout)
+    assert_not_equal 0 $(jq -rcM '.[0].Labels | length' <<< $stdout)
+    assert_equal false $(jq -rcM '.[0].Labels["Operating-System"] == null' <<< $stdout)
+    assert_equal false $(jq -rcM '.[0].Labels["Architecture"] == null' <<< $stdout)
+    assert_equal value $(jq -rcM '.[0].Labels["key"]' <<< $stdout)
+    assert_equal $WORD $(jq -rcM '.[0].Labels["random"]' <<< $stdout)
+}
+
+testcase_receive_labels_about_requester_node_for_nats() {
+    subject bacalhau config set node.network.type nats
+    assert_equal 0 $status
+    run_test requester
+}
+
+testcase_receive_extra_labels_about_compute_node_for_nats() {
+    subject bacalhau config set node.network.type nats
+    assert_equal 0 $status
+    run_test requester,compute
+    assert_equal false $(jq -rcM '.[0].Labels["git-lfs"] == null' <<< $stdout)
+}
+
+testcase_receive_labels_about_requester_node_for_libp2p() {
+    subject bacalhau config set node.network.type libp2p
+    assert_equal 0 $status
+    run_test requester
+}
+
+testcase_receive_extra_labels_about_compute_node_for_libp2p() {
+    subject bacalhau config set node.network.type libp2p
+    assert_equal 0 $status
+    run_test requester,compute
+    assert_equal false $(jq -rcM '.[0].Labels["git-lfs"] == null' <<< $stdout)
+}


### PR DESCRIPTION
A previous commit accidentally removed the labels used by the compute node from the NodeInfoProvider used by LibP2P. This commit restores those labels to that provider and adds a test that labels are available via the CLI in both LibP2P and NATS networking.