### PR TITLE
refactor: return client version by default

### DIFF
--- a/docs/docs/dev/cli-reference/all-flags.md
+++ b/docs/docs/dev/cli-reference/all-flags.md
@@ -1900,7 +1900,7 @@ bacalhau validate ./job.yaml
 
 ## Version
 
-The `bacalhau version` command allows you to get the client and server version.
+The `bacalhau version` command allows you to get the client and optionally the server version.
 
 Usage:
 ```shell
@@ -1909,7 +1909,7 @@ bacalhau version [flags]
 
 ```shell
 Flags:
-      --client          If true, shows client version only (no server required).
+      --server          If true, queries the server (requester) for its version. (default false)
   -h, --help            help for version
       --hide-header     do not print the column headers.
       --no-style        remove all styling from table output.


### PR DESCRIPTION
- replaces the '--client' flag on the `version` command with '--server'. The default value of '--server' is false. This results in the `version` command always succeeding.
- closes #3308
- see https://github.com/bacalhau-project/get.bacalhau.org/pull/28

New Behavior:
```bash
> bacalhau version
 CLIENT                UPDATE MESSAGE 
 v1.3.0-44-g2b688b95b                 

> bacalhau version --client=false
Flag --client has been deprecated, use --server
 CLIENT                SERVER  LATEST  UPDATE MESSAGE 
 v1.3.0-44-g2b688b95b  v1.3.0  v1.3.0                 

> bacalhau version --client=true
Flag --client has been deprecated, use --server
 CLIENT                UPDATE MESSAGE 
 v1.3.0-44-g2b688b95b                 

> .bacalhau version --server
 CLIENT                SERVER  LATEST  UPDATE MESSAGE 
 v1.3.0-44-g2b688b95b  v1.3.0  v1.3.0                 

> bacalhau version --server=false
 CLIENT                UPDATE MESSAGE 
 v1.3.0-44-g2b688b95b                 
