### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: request/new, type/bug
+assignees: ''
+
+---
+
+### Bug Description
+*Briefly describe the unexpected behavior or performance regression. What happened that wasn’t supposed to?*
+
+### Expected Behavior
+*Detail what you expected to happen instead of the bug.*
+
+### Steps to Reproduce
+1. Step one to reproduce
+2. Step two
+3. Step three
+4. (Continue as necessary)
+
+### Bacalhau Versions
+- **Agent Version**: Run `bacalhau agent version` to get this.
+- **CLI Client Version**: Run `bacalhau version` for the client info.
+
+### Host Environment
+*Provide details about the environment where the bug occurred:*
+- Operating System:
+- CPU Architecture:
+- Any other relevant environment details:
+
+### Job Specification
+*(If applicable, provide the job spec used when the issue occurred.)*
+
+### Logs
+#### Agent Logs: 
+*(Include here if applicable.)*
+
+#### Client Logs:
+*(Include here if applicable.)*

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion
+    url: https://github.com/bacalhau-project/bacalhau/discussions
+    about: Ideal for ideas, feedback, or longer form questions.
+  - name: Chat
+    url: https://bacalhauproject.slack.com
+    about: Ideal for short questions, looking for advice, general conversation, and meeting other Bacalhau users!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement to Bacalhau
+title: ''
+labels: request/new, type/enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,15 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  labels:
+    - "lang/go"
+    - "th/dependencies"
   open-pull-requests-limit: 1
 - package-ecosystem: "pip"
   directory: "/integration/"
   schedule:
     interval: daily
+  labels:
+    - "lang/python"
+    - "th/dependencies"
   open-pull-requests-limit: 1


### PR DESCRIPTION
Add a template for when users open a new issue, similar to what you see in https://github.com/nats-io/nats.go/issues/new/choose