### PR TITLE
[Documentation] rename configuration to Configuration Management

### DIFF
--- a/docs/docs/setting-up/running-node/configuration.md
+++ b/docs/docs/setting-up/running-node/configuration.md
@@ -1,10 +1,10 @@
 ---
-sidebar_label: 'Configuration'
+sidebar_label: 'Configuration Management'
 sidebar_position: 160
 description: How to configure your Bacalhau node.
 ---
 
-# Configuration Overview
+# Configuration Management
 
 Bacalhau employs the [viper](https://github.com/spf13/viper) and [cobra](https://github.com/spf13/cobra) libraries for configuration management. Users can configure their Bacalhau node through a combination of command-line flags, environment variables, and the dedicated configuration file.
 


### PR DESCRIPTION
rename configuration page to Configuration Management as part of the Doc upgrading - v1.1 scope