### PR TITLE
test flakiness improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ commands:
       - run:
           name: Start IPFS Daemon
           command: |
-            ipfs daemon
+            ipfs daemon --offline
           background: true
 jobs:
   build_cli:

--- a/cmd/cli/job/get_test.go
+++ b/cmd/cli/job/get_test.go
@@ -58,7 +58,7 @@ func (s *GetSuite) TestGetSingleFileFromOutputBadChoice() {
 	)
 
 	require.Error(s.T(), err, "expected error but it wasn't returned")
-	require.Contains(s.T(), getoutput, "error downloading job")
+	require.Contains(s.T(), getoutput, "Error: downloading job")
 }
 
 func (s *GetSuite) TestGetSingleFileFromOutput() {

--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -100,7 +100,7 @@ func PrintJobExecution(
 		}
 	}
 
-	if runtimeSettings.PrintNodeDetails {
+	if runtimeSettings.PrintNodeDetails || jobErr != nil {
 		executions, err := client.Jobs().Executions(ctx, &apimodels.ListJobExecutionsRequest{
 			JobID: jobID,
 		})

--- a/pkg/telemetry/tracing_helpers_test.go
+++ b/pkg/telemetry/tracing_helpers_test.go
@@ -171,7 +171,9 @@ func TestRecordErrorOnSpanOneChannel_withoutError(t *testing.T) {
 	assert.False(t, span.ended, "span should only be closed once the channel has received a response")
 	realChan <- expectedParam
 	actualParam := <-actualChan
-	assert.True(t, span.ended, "span should only be closed once the channel has received a response")
+	assert.Eventually(t, func() bool {
+		return span.ended
+	}, 1*time.Second, 5*time.Millisecond, "span should only be closed once the channel has received a response")
 	assert.Equal(t, expectedParam, actualParam)
 }
 
@@ -193,8 +195,9 @@ func TestRecordErrorOnSpanTwoChannels_withError(t *testing.T) {
 	assert.False(t, span.ended, "span should only be closed once the channel has received a response")
 	errChan <- expectedErr
 	actualErr := <-actualErrChan
-	assert.True(t, span.ended, "span should only be closed once the channel has received a response")
-
+	assert.Eventually(t, func() bool {
+		return span.ended
+	}, 1*time.Second, 5*time.Millisecond, "span should only be closed once the channel has received a response")
 	assert.Equal(t, expectedErr, actualErr)
 	assert.Equal(t, expectedErr, span.err)
 	assert.Equal(t, codes.Error, span.statusCode)


### PR DESCRIPTION
Improve stability and fix few tests, including:
- Make IPFS daemon offline to stabilize IPFS related tests
- Fix `get_test.go` which was checking for wrong error message. Not sure how they were passing before!
- Fix `TestDockerRunSuite/TestRun_BadExecutables/bad-image-bad-executable` who was checking for node error details in the output message, but we weren't printing it in the new print path. Again not sure how they were passing!
- Fix tracing tests race condition when checking for span closure

Actually printing node details when there is an error is not test related and should be merged before 1.4