### PR TITLE
feat: implement UnmarshalJob method with clear errors

### DIFF
--- a/cmd/cli/job/run.go
+++ b/cmd/cli/job/run.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util/output"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/template"
-	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 
@@ -135,10 +134,7 @@ func (o *RunOptions) run(cmd *cobra.Command, args []string, api client.API) erro
 		}
 	}
 
-	// Turns out the yaml parser supports both yaml & json (because json is a subset of yaml)
-	// so we can just use that
-	var j *models.Job
-	err = marshaller.YAMLUnmarshalWithMax(byteResult, &j)
+	j, err := marshaller.UnmarshalJob(byteResult)
 	if err != nil {
 		return fmt.Errorf("%s: %w", userstrings.JobSpecBad, err)
 	}

--- a/pkg/lib/marshaller/utils.go
+++ b/pkg/lib/marshaller/utils.go
@@ -2,13 +2,15 @@ package marshaller
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/c2h5oh/datasize"
 	"sigs.k8s.io/yaml"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
 )
 
 type KeyString string
@@ -97,3 +99,90 @@ func normalizeIfApplicable(obj interface{}) {
 		normalizable.Normalize()
 	}
 }
+
+// UnmarshalJob unmarshalled `in` into a models.Job. It returns an error if:
+// - `in` cannot be marshaled to json.
+// - `in` contains an un-settable or unknown field.
+// - `in` cannot be marshaled into a models.Job.
+func UnmarshalJob(in []byte) (*models.Job, error) {
+	// json is a subset of yaml, if `in` is already json this is a noop.
+	jsonBytes, err := yaml.YAMLToJSON(in)
+	if err != nil {
+		return nil, fmt.Errorf("converting yaml to json: %w", err)
+	}
+
+	// unmarshal the job into a generic map
+	var raw map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
+		return nil, err
+	}
+	// error(s) if un-settable or unknown fields are provided.
+	if err := validateRawJob(raw); err != nil {
+		return nil, err
+	}
+
+	var out *models.Job
+	if err := json.Unmarshal(jsonBytes, &out); err != nil {
+		switch v := err.(type) {
+		// json.UnmarshalTypeError describes a JSON value that as not appropriate for the value of the specified Go type.
+		// e.g. if the Count field was not an int, or the Name field was not a string
+		case *json.UnmarshalTypeError:
+			return nil, fmt.Errorf("field: '%s' in '%s' is invalid type: '%s' expected: '%s'", v.Field, v.Struct, v.Value, v.Type.String())
+		default:
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// validateRawJob returns an error if `jobSpec` contains a job field that may not be set by the user or if unknown
+// fields were included in `jobSpec`.
+func validateRawJob(jobSpec map[string]interface{}) error {
+	var mErr error
+	// first check if any un-settable fields were provided.
+	for key := range jobSpec {
+		specKey := strings.ToLower(key)
+		if _, found := disallowedKeys[specKey]; found {
+			mErr = errors.Join(mErr, fmt.Errorf("field: '%s' in 'Job' is not allowed", key))
+		}
+	}
+	// remove all known fields from the provided spec.
+	for key := range jobSpec {
+		specKey := strings.ToLower(key)
+		if _, ok := disallowedKeys[specKey]; ok {
+			delete(jobSpec, key)
+		}
+		if _, ok := allowedKeys[specKey]; ok {
+			delete(jobSpec, key)
+		}
+	}
+	// any fields that remain are considered unknown
+	for key := range jobSpec {
+		mErr = errors.Join(mErr, fmt.Errorf("unknown field: '%s' in 'Job' is ignored", key))
+	}
+	return mErr
+}
+
+var (
+	// disallowedKeys contains system fields that users may not set when providing a job spec.
+	disallowedKeys = map[string]struct{}{
+		"id":         {},
+		"state":      {},
+		"version":    {},
+		"revision":   {},
+		"createtime": {},
+		"modifytime": {},
+	}
+	// allowedKeys contains fields users are permitted to set when providing a job spec.
+	allowedKeys = map[string]struct{}{
+		"name":        {},
+		"namespace":   {},
+		"type":        {},
+		"priority":    {},
+		"count":       {},
+		"constraints": {},
+		"meta":        {},
+		"labels":      {},
+		"tasks":       {},
+	}
+)

--- a/pkg/lib/marshaller/utils_test.go
+++ b/pkg/lib/marshaller/utils_test.go
@@ -1,0 +1,138 @@
+//go:build unit || !integration
+
+package marshaller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalJob(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		var jobWithUnknownFields = `
+{
+  "Name": "A Simple Docker Job",
+  "Type": "batch",
+  "Count": 1,
+  "Tasks": [
+    {
+      "Name": "My main task",
+      "Engine": {
+        "Type": "docker",
+        "Params": {
+          "Image": "ubuntu:latest",
+          "Entrypoint": [
+            "/bin/bash"
+          ],
+          "Parameters": [
+            "-c",
+            "echo Hello Bacalhau!"
+          ]
+        }
+      }
+    }
+  ]
+}
+`
+		j, err := UnmarshalJob([]byte(jobWithUnknownFields))
+		assert.NotNil(t, j)
+		assert.NoError(t, err)
+	})
+	t.Run("job with unknown field", func(t *testing.T) {
+		var jobWithUnknownFields = `
+{
+  "Name": "A Simple Docker Job",
+  "Type": "batch",
+  "Selector": "nope",
+  "Count": 1,
+  "Tasks": [
+    {
+      "Name": "My main task",
+      "Engine": {
+        "Type": "docker",
+        "Params": {
+          "Image": "ubuntu:latest",
+          "Entrypoint": [
+            "/bin/bash"
+          ],
+          "Parameters": [
+            "-c",
+            "echo Hello Bacalhau!"
+          ]
+        }
+      }
+    }
+  ]
+}
+`
+		j, err := UnmarshalJob([]byte(jobWithUnknownFields))
+		assert.Nil(t, j)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "unknown field: 'Selector' in 'Job' is ignored")
+	})
+	t.Run("job with un-settable field", func(t *testing.T) {
+		var jobWithUnknownFields = `
+{
+  "Name": "A Simple Docker Job",
+  "Type": "batch",
+  "Version": 1,
+  "Count": 1,
+  "Tasks": [
+    {
+      "Name": "My main task",
+      "Engine": {
+        "Type": "docker",
+        "Params": {
+          "Image": "ubuntu:latest",
+          "Entrypoint": [
+            "/bin/bash"
+          ],
+          "Parameters": [
+            "-c",
+            "echo Hello Bacalhau!"
+          ]
+        }
+      }
+    }
+  ]
+}
+`
+		j, err := UnmarshalJob([]byte(jobWithUnknownFields))
+		assert.Nil(t, j)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "field: 'Version' in 'Job' is not allowed")
+	})
+	t.Run("job with invalid field type field", func(t *testing.T) {
+		var jobWithUnknownFields = `
+{
+  "Name": "A Simple Docker Job",
+  "Type": "batch",
+  "Count": "1",
+  "Tasks": [
+    {
+      "Name": "My main task",
+      "Engine": {
+        "Type": "docker",
+        "Params": {
+          "Image": "ubuntu:latest",
+          "Entrypoint": [
+            "/bin/bash"
+          ],
+          "Parameters": [
+            "-c",
+            "echo Hello Bacalhau!"
+          ]
+        }
+      }
+    }
+  ]
+}
+`
+		j, err := UnmarshalJob([]byte(jobWithUnknownFields))
+		assert.Nil(t, j)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "field: 'Count' in 'Job' is invalid type: 'string' expected: 'int'")
+	})
+
+}


### PR DESCRIPTION
- provids clear errors when a job contains:
  - un-settable fields
  - invalid field types
  - unknown fields

- closes #3719

## Example:
This job contains an unknown field `Selector` and an un-settable field `Version`:
```json
{
  "Name": "A Simple Docker Job",
  "Type": "batch",
  "Version": 10,
  "Selector": "nope",
  "Count": "1",
  "Tasks": [
    {
      "Name": "My main task",
      "Engine": {
        "Type": "docker",
        "Params": {
          "Image": "ubuntu:latest",
          "Entrypoint": [
            "/bin/bash"
          ],
          "Parameters": [
            "-c",
            "echo Hello Bacalhau!"
          ]
        }
      }
    }
  ]
}
```
The errors produced from this look like:
```bash
$ bacalhau job run bad_job.json 
Error: the job provided is invalid: field: 'Version' in 'Job' is not allowed
unknown field: 'Selector' in 'Job' is ignored
```

This job contains an allowed field `Count`, but its the wrong type `string`, it should be an `int`:
 ```json
 {
  "Name": "A Simple Docker Job",
  "Type": "batch",
  "Count": "1",
  "Tasks": [
    {
      "Name": "My main task",
      "Engine": {
        "Type": "docker",
        "Params": {
          "Image": "ubuntu:latest",
          "Entrypoint": [
            "/bin/bash"
          ],
          "Parameters": [
            "-c",
            "echo Hello Bacalhau!"
          ]
        }
      }
    }
  ]
}
```
The errors produced from this like:
```
$ bacalhau job run job_w_version.json
Error: the job provided is invalid: field: 'Count' in 'Job' is invalid type: 'string' expected: 'int'
```