### PR TITLE
fix: require connected and approved nodes for scheduling

### DIFF
--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -145,41 +145,24 @@ func NewRequesterNode(
 		retryStrategy = retryStrategyChain
 	}
 
-	// TODO(forrest): [refactor] the selector constraints ought to be a parameter to the node selector.
 	// node selector
-	nodeSelector := selector.NewNodeSelector(selector.NodeSelectorParams{
-		NodeDiscoverer: nodeInfoStore,
-		NodeRanker:     nodeRankerChain,
-	})
-	// selector constraints: require nodes be online and approved to schedule
-	selectorConstraints := orchestrator.NodeSelectionConstraints{
-		RequireConnected: true,
-		RequireApproval:  true,
-	}
+	nodeSelector := selector.NewNodeSelector(
+		nodeInfoStore,
+		nodeRankerChain,
+		// selector constraints: require nodes be online and approved to schedule
+		orchestrator.NodeSelectionConstraints{
+			RequireConnected: true,
+			RequireApproval:  true,
+		},
+	)
 
 	// scheduler provider
-	batchServiceJobScheduler := scheduler.NewBatchServiceJobScheduler(
-		jobStore,
-		planners,
-		nodeSelector,
-		retryStrategy,
-		selectorConstraints,
-	)
+	batchServiceJobScheduler := scheduler.NewBatchServiceJobScheduler(jobStore, planners, nodeSelector, retryStrategy)
 	schedulerProvider := orchestrator.NewMappedSchedulerProvider(map[string]orchestrator.Scheduler{
 		models.JobTypeBatch:   batchServiceJobScheduler,
 		models.JobTypeService: batchServiceJobScheduler,
-		models.JobTypeOps: scheduler.NewOpsJobScheduler(
-			jobStore,
-			planners,
-			nodeSelector,
-			selectorConstraints,
-		),
-		models.JobTypeDaemon: scheduler.NewDaemonJobScheduler(
-			jobStore,
-			planners,
-			nodeSelector,
-			selectorConstraints,
-		),
+		models.JobTypeOps:     scheduler.NewOpsJobScheduler(jobStore, planners, nodeSelector),
+		models.JobTypeDaemon:  scheduler.NewDaemonJobScheduler(jobStore, planners, nodeSelector),
 	})
 
 	workers := make([]*orchestrator.Worker, 0, requesterConfig.WorkerCount)

--- a/pkg/orchestrator/interfaces.go
+++ b/pkg/orchestrator/interfaces.go
@@ -106,11 +106,11 @@ type NodeSelector interface {
 	AllNodes(ctx context.Context) ([]models.NodeInfo, error)
 
 	// AllMatchingNodes returns all nodes that match the job constrains and selection criteria.
-	AllMatchingNodes(ctx context.Context, job *models.Job, constraints *NodeSelectionConstraints) ([]models.NodeInfo, error)
+	AllMatchingNodes(ctx context.Context, job *models.Job) ([]models.NodeInfo, error)
 
 	// TopMatchingNodes return the top ranked desiredCount number of nodes that match job constraints
 	// ordered in descending order based on their rank, or error if not enough nodes match.
-	TopMatchingNodes(ctx context.Context, job *models.Job, desiredCount int, constraints *NodeSelectionConstraints) ([]models.NodeInfo, error)
+	TopMatchingNodes(ctx context.Context, job *models.Job, desiredCount int) ([]models.NodeInfo, error)
 }
 
 type RetryStrategy interface {

--- a/pkg/orchestrator/mocks.go
+++ b/pkg/orchestrator/mocks.go
@@ -15,6 +15,7 @@ import (
 	time "time"
 
 	models "github.com/bacalhau-project/bacalhau/pkg/models"
+	routing "github.com/bacalhau-project/bacalhau/pkg/routing"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -291,19 +292,24 @@ func (m *MockNodeDiscoverer) EXPECT() *MockNodeDiscovererMockRecorder {
 	return m.recorder
 }
 
-// ListNodes mocks base method.
-func (m *MockNodeDiscoverer) ListNodes(ctx context.Context) ([]models.NodeInfo, error) {
+// List mocks base method.
+func (m *MockNodeDiscoverer) List(ctx context.Context, filter ...routing.NodeStateFilter) ([]models.NodeState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes", ctx)
-	ret0, _ := ret[0].([]models.NodeInfo)
+	varargs := []any{ctx}
+	for _, a := range filter {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "List", varargs...)
+	ret0, _ := ret[0].([]models.NodeState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListNodes indicates an expected call of ListNodes.
-func (mr *MockNodeDiscovererMockRecorder) ListNodes(ctx any) *gomock.Call {
+// List indicates an expected call of List.
+func (mr *MockNodeDiscovererMockRecorder) List(ctx any, filter ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockNodeDiscoverer)(nil).ListNodes), ctx)
+	varargs := append([]any{ctx}, filter...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockNodeDiscoverer)(nil).List), varargs...)
 }
 
 // MockNodeRanker is a mock of NodeRanker interface.
@@ -368,18 +374,18 @@ func (m *MockNodeSelector) EXPECT() *MockNodeSelectorMockRecorder {
 }
 
 // AllMatchingNodes mocks base method.
-func (m *MockNodeSelector) AllMatchingNodes(ctx context.Context, job *models.Job, constraints *NodeSelectionConstraints) ([]models.NodeInfo, error) {
+func (m *MockNodeSelector) AllMatchingNodes(ctx context.Context, job *models.Job) ([]models.NodeInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllMatchingNodes", ctx, job, constraints)
+	ret := m.ctrl.Call(m, "AllMatchingNodes", ctx, job)
 	ret0, _ := ret[0].([]models.NodeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AllMatchingNodes indicates an expected call of AllMatchingNodes.
-func (mr *MockNodeSelectorMockRecorder) AllMatchingNodes(ctx, job, constraints any) *gomock.Call {
+func (mr *MockNodeSelectorMockRecorder) AllMatchingNodes(ctx, job any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMatchingNodes", reflect.TypeOf((*MockNodeSelector)(nil).AllMatchingNodes), ctx, job, constraints)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMatchingNodes", reflect.TypeOf((*MockNodeSelector)(nil).AllMatchingNodes), ctx, job)
 }
 
 // AllNodes mocks base method.
@@ -398,18 +404,18 @@ func (mr *MockNodeSelectorMockRecorder) AllNodes(ctx any) *gomock.Call {
 }
 
 // TopMatchingNodes mocks base method.
-func (m *MockNodeSelector) TopMatchingNodes(ctx context.Context, job *models.Job, desiredCount int, constraints *NodeSelectionConstraints) ([]models.NodeInfo, error) {
+func (m *MockNodeSelector) TopMatchingNodes(ctx context.Context, job *models.Job, desiredCount int) ([]models.NodeInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TopMatchingNodes", ctx, job, desiredCount, constraints)
+	ret := m.ctrl.Call(m, "TopMatchingNodes", ctx, job, desiredCount)
 	ret0, _ := ret[0].([]models.NodeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TopMatchingNodes indicates an expected call of TopMatchingNodes.
-func (mr *MockNodeSelectorMockRecorder) TopMatchingNodes(ctx, job, desiredCount, constraints any) *gomock.Call {
+func (mr *MockNodeSelectorMockRecorder) TopMatchingNodes(ctx, job, desiredCount any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopMatchingNodes", reflect.TypeOf((*MockNodeSelector)(nil).TopMatchingNodes), ctx, job, desiredCount, constraints)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopMatchingNodes", reflect.TypeOf((*MockNodeSelector)(nil).TopMatchingNodes), ctx, job, desiredCount)
 }
 
 // MockRetryStrategy is a mock of RetryStrategy interface.

--- a/pkg/orchestrator/scheduler/batch_job_test.go
+++ b/pkg/orchestrator/scheduler/batch_job_test.go
@@ -49,12 +49,16 @@ func (s *BatchJobSchedulerTestSuite) SetupTest() {
 	s.nodeSelector = orchestrator.NewMockNodeSelector(ctrl)
 	s.retryStrategy = retry.NewFixedStrategy(retry.FixedStrategyParams{ShouldRetry: true})
 
-	s.scheduler = NewBatchServiceJobScheduler(BatchServiceJobSchedulerParams{
-		JobStore:      s.jobStore,
-		Planner:       s.planner,
-		NodeSelector:  s.nodeSelector,
-		RetryStrategy: s.retryStrategy,
-	})
+	s.scheduler = NewBatchServiceJobScheduler(
+		s.jobStore,
+		s.planner,
+		s.nodeSelector,
+		s.retryStrategy,
+		orchestrator.NodeSelectionConstraints{
+			RequireConnected: false,
+			RequireApproval:  false,
+		},
+	)
 }
 
 func TestBatchSchedulerTestSuite(t *testing.T) {

--- a/pkg/orchestrator/scheduler/batch_job_test.go
+++ b/pkg/orchestrator/scheduler/batch_job_test.go
@@ -54,10 +54,6 @@ func (s *BatchJobSchedulerTestSuite) SetupTest() {
 		s.planner,
 		s.nodeSelector,
 		s.retryStrategy,
-		orchestrator.NodeSelectionConstraints{
-			RequireConnected: false,
-			RequireApproval:  false,
-		},
 	)
 }
 
@@ -308,19 +304,13 @@ func (s *BatchJobSchedulerTestSuite) TestProcess_ShouldMarkJobAsFailed_NoRetry()
 }
 
 func (s *BatchJobSchedulerTestSuite) mockNodeSelection(job *models.Job, nodeInfos []models.NodeInfo, desiredCount int) {
-	constraints := &orchestrator.NodeSelectionConstraints{
-		RequireApproval:  false,
-		RequireConnected: false,
-	}
-
 	if len(nodeInfos) < desiredCount {
-		s.nodeSelector.EXPECT().TopMatchingNodes(gomock.Any(), job, desiredCount, constraints).Return(nil, orchestrator.ErrNotEnoughNodes{})
+		s.nodeSelector.EXPECT().TopMatchingNodes(gomock.Any(), job, desiredCount).Return(nil, orchestrator.ErrNotEnoughNodes{})
 	} else {
 		s.nodeSelector.EXPECT().TopMatchingNodes(
 			gomock.Any(),
 			job,
 			desiredCount,
-			constraints,
 		).Return(nodeInfos, nil)
 	}
 }

--- a/pkg/orchestrator/scheduler/daemon_job.go
+++ b/pkg/orchestrator/scheduler/daemon_job.go
@@ -18,20 +18,17 @@ type DaemonJobScheduler struct {
 	jobStore     jobstore.Store
 	planner      orchestrator.Planner
 	nodeSelector orchestrator.NodeSelector
-	constraints  orchestrator.NodeSelectionConstraints
 }
 
 func NewDaemonJobScheduler(
 	store jobstore.Store,
 	planner orchestrator.Planner,
 	selector orchestrator.NodeSelector,
-	constraints orchestrator.NodeSelectionConstraints,
 ) *DaemonJobScheduler {
 	return &DaemonJobScheduler{
 		jobStore:     store,
 		planner:      planner,
 		nodeSelector: selector,
-		constraints:  constraints,
 	}
 }
 
@@ -87,12 +84,7 @@ func (b *DaemonJobScheduler) createMissingExecs(
 	ctx context.Context, job *models.Job, plan *models.Plan, existingExecs execSet) (execSet, error) {
 	newExecs := execSet{}
 
-	// Require nodes to be approved and connected to schedule work.
-	nodes, err := b.nodeSelector.AllMatchingNodes(
-		ctx,
-		job,
-		&orchestrator.NodeSelectionConstraints{RequireApproval: true, RequireConnected: true},
-	)
+	nodes, err := b.nodeSelector.AllMatchingNodes(ctx, job)
 	if err != nil {
 		return newExecs, err
 	}

--- a/pkg/orchestrator/scheduler/daemon_job.go
+++ b/pkg/orchestrator/scheduler/daemon_job.go
@@ -18,19 +18,20 @@ type DaemonJobScheduler struct {
 	jobStore     jobstore.Store
 	planner      orchestrator.Planner
 	nodeSelector orchestrator.NodeSelector
+	constraints  orchestrator.NodeSelectionConstraints
 }
 
-type DaemonJobSchedulerParams struct {
-	JobStore     jobstore.Store
-	Planner      orchestrator.Planner
-	NodeSelector orchestrator.NodeSelector
-}
-
-func NewDaemonJobScheduler(params DaemonJobSchedulerParams) *DaemonJobScheduler {
+func NewDaemonJobScheduler(
+	store jobstore.Store,
+	planner orchestrator.Planner,
+	selector orchestrator.NodeSelector,
+	constraints orchestrator.NodeSelectionConstraints,
+) *DaemonJobScheduler {
 	return &DaemonJobScheduler{
-		jobStore:     params.JobStore,
-		planner:      params.Planner,
-		nodeSelector: params.NodeSelector,
+		jobStore:     store,
+		planner:      planner,
+		nodeSelector: selector,
+		constraints:  constraints,
 	}
 }
 
@@ -86,11 +87,11 @@ func (b *DaemonJobScheduler) createMissingExecs(
 	ctx context.Context, job *models.Job, plan *models.Plan, existingExecs execSet) (execSet, error) {
 	newExecs := execSet{}
 
-	// Require approval when selecting nodes, but do not require them to be connected.
+	// Require nodes to be approved and connected to schedule work.
 	nodes, err := b.nodeSelector.AllMatchingNodes(
 		ctx,
 		job,
-		&orchestrator.NodeSelectionConstraints{RequireApproval: true, RequireConnected: false},
+		&orchestrator.NodeSelectionConstraints{RequireApproval: true, RequireConnected: true},
 	)
 	if err != nil {
 		return newExecs, err

--- a/pkg/orchestrator/scheduler/daemon_job_test.go
+++ b/pkg/orchestrator/scheduler/daemon_job_test.go
@@ -34,10 +34,6 @@ func (s *DaemonJobSchedulerTestSuite) SetupTest() {
 		s.jobStore,
 		s.planner,
 		s.nodeSelector,
-		orchestrator.NodeSelectionConstraints{
-			RequireConnected: true,
-			RequireApproval:  true,
-		},
 	)
 }
 
@@ -57,7 +53,7 @@ func (s *DaemonJobSchedulerTestSuite) TestProcess_ShouldCreateNewExecutions() {
 		*fakeNodeInfo(s.T(), nodeIDs[1]),
 		*fakeNodeInfo(s.T(), nodeIDs[2]),
 	}
-	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return(nodeInfos, nil)
+	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), gomock.Any()).Return(nodeInfos, nil)
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
 		Evaluation:               evaluation,
@@ -82,7 +78,7 @@ func (s *DaemonJobSchedulerTestSuite) TestProcess_ShouldNOTMarkJobAsCompleted() 
 	executions[1].ComputeState = models.NewExecutionState(models.ExecutionStateCompleted) // Simulate a completed execution
 	s.jobStore.EXPECT().GetJob(gomock.Any(), job.ID).Return(*job, nil)
 	s.jobStore.EXPECT().GetExecutions(gomock.Any(), jobstore.GetExecutionsOptions{JobID: job.ID}).Return(executions, nil)
-	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]models.NodeInfo{}, nil)
+	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), gomock.Any()).Return([]models.NodeInfo{}, nil)
 
 	// Noop plan
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
@@ -105,7 +101,7 @@ func (s *DaemonJobSchedulerTestSuite) TestProcess_ShouldMarkLostExecutionsOnUnhe
 		*fakeNodeInfo(s.T(), executions[1].NodeID),
 	}
 	s.nodeSelector.EXPECT().AllNodes(gomock.Any()).Return(nodeInfos, nil)
-	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job, gomock.Any()).Return(nodeInfos, nil)
+	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job).Return(nodeInfos, nil)
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
 		Evaluation:         evaluation,
@@ -134,7 +130,7 @@ func (s *DaemonJobSchedulerTestSuite) TestProcess_ShouldNOTMarkJobAsFailed() {
 		*fakeNodeInfo(s.T(), executions[1].NodeID),
 	}
 	s.nodeSelector.EXPECT().AllNodes(gomock.Any()).Return(nodeInfos, nil)
-	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job, gomock.Any()).Return(nodeInfos, nil)
+	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job).Return(nodeInfos, nil)
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
 		Evaluation: evaluation,
@@ -170,7 +166,7 @@ func (s *DaemonJobSchedulerTestSuite) TestProcessFail_NoMatchingNodes() {
 	executions := []models.Execution{} // no executions yet
 	s.jobStore.EXPECT().GetJob(gomock.Any(), job.ID).Return(*job, nil)
 	s.jobStore.EXPECT().GetExecutions(gomock.Any(), jobstore.GetExecutionsOptions{JobID: job.ID}).Return(executions, nil)
-	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job, gomock.Any()).Return([]models.NodeInfo{}, nil)
+	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job).Return([]models.NodeInfo{}, nil)
 
 	// Noop plan
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{

--- a/pkg/orchestrator/scheduler/daemon_job_test.go
+++ b/pkg/orchestrator/scheduler/daemon_job_test.go
@@ -30,11 +30,15 @@ func (s *DaemonJobSchedulerTestSuite) SetupTest() {
 	s.planner = orchestrator.NewMockPlanner(ctrl)
 	s.nodeSelector = orchestrator.NewMockNodeSelector(ctrl)
 
-	s.scheduler = NewDaemonJobScheduler(DaemonJobSchedulerParams{
-		JobStore:     s.jobStore,
-		Planner:      s.planner,
-		NodeSelector: s.nodeSelector,
-	})
+	s.scheduler = NewDaemonJobScheduler(
+		s.jobStore,
+		s.planner,
+		s.nodeSelector,
+		orchestrator.NodeSelectionConstraints{
+			RequireConnected: true,
+			RequireApproval:  true,
+		},
+	)
 }
 
 func TestDaemonJobSchedulerTestSuite(t *testing.T) {

--- a/pkg/orchestrator/scheduler/ops_job.go
+++ b/pkg/orchestrator/scheduler/ops_job.go
@@ -16,22 +16,23 @@ import (
 
 // OpsJobScheduler is a scheduler for batch jobs that run until completion
 type OpsJobScheduler struct {
-	jobStore     jobstore.Store
-	planner      orchestrator.Planner
-	nodeSelector orchestrator.NodeSelector
+	jobStore            jobstore.Store
+	planner             orchestrator.Planner
+	nodeSelector        orchestrator.NodeSelector
+	selectorConstraints orchestrator.NodeSelectionConstraints
 }
 
-type OpsJobSchedulerParams struct {
-	JobStore     jobstore.Store
-	Planner      orchestrator.Planner
-	NodeSelector orchestrator.NodeSelector
-}
-
-func NewOpsJobScheduler(params OpsJobSchedulerParams) *OpsJobScheduler {
+func NewOpsJobScheduler(
+	store jobstore.Store,
+	planner orchestrator.Planner,
+	selector orchestrator.NodeSelector,
+	constraints orchestrator.NodeSelectionConstraints,
+) *OpsJobScheduler {
 	return &OpsJobScheduler{
-		jobStore:     params.JobStore,
-		planner:      params.Planner,
-		nodeSelector: params.NodeSelector,
+		jobStore:            store,
+		planner:             planner,
+		nodeSelector:        selector,
+		selectorConstraints: constraints,
 	}
 }
 
@@ -107,7 +108,7 @@ func (b *OpsJobScheduler) createMissingExecs(
 		ctx,
 		job, &orchestrator.NodeSelectionConstraints{
 			RequireApproval:  true,
-			RequireConnected: false,
+			RequireConnected: true,
 		})
 	if err != nil {
 		return newExecs, err

--- a/pkg/orchestrator/scheduler/ops_job.go
+++ b/pkg/orchestrator/scheduler/ops_job.go
@@ -16,23 +16,20 @@ import (
 
 // OpsJobScheduler is a scheduler for batch jobs that run until completion
 type OpsJobScheduler struct {
-	jobStore            jobstore.Store
-	planner             orchestrator.Planner
-	nodeSelector        orchestrator.NodeSelector
-	selectorConstraints orchestrator.NodeSelectionConstraints
+	jobStore jobstore.Store
+	planner  orchestrator.Planner
+	selector orchestrator.NodeSelector
 }
 
 func NewOpsJobScheduler(
 	store jobstore.Store,
 	planner orchestrator.Planner,
 	selector orchestrator.NodeSelector,
-	constraints orchestrator.NodeSelectionConstraints,
 ) *OpsJobScheduler {
 	return &OpsJobScheduler{
-		jobStore:            store,
-		planner:             planner,
-		nodeSelector:        selector,
-		selectorConstraints: constraints,
+		jobStore: store,
+		planner:  planner,
+		selector: selector,
 	}
 }
 
@@ -65,7 +62,7 @@ func (b *OpsJobScheduler) Process(ctx context.Context, evaluation *models.Evalua
 	}
 
 	// Retrieve the info for all the nodes that have executions for this job
-	nodeInfos, err := existingNodeInfos(ctx, b.nodeSelector, nonTerminalExecs)
+	nodeInfos, err := existingNodeInfos(ctx, b.selector, nonTerminalExecs)
 	if err != nil {
 		return err
 	}
@@ -104,12 +101,7 @@ func (b *OpsJobScheduler) Process(ctx context.Context, evaluation *models.Evalua
 func (b *OpsJobScheduler) createMissingExecs(
 	ctx context.Context, job *models.Job, plan *models.Plan) (execSet, error) {
 	newExecs := execSet{}
-	nodes, err := b.nodeSelector.AllMatchingNodes(
-		ctx,
-		job, &orchestrator.NodeSelectionConstraints{
-			RequireApproval:  true,
-			RequireConnected: true,
-		})
+	nodes, err := b.selector.AllMatchingNodes(ctx, job)
 	if err != nil {
 		return newExecs, err
 	}

--- a/pkg/orchestrator/scheduler/ops_job_test.go
+++ b/pkg/orchestrator/scheduler/ops_job_test.go
@@ -34,10 +34,6 @@ func (s *OpsJobSchedulerTestSuite) SetupTest() {
 		s.jobStore,
 		s.planner,
 		s.nodeSelector,
-		orchestrator.NodeSelectionConstraints{
-			RequireConnected: false,
-			RequireApproval:  false,
-		},
 	)
 }
 
@@ -172,7 +168,7 @@ func (s *OpsJobSchedulerTestSuite) TestProcessFail_NoMatchingNodes() {
 }
 
 func (s *OpsJobSchedulerTestSuite) mockNodeSelection(job *models.Job, nodeInfos []models.NodeInfo) {
-	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job, gomock.Any()).Return(nodeInfos, nil)
+	s.nodeSelector.EXPECT().AllMatchingNodes(gomock.Any(), job).Return(nodeInfos, nil)
 }
 
 func mockOpsJob() (*models.Job, []models.Execution, *models.Evaluation) {

--- a/pkg/orchestrator/scheduler/ops_job_test.go
+++ b/pkg/orchestrator/scheduler/ops_job_test.go
@@ -30,11 +30,15 @@ func (s *OpsJobSchedulerTestSuite) SetupTest() {
 	s.planner = orchestrator.NewMockPlanner(ctrl)
 	s.nodeSelector = orchestrator.NewMockNodeSelector(ctrl)
 
-	s.scheduler = NewOpsJobScheduler(OpsJobSchedulerParams{
-		JobStore:     s.jobStore,
-		Planner:      s.planner,
-		NodeSelector: s.nodeSelector,
-	})
+	s.scheduler = NewOpsJobScheduler(
+		s.jobStore,
+		s.planner,
+		s.nodeSelector,
+		orchestrator.NodeSelectionConstraints{
+			RequireConnected: false,
+			RequireApproval:  false,
+		},
+	)
 }
 
 func TestOpsJobSchedulerTestSuite(t *testing.T) {

--- a/pkg/orchestrator/scheduler/service_job_test.go
+++ b/pkg/orchestrator/scheduler/service_job_test.go
@@ -46,10 +46,6 @@ func (s *ServiceJobSchedulerTestSuite) SetupTest() {
 		s.planner,
 		s.nodeSelector,
 		s.retryStrategy,
-		orchestrator.NodeSelectionConstraints{
-			RequireConnected: false,
-			RequireApproval:  false,
-		},
 	)
 }
 
@@ -326,14 +322,10 @@ func (s *ServiceJobSchedulerTestSuite) TestProcess_ShouldMarkJobAsFailed_NoRetry
 }
 
 func (s *ServiceJobSchedulerTestSuite) mockNodeSelection(job *models.Job, nodeInfos []models.NodeInfo, desiredCount int) {
-	constraints := &orchestrator.NodeSelectionConstraints{
-		RequireApproval:  false,
-		RequireConnected: false,
-	}
 	if len(nodeInfos) < desiredCount {
-		s.nodeSelector.EXPECT().TopMatchingNodes(gomock.Any(), job, desiredCount, constraints).Return(nil, orchestrator.ErrNotEnoughNodes{})
+		s.nodeSelector.EXPECT().TopMatchingNodes(gomock.Any(), job, desiredCount).Return(nil, orchestrator.ErrNotEnoughNodes{})
 	} else {
-		s.nodeSelector.EXPECT().TopMatchingNodes(gomock.Any(), job, desiredCount, constraints).Return(nodeInfos, nil)
+		s.nodeSelector.EXPECT().TopMatchingNodes(gomock.Any(), job, desiredCount).Return(nodeInfos, nil)
 	}
 }
 

--- a/pkg/orchestrator/scheduler/service_job_test.go
+++ b/pkg/orchestrator/scheduler/service_job_test.go
@@ -41,12 +41,16 @@ func (s *ServiceJobSchedulerTestSuite) SetupTest() {
 	s.nodeSelector = orchestrator.NewMockNodeSelector(ctrl)
 	s.retryStrategy = retry.NewFixedStrategy(retry.FixedStrategyParams{ShouldRetry: true})
 
-	s.scheduler = NewBatchServiceJobScheduler(BatchServiceJobSchedulerParams{
-		JobStore:      s.jobStore,
-		Planner:       s.planner,
-		NodeSelector:  s.nodeSelector,
-		RetryStrategy: s.retryStrategy,
-	})
+	s.scheduler = NewBatchServiceJobScheduler(
+		s.jobStore,
+		s.planner,
+		s.nodeSelector,
+		s.retryStrategy,
+		orchestrator.NodeSelectionConstraints{
+			RequireConnected: false,
+			RequireApproval:  false,
+		},
+	)
 }
 
 func TestServiceSchedulerTestSuite(t *testing.T) {

--- a/pkg/test/requester/node_selection_test.go
+++ b/pkg/test/requester/node_selection_test.go
@@ -63,13 +63,10 @@ func (s *NodeSelectionSuite) SetupSuite() {
 			},
 		},
 	}
-	requesterConfig, err := node.NewRequesterConfigWith(
-		node.RequesterConfigParams{
-			NodeRankRandomnessRange: 0,
-			OverAskForBidsFactor:    1,
-		},
-	)
+	requesterConfig, err := node.NewRequesterConfigWithDefaults()
 	s.Require().NoError(err)
+	requesterConfig.OverAskForBidsFactor = 1
+
 	stack := teststack.Setup(ctx,
 		s.T(),
 		devstack.WithNumberOfRequesterOnlyNodes(1),

--- a/pkg/test/requester/retries_test.go
+++ b/pkg/test/requester/retries_test.go
@@ -132,13 +132,10 @@ func (s *RetriesSuite) SetupSuite() {
 	}
 	ctx := context.Background()
 
-	requesterConfig, err := node.NewRequesterConfigWith(
-		node.RequesterConfigParams{
-			NodeRankRandomnessRange: 0,
-			OverAskForBidsFactor:    1,
-		},
-	)
+	requesterConfig, err := node.NewRequesterConfigWithDefaults()
 	s.Require().NoError(err)
+	requesterConfig.OverAskForBidsFactor = 1
+
 	stack := teststack.Setup(ctx, s.T(),
 		devstack.WithNumberOfRequesterOnlyNodes(1),
 		devstack.WithNumberOfComputeOnlyNodes(len(nodeOverrides)-1),


### PR DESCRIPTION
- This change modifies the Requester nodes scheduling constraints s.t. jobs will only be scheduled on nodes that are online and approved. Disconnected nodes and nodes that are rejected or pending will not be eligible to run jobs.
- Additionally, this change cleans up some code by making constraints an parameter to the node selector - which simplify various parts of dependency construction.
- Lastly, this change removes some *Param types to avoid the possibility of NPD.
- fixes #3784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization and configuration process for job schedulers and node selectors for better performance and maintainability.
  - Streamlined node selection logic by removing redundant parameters and simplifying method signatures.
  - Renamed several methods and fields to enhance clarity and consistency across the application.

- **New Features**
  - Enhanced node selection capabilities with additional constraints to better tailor node selection to specific job requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->