### PR TITLE
Job disk resource limits should be honoured for `urldownload` storage provider

### DIFF
--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -95,7 +95,7 @@ func (sp *StorageProvider) GetVolumeSize(ctx context.Context, storageSpec models
 		return 0, err
 	}
 
-	res, err := sp.client.Do(req)
+	res, err := sp.client.Do(req) //nolint:bodyclose // this is being closed - golangci-lint is wrong again
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -339,3 +339,87 @@ func (s *StorageSuite) TestPrepareStorageURL() {
 		})
 	}
 }
+
+func (s *StorageSuite) TestGetVolumeSize_WithServerReturningValidSize() {
+	path := "/initial"
+	headers := &map[string]string{
+		"Content-Length": "500",
+	}
+	code := 200
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != path {
+			http.Error(w, fmt.Sprintf("invalid path: %s should be %s", r.URL.Path, path), 999)
+			return
+		}
+
+		if headers != nil {
+			// Set the headers, if any, before WriteHeader is called
+			for k, v := range *headers {
+				w.Header().Add(k, v)
+			}
+		}
+
+		w.WriteHeader(code)
+
+		_, err := w.Write([]byte(""))
+		s.NoError(err)
+	}))
+	s.T().Cleanup(ts.Close)
+
+	subject := NewStorage()
+
+	url := fmt.Sprintf("%s%s", ts.URL, path)
+	spec := models.InputSource{
+		Source: &models.SpecConfig{
+			Type: models.StorageSourceURL,
+			Params: Source{
+				URL: url,
+			}.ToMap(),
+		},
+		Target: "/inputs",
+	}
+
+	vs, err := subject.GetVolumeSize(context.Background(), spec)
+	s.Require().NoError(err)
+
+	s.Equal(uint64(500), vs, "content-length does not match")
+
+}
+
+func (s *StorageSuite) TestGetVolumeSize_WithServerReturningInvalidSize() {
+	path := "/initial"
+	code := 200
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Path != path {
+			http.Error(w, fmt.Sprintf("invalid path: %s should be %s", r.URL.Path, path), 999)
+			return
+		}
+
+		w.WriteHeader(code)
+
+		_, err := w.Write([]byte(""))
+		s.NoError(err)
+	}))
+	s.T().Cleanup(ts.Close)
+
+	subject := NewStorage()
+
+	url := fmt.Sprintf("%s%s", ts.URL, path)
+	spec := models.InputSource{
+		Source: &models.SpecConfig{
+			Type: models.StorageSourceURL,
+			Params: Source{
+				URL: url,
+			}.ToMap(),
+		},
+		Target: "/inputs",
+	}
+
+	_, err := subject.GetVolumeSize(context.Background(), spec)
+	s.Require().ErrorIs(err, ErrNoContentLengthFound)
+
+}


### PR DESCRIPTION
This PR aims at the following 

- For `urldownload` storage provider, while getting volume size we send a `HEAD` request to the server. 
- If the size is obtained we send that size, if not the error is thrown.
- Currently with this PR we do not take care of the case when server does not respond with correct size. 
