### PR TITLE
Stop approval states being overwritten

### DIFF
--- a/pkg/node/manager/node_manager.go
+++ b/pkg/node/manager/node_manager.go
@@ -120,6 +120,13 @@ func (n *NodeManager) UpdateInfo(ctx context.Context, request requests.UpdateInf
 		}, nil
 	}
 
+	// The NodeInfo we are receiving from the compute node will likely contain an
+	// approval field with an empty string. We don't want to overwrite the approval
+	// held here so we'll set it to whatever we currently have stored. We may want to
+	// remove the Approval and State fields from the version of NodeInfo that the
+	// compute node stores instead.
+	request.Info.Approval = existing.Approval
+
 	// TODO: Add a Put endpoint that takes the revision into account?
 	if err := n.nodeInfo.Add(ctx, request.Info); err != nil {
 		return nil, errors.Wrap(err, "failed to save nodeinfo during node registration")


### PR DESCRIPTION
When computes nodes send their info updates, they were sending a version of the NodeInfo struct that contains an empty approval value.  We shouldn't accept them at all, and so this commit will overwrite whatever the client sends with the current approval state.

We should probably change what the compute node sends so that the NodeInfo on the requester node is an enhanced version of the info the compute node has.

Possible fix for: https://github.com/bacalhau-project/bacalhau/issues/3783
