### PR TITLE
[Documentation] rename category to Running Nodes

### DIFF
--- a/docs/docs/setting-up/running-node/_category_.yml
+++ b/docs/docs/setting-up/running-node/_category_.yml
@@ -1,2 +1,2 @@
-label: "Running a Node"
+label: "Running Nodes"
 position: 6


### PR DESCRIPTION
Rename category to `Running Nodes` as part of the Doc upgrading - v1.1 scope