### PR TITLE
Print command line executable when displaying additional commands

### DIFF
--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -102,11 +102,11 @@ func PrintJobExecution(
 	if !quiet {
 		cmd.Println()
 		cmd.Println("To get more details about the run, execute:")
-		cmd.Println("\tbacalhau job describe " + jobID)
+		cmd.Println("\t" + os.Args[0] + " job describe " + jobID)
 
 		cmd.Println()
 		cmd.Println("To get more details about the run executions, execute:")
-		cmd.Println("\tbacalhau job executions " + jobID)
+		cmd.Println("\t" + os.Args[0] + " job executions " + jobID)
 	}
 
 	return nil

--- a/cmd/util/printer/print_legacy.go
+++ b/cmd/util/printer/print_legacy.go
@@ -129,11 +129,11 @@ func PrintJobExecutionLegacy(
 
 	hasResults := slices.ContainsFunc(js.Executions, func(e model.ExecutionState) bool { return e.RunOutput != nil })
 	if !quiet && hasResults {
-		cmd.Printf("\nTo download the results, execute:\n\tbacalhau get %s\n", j.ID())
+		cmd.Printf("\nTo download the results, execute:\n\t"+os.Args[0]+" get %s\n", j.ID())
 	}
 
 	if !quiet {
-		cmd.Printf("\nTo get more details about the run, execute:\n\tbacalhau describe %s\n", j.ID())
+		cmd.Printf("\nTo get more details about the run, execute:\n\t"+os.Args[0]+" describe %s\n", j.ID())
 	}
 
 	if hasResults && runtimeSettings.AutoDownloadResults {


### PR DESCRIPTION
This was removed in #2560 but it's really helpful for users who aren't using the executable through the name we expect (e.g. because of a shell alias) or for developers who are running a local build.