### PR TITLE
fix: allow timeouts in the client methods that make API call

### DIFF
--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -59,8 +59,8 @@ func GetAPIClientV2(cmd *cobra.Command) clientv2.API {
 			PersistCredential: func(cred *apimodels.HTTPCredential) error {
 				return WriteToken(base, cred)
 			},
-			Authenticate: func(a *clientv2.Auth) (*apimodels.HTTPCredential, error) {
-				return auth.RunAuthenticationFlow(cmd, a)
+			Authenticate: func(ctx context.Context, a *clientv2.Auth) (*apimodels.HTTPCredential, error) {
+				return auth.RunAuthenticationFlow(ctx, cmd, a)
 			},
 		},
 	)

--- a/cmd/util/auth/auth.go
+++ b/cmd/util/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,13 +20,13 @@ import (
 
 type responder = func(request *json.RawMessage) (response []byte, err error)
 
-func RunAuthenticationFlow(cmd *cobra.Command, auth *client.Auth) (*apimodels.HTTPCredential, error) {
+func RunAuthenticationFlow(ctx context.Context, cmd *cobra.Command, auth *client.Auth) (*apimodels.HTTPCredential, error) {
 	supportedMethods := map[authn.MethodType]responder{
 		authn.MethodTypeChallenge: challenge.Respond,
 		authn.MethodTypeAsk:       askResponder(cmd),
 	}
 
-	methods, err := auth.Methods(cmd.Context(), &apimodels.ListAuthnMethodsRequest{})
+	methods, err := auth.Methods(ctx, &apimodels.ListAuthnMethodsRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +61,7 @@ func RunAuthenticationFlow(cmd *cobra.Command, auth *client.Auth) (*apimodels.HT
 			return nil, err
 		}
 
-		authnResponse, err := auth.Authenticate(cmd.Context(), &apimodels.AuthnRequest{
+		authnResponse, err := auth.Authenticate(ctx, &apimodels.AuthnRequest{
 			Name:       chosenMethodName,
 			MethodData: response,
 		})


### PR DESCRIPTION
Allows `bacalhau version` to fail quickly if the server is offline.