### PR TITLE
refactor: implement JobSpec type used for submitting job to V2 api

### DIFF
--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -111,7 +111,17 @@ func exec(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, options *E
 
 	client := util.GetAPIClientV2(cmd)
 	resp, err := client.Jobs().Put(cmd.Context(), &apimodels.PutJobRequest{
-		Job: job,
+		Job: &models.JobSpec{
+			Name:        job.Name,
+			Namespace:   job.Namespace,
+			Type:        job.Type,
+			Priority:    job.Priority,
+			Count:       job.Count,
+			Constraints: job.Constraints,
+			Meta:        job.Meta,
+			Labels:      job.Labels,
+			Tasks:       job.Tasks,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed request: %w", err)

--- a/cmd/cli/job/run.go
+++ b/cmd/cli/job/run.go
@@ -149,7 +149,17 @@ func (o *RunOptions) run(cmd *cobra.Command, args []string) error {
 	// Submit the job
 	client := util.GetAPIClientV2(cmd)
 	resp, err := client.Jobs().Put(ctx, &apimodels.PutJobRequest{
-		Job: j,
+		Job: &models.JobSpec{
+			Name:        j.Name,
+			Namespace:   j.Namespace,
+			Type:        j.Type,
+			Priority:    j.Priority,
+			Count:       j.Count,
+			Constraints: j.Constraints,
+			Meta:        j.Meta,
+			Labels:      j.Labels,
+			Tasks:       j.Tasks,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed request: %w", err)

--- a/pkg/models/job_submit.go
+++ b/pkg/models/job_submit.go
@@ -1,0 +1,116 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+)
+
+type JobSpec struct {
+	// Name is the logical name of the job used to refer to it.
+	// Submitting a job with the same name as an existing job will result in an
+	// update to the existing job.
+	Name string `json:"Name"`
+
+	// Namespace is the namespace this job is running in.
+	Namespace string `json:"Namespace"`
+
+	// Type is the type of job this is, e.g. "daemon" or "batch".
+	Type string `json:"Type"`
+
+	// Priority defines the scheduling priority of this job.
+	Priority int `json:"Priority"`
+
+	// Count is the number of replicas that should be scheduled.
+	Count int `json:"Count"`
+
+	// Constraints is a selector which must be true for the compute node to run this job.
+	Constraints []*LabelSelectorRequirement `json:"Constraints"`
+
+	// Meta is used to associate arbitrary metadata with this job.
+	Meta map[string]string `json:"Meta"`
+
+	// Labels is used to associate arbitrary labels with this job, which can be used
+	// for filtering.
+	Labels map[string]string `json:"Labels"`
+
+	Tasks []*Task `json:"Tasks"`
+}
+
+// ValidateSubmission is used to check a job for reasonable configuration when it is submitted.
+// It is a subset of Validate that does not check fields with defaults, such as job ID
+func (j *JobSpec) ValidateSubmission() error {
+	if j == nil {
+		return errors.New("empty/nil job")
+	}
+
+	var mErr error
+	switch j.Type {
+	case JobTypeService, JobTypeBatch, JobTypeDaemon, JobTypeOps:
+	case "":
+		mErr = errors.Join(mErr, errors.New("missing job type"))
+	default:
+		mErr = errors.Join(mErr, fmt.Errorf("invalid job type: %q", j.Type))
+	}
+
+	if j.Count < 0 {
+		mErr = errors.Join(mErr, errors.New("job count must be >= 0"))
+	}
+	if len(j.Tasks) == 0 {
+		mErr = errors.Join(mErr, errors.New("missing job tasks"))
+	}
+	for idx, constr := range j.Constraints {
+		if err := constr.Validate(); err != nil {
+			outer := fmt.Errorf("constraint %d validation failed: %s", idx+1, err)
+			mErr = errors.Join(mErr, outer)
+		}
+	}
+
+	// Validate the task group
+	for _, task := range j.Tasks {
+		if err := task.ValidateSubmission(); err != nil {
+			outer := fmt.Errorf("task %s validation failed: %v", task.Name, err)
+			mErr = errors.Join(mErr, outer)
+		}
+	}
+
+	return mErr
+}
+
+// Normalize is used to canonicalize fields in the Job. This should be
+// called when registering a Job.
+func (j *JobSpec) Normalize() {
+	if j == nil {
+		return
+	}
+
+	// Ensure that an empty and nil map are treated the same to avoid scheduling
+	// problems since we use reflect DeepEquals.
+	if j.Meta == nil {
+		j.Meta = make(map[string]string)
+	}
+
+	if j.Labels == nil {
+		j.Labels = make(map[string]string)
+	}
+
+	if j.Constraints == nil {
+		j.Constraints = make([]*LabelSelectorRequirement, 0)
+	}
+
+	if j.Tasks == nil {
+		j.Tasks = make([]*Task, 0)
+	}
+
+	// Ensure the job is in a namespace.
+	if j.Namespace == "" {
+		j.Namespace = DefaultNamespace
+	}
+
+	if (j.Type == JobTypeDaemon || j.Type == JobTypeOps) && j.Count == 0 {
+		j.Count = 1
+	}
+
+	for _, task := range j.Tasks {
+		task.Normalize()
+	}
+}

--- a/pkg/publicapi/apimodels/job.go
+++ b/pkg/publicapi/apimodels/job.go
@@ -3,13 +3,14 @@ package apimodels
 import (
 	"strconv"
 
-	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
 )
 
 type PutJobRequest struct {
 	BasePutRequest
-	Job *models.Job `json:"Job"`
+	Job *models.JobSpec `json:"Job"`
 }
 
 // Normalize is used to canonicalize fields in the PutJobRequest.

--- a/pkg/publicapi/endpoint/orchestrator/job.go
+++ b/pkg/publicapi/endpoint/orchestrator/job.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
 
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -44,7 +45,17 @@ func (e *Endpoint) putJob(c echo.Context) error {
 		return err
 	}
 	resp, err := e.orchestrator.SubmitJob(ctx, &orchestrator.SubmitJobRequest{
-		Job: args.Job,
+		Job: &models.Job{
+			Name:        args.Job.Name,
+			Namespace:   args.Job.Namespace,
+			Type:        args.Job.Type,
+			Priority:    args.Job.Priority,
+			Count:       args.Job.Count,
+			Constraints: args.Job.Constraints,
+			Meta:        args.Job.Meta,
+			Labels:      args.Job.Labels,
+			Tasks:       args.Job.Tasks,
+		},
 	})
 	if err != nil {
 		return err

--- a/pkg/publicapi/test/job_test.go
+++ b/pkg/publicapi/test/job_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 )
@@ -13,7 +14,17 @@ import (
 func (s *ServerSuite) TestJobOperations() {
 	ctx := context.Background()
 	job := mock.Job()
-	putResponse, err := s.client.Jobs().Put(ctx, &apimodels.PutJobRequest{Job: job})
+	putResponse, err := s.client.Jobs().Put(ctx, &apimodels.PutJobRequest{Job: &models.JobSpec{
+		Name:        job.Name,
+		Namespace:   job.Namespace,
+		Type:        job.Type,
+		Priority:    job.Priority,
+		Count:       job.Count,
+		Constraints: job.Constraints,
+		Meta:        job.Meta,
+		Labels:      job.Labels,
+		Tasks:       job.Tasks,
+	}})
 	s.Require().NoError(err)
 	s.Require().NotNil(putResponse)
 	s.Require().NotEmpty(putResponse.JobID)


### PR DESCRIPTION
This change implements the `JobSpec` type which contains only the fields of a Job users are permitted to set when submitting a job to run. This change modifies the `PutJobRequest` to use `JobSpec` as the new payload. 
- progress towards #3983