### PR TITLE
refactor: deprecate requester api endpoint

### DIFF
--- a/pkg/publicapi/endpoint/requester/endpoint.go
+++ b/pkg/publicapi/endpoint/requester/endpoint.go
@@ -1,15 +1,19 @@
 package requester
 
 import (
+	"fmt"
+	"net/http"
+	"os"
 	"sync"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
 
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/middleware"
 	"github.com/bacalhau-project/bacalhau/pkg/requester"
-	"github.com/gorilla/websocket"
-	"github.com/labstack/echo/v4"
 )
 
 type EndpointParams struct {
@@ -31,6 +35,8 @@ type Endpoint struct {
 	websocketsMutex sync.RWMutex
 }
 
+const UseDeprecatedEndpointsForTesting = "REQUESTER_ENDPOINT_USE_DEPRECATED_ENV"
+
 func NewEndpoint(params EndpointParams) *Endpoint {
 	e := &Endpoint{
 		router:             params.Router,
@@ -43,15 +49,42 @@ func NewEndpoint(params EndpointParams) *Endpoint {
 
 	g := e.router.Group("/api/v1/requester")
 	g.Use(middleware.SetContentType(echo.MIMEApplicationJSON))
-	g.POST("/list", e.list)
-	g.GET("/nodes", e.nodes)
-	g.POST("/states", e.states)
-	g.POST("/results", e.results)
-	g.POST("/events", e.events)
-	g.POST("/submit", e.submit)
-	g.POST("/cancel", e.cancel)
-	g.POST("/debug", e.debug)
-	g.GET("/websocket/events", e.websocketJobEvents)
+	if key := os.Getenv(UseDeprecatedEndpointsForTesting); key != "" {
+		g.POST("/list", e.list)
+		g.GET("/nodes", e.nodes)
+		g.POST("/states", e.states)
+		g.POST("/results", e.results)
+		g.POST("/events", e.events)
+		g.POST("/submit", e.submit)
+		g.POST("/cancel", e.cancel)
+		g.POST("/debug", e.debug)
+		g.GET("/websocket/events", e.websocketJobEvents)
+		return e
+	}
 
+	registerDeprecatedLegacyMethods(g)
 	return e
+}
+
+// registerDeprecatedLegacyMethods registers routes on the router that are 'Gone'.
+func registerDeprecatedLegacyMethods(group *echo.Group) {
+	// Legacy API Endpoints
+	// All return status 410 https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410
+	group.POST("/list", methodGone("https://docs.bacalhau.org/references/api/jobs#list-jobs"))
+	group.GET("/nodes", methodGone("https://docs.bacalhau.org/references/api/nodes#list-nodes"))
+	group.POST("/states", methodGone("https://docs.bacalhau.org/references/api/jobs#describe-job"))
+	group.POST("/results", methodGone("https://docs.bacalhau.org/references/api/jobs#describe-job"))
+	group.POST("/events", methodGone("https://docs.bacalhau.org/references/api/jobs#job-history"))
+	group.POST("/submit", methodGone("https://docs.bacalhau.org/references/api/jobs#create-job"))
+	group.POST("/cancel", methodGone("https://docs.bacalhau.org/references/api/jobs#stop-job"))
+	group.POST("/debug", methodGone("https://docs.bacalhau.org/references/api/nodes#describe-node"))
+	group.GET("/websocket/events", methodGone("https://docs.bacalhau.org/references/api/jobs#job-history"))
+}
+
+const deprecationMessage = "This endpoint is deprecated and no longer available. Please refer to %s for more information. If you encountered this error using the Bacalhau client or CLI, please update your node by following the instructions here: https://docs.bacalhau.org/getting-started/installation" //nolint:lll
+
+func methodGone(docsLink string) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		return c.JSON(http.StatusGone, fmt.Sprintf(deprecationMessage, docsLink))
+	}
 }

--- a/pkg/publicapi/test/util_test.go
+++ b/pkg/publicapi/test/util_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store/boltdb"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	boltjobstore "github.com/bacalhau-project/bacalhau/pkg/jobstore/boltdb"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/requester"
 
 	"github.com/bacalhau-project/bacalhau/pkg/devstack"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/network"
@@ -72,6 +74,9 @@ func setupNodeForTestWithConfig(t *testing.T, apiCfg publicapi.Config) (*node.No
 		NetworkConfig:       networkConfig,
 	}
 
+	if err := os.Setenv(requester.UseDeprecatedEndpointsForTesting, "true"); err != nil {
+		t.Fatal(err)
+	}
 	n, err := node.NewNode(ctx, c, nodeConfig, repo)
 	require.NoError(t, err)
 

--- a/pkg/test/teststack/stack.go
+++ b/pkg/test/teststack/stack.go
@@ -4,6 +4,7 @@ package teststack
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/node"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/requester"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
@@ -49,6 +51,9 @@ func Setup(
 	t.Cleanup(func() {
 		cm.Cleanup(ctx)
 	})
+	if err := os.Setenv(requester.UseDeprecatedEndpointsForTesting, "true"); err != nil {
+		t.Fatal(err)
+	}
 	stack, err := devstack.Setup(ctx, cfg, cm, fsr, append(testDevStackConfig().Options(), opts...)...)
 	if err != nil {
 		t.Fatalf("creating teststack: %s", err)


### PR DESCRIPTION
- closes #4104

If an outdated bacalhau node uses a deprecated CLI method that calls one of these endpoints, or if one is curled, the follow error message is returned:

**CLI**
```shell
bacalhau list
Error: publicapi: after posting request: "This endpoint is deprecated and no longer available. Please refer to https://docs.bacalhau.org/references/api/jobs#list-jobs for more information. If you encountered this error using the Bacalhau client or CLI, please update your node by following the instructions here: https://docs.bacalhau.org/getting-started/installation"
```

**Curl**
```shell
curl -v -X POST 0.0.0.0:1234/api/v1/requester/states
*   Trying 0.0.0.0:1234...
* Connected to 0.0.0.0 (127.0.0.1) port 1234 (#0)
> POST /api/v1/requester/states HTTP/1.1
> Host: 0.0.0.0:1234
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 410 Gone
< Content-Type: application/json
< Vary: Origin
< X-Bacalhau-Arch: amd64
< X-Bacalhau-Build-Date: 2024-06-18 16:01:50 +0000 UTC
< X-Bacalhau-Build-Os: linux
< X-Bacalhau-Git-Commit: 43b311c355e857e92109bf48228431ed90d82553
< X-Bacalhau-Git-Version: v1.3.2-26-g43b311c35
< X-Request-Id: qgdrqWoZhjbFarFeDTZTBAaQTBKbQbRX
< Date: Tue, 18 Jun 2024 20:58:17 GMT
< Content-Length: 123
< 
"This endpoint is deprecated and no longer available. Please refer to https://docs.bacalhau.org/references/api/jobs#list-jobs for more information. If you encountered this error using the Bacalhau client or CLI, please update your node by following the instructions here: https://docs.bacalhau.org/getting-started/installation"
```

The error message includes links to each new API method and additionally a link to our installation guide.