### PR TITLE
Optimize locking in producer and consumer NATS streaming client

### DIFF
--- a/pkg/nats/proxy/compute_handler.go
+++ b/pkg/nats/proxy/compute_handler.go
@@ -158,6 +158,12 @@ func processAndStream[Request, Response any](ctx context.Context, streamingClien
 		return
 	}
 
+	// This context is passed down to particular engine serving the stream. The cancel function is stored as part of
+	// the StreamInfo. When the consumer client informs the producer client via heartBeat that it is no longer interested
+	// in the stream, we call this cancel function. This also informs the engine that we are no longer interested in this
+	// stream and hence close it. There might be scenarios where few logs will make it through after context cancelation
+	// due to race conditions. This should be find and won't result in nil pointers or writing to a closed writer as
+	// we only close the writer after source channel is closed.
 	childCtx, cancel := context.WithCancel(ctx)
 	err = streamingClient.AddStream(
 		streamRequest.ConsumerID,

--- a/pkg/nats/stream/types.go
+++ b/pkg/nats/stream/types.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"context"
 	"strconv"
 	"time"
 )
@@ -47,6 +48,8 @@ type StreamInfo struct {
 	RequestSub string
 	// CreatedAt represents the time the stream was created.
 	CreatedAt time.Time
+	// Function to cancel the stream
+	Cancel context.CancelFunc
 }
 
 // StreamProducerClientConfig represents the configuration of NATS based streaming

--- a/pkg/nats/stream/types.go
+++ b/pkg/nats/stream/types.go
@@ -48,7 +48,9 @@ type StreamInfo struct {
 	RequestSub string
 	// CreatedAt represents the time the stream was created.
 	CreatedAt time.Time
-	// Function to cancel the stream
+	// Function to cancel the stream. This is useful in the event the consumer client
+	// is no longer interested in the stream. The cancel function is inovked informing the
+	// producer to no longer serve the stream.
 	Cancel context.CancelFunc
 }
 


### PR DESCRIPTION
## What are we doing here ?

- With this PR, we are making sure we do locking correctly. 
- In addition, we come up with a good way to cancel the stream. We store a `cancel` function as part of stream.  This cancel function is attached to the context which gets passed on to the engine, which serves the stream (currently only the log stream).  If a heartbeat response is received from the consumer stating that it is no longer interested in this stream, then we invoke this `cancel` function. There might be scenarios where few logs will make it through after context cancelation due to race conditions. This should be fine and won't result in `nil` pointers or writing to a closed writer as we only close the writer after source channel is closed.