### PR TITLE
fix canary after config changes

### DIFF
--- a/ops/aws/canary/lambda/pkg/test/local_test.go
+++ b/ops/aws/canary/lambda/pkg/test/local_test.go
@@ -65,7 +65,7 @@ func TestScenariosAgainstDevstack(t *testing.T) {
 	for name := range router.TestcasesMap {
 		t.Run(name, func(t *testing.T) {
 			event := models.Event{Action: name}
-			err := router.Route(context.Background(), event, router.WithConfig(c))
+			err := router.RouteWithOpts(context.Background(), event, router.WithConfig(c))
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
Canaries has been failing with `handlers may not take more than two arguments, but handler takes 3: errorString null` error