### PR TITLE
new cli and api migration url

### DIFF
--- a/cmd/cli/deprecated/cancel.go
+++ b/cmd/cli/deprecated/cancel.go
@@ -8,7 +8,7 @@ func NewCancelCmd() *cobra.Command {
 	cancelCmd := &cobra.Command{
 		Use:        "cancel [id]",
 		Short:      "DEPRECATED: Cancel a previously submitted job",
-		Deprecated: "Please use `job stop` to cancel jobs.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job stop` to cancel jobs.\n" + migrationMessageSuffix,
 		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			return nil
 		},

--- a/cmd/cli/deprecated/cancel.go
+++ b/cmd/cli/deprecated/cancel.go
@@ -1,15 +1,14 @@
-package cancel
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewCancelCmd() *cobra.Command {
 	cancelCmd := &cobra.Command{
 		Use:        "cancel [id]",
 		Short:      "DEPRECATED: Cancel a previously submitted job",
-		Deprecated: "This command has moved! Please use `job stop` to cancel jobs.",
-		Args:       cobra.ExactArgs(1),
+		Deprecated: "Please use `job stop` to cancel jobs.\n" + migrationMessageSuffix,
 		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			return nil
 		},

--- a/cmd/cli/deprecated/create.go
+++ b/cmd/cli/deprecated/create.go
@@ -8,7 +8,7 @@ func NewCreateCmd() *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:        "create",
 		Short:      "DEPRECATED: Create a job using a json or yaml file.",
-		Deprecated: "Please use `job run` to create jobs.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job run` to create jobs.\n" + migrationMessageSuffix,
 		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			return nil
 		},

--- a/cmd/cli/deprecated/create.go
+++ b/cmd/cli/deprecated/create.go
@@ -1,15 +1,14 @@
-package create
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewCreateCmd() *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:        "create",
 		Short:      "DEPRECATED: Create a job using a json or yaml file.",
-		Deprecated: "This command has moved! Please use `job run` to create jobs.",
-		Args:       cobra.MinimumNArgs(0),
+		Deprecated: "Please use `job run` to create jobs.\n" + migrationMessageSuffix,
 		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			return nil
 		},

--- a/cmd/cli/deprecated/describe.go
+++ b/cmd/cli/deprecated/describe.go
@@ -8,7 +8,7 @@ func NewDescribeCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "describe [id]",
 		Short:      "DEPRECATED: Describe a job on the network",
-		Deprecated: "Please use `job describe` to describe jobs.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job describe` to describe jobs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, cmdArgs []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/describe.go
+++ b/cmd/cli/deprecated/describe.go
@@ -1,14 +1,14 @@
-package describe
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewDescribeCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "describe [id]",
 		Short:      "DEPRECATED: Describe a job on the network",
-		Deprecated: "This command has moved! Please use `job describe` to describe jobs.",
+		Deprecated: "Please use `job describe` to describe jobs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, cmdArgs []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/get.go
+++ b/cmd/cli/deprecated/get.go
@@ -8,7 +8,7 @@ func NewGetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "get [id]",
 		Short:      "DEPRECATED: Get the results of a job",
-		Deprecated: "Please use `job get` to download results of a job.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job get` to download results of a job.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, cmdArgs []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/get.go
+++ b/cmd/cli/deprecated/get.go
@@ -1,14 +1,14 @@
-package get
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewGetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "get [id]",
 		Short:      "DEPRECATED: Get the results of a job",
-		Deprecated: "This command has moved! Please use `job get` to download results of a job.",
+		Deprecated: "Please use `job get` to download results of a job.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, cmdArgs []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/helper.go
+++ b/cmd/cli/deprecated/helper.go
@@ -1,0 +1,9 @@
+package deprecated
+
+import (
+	"fmt"
+)
+
+const MigrationURL = "https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration"
+
+var migrationMessageSuffix = fmt.Sprintf(`See the migration guide at %s for more information.`, MigrationURL)

--- a/cmd/cli/deprecated/helper.go
+++ b/cmd/cli/deprecated/helper.go
@@ -2,8 +2,10 @@ package deprecated
 
 import (
 	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/requester"
 )
 
-const MigrationURL = "https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration"
+const migrationURL = requester.MigrationGuideURL
 
-var migrationMessageSuffix = fmt.Sprintf(`See the migration guide at %s for more information.`, MigrationURL)
+var migrationMessageSuffix = fmt.Sprintf(`See the migration guide at %s for more information.`, migrationURL)

--- a/cmd/cli/deprecated/id.go
+++ b/cmd/cli/deprecated/id.go
@@ -8,7 +8,7 @@ func NewIDCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "id",
 		Short:      "DEPRECATED: Show bacalhau node id info",
-		Deprecated: "Please use `agent node` to inspect bacalhau nodes.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau agent node` to inspect bacalhau nodes.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, _ []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/id.go
+++ b/cmd/cli/deprecated/id.go
@@ -1,14 +1,14 @@
-package id
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewIDCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "id",
 		Short:      "DEPRECATED: Show bacalhau node id info",
-		Deprecated: "This command has moved! Please use `agent node` to inspect bacalhau nodes.",
+		Deprecated: "Please use `agent node` to inspect bacalhau nodes.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, _ []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/list.go
+++ b/cmd/cli/deprecated/list.go
@@ -1,14 +1,14 @@
-package list
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "list",
 		Short:      "DEPRECATED: List jobs on the network",
-		Deprecated: "This command has moved! Please use `job list` to list jobs.",
+		Deprecated: "Please use `job list` to list jobs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, _ []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/list.go
+++ b/cmd/cli/deprecated/list.go
@@ -8,7 +8,7 @@ func NewListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "list",
 		Short:      "DEPRECATED: List jobs on the network",
-		Deprecated: "Please use `job list` to list jobs.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job list` to list jobs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, _ []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/logs.go
+++ b/cmd/cli/deprecated/logs.go
@@ -8,7 +8,7 @@ func NewLogsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "logs [id]",
 		Short:      "DEPRECATED: Follow logs from a currently executing job",
-		Deprecated: "Please use `job logs` to follow job logs.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job logs` to follow job logs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, _ []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/logs.go
+++ b/cmd/cli/deprecated/logs.go
@@ -1,14 +1,14 @@
-package logs
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewLogsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "logs [id]",
 		Short:      "DEPRECATED: Follow logs from a currently executing job",
-		Deprecated: "This command has moved! Please use `job logs` to follow job logs.",
+		Deprecated: "Please use `job logs` to follow job logs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, _ []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/validate.go
+++ b/cmd/cli/deprecated/validate.go
@@ -1,14 +1,14 @@
-package validate
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmd() *cobra.Command {
+func NewValidateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "validate",
 		Short:      "DEPRECATED: validate a job using a json or yaml file.",
-		Deprecated: "This command has moved! Please use `job validate` to validate jobs.",
+		Deprecated: "Please use `job validate` to validate jobs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, cmdArgs []string) error { return nil },
 	}
 }

--- a/cmd/cli/deprecated/validate.go
+++ b/cmd/cli/deprecated/validate.go
@@ -8,7 +8,7 @@ func NewValidateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "validate",
 		Short:      "DEPRECATED: validate a job using a json or yaml file.",
-		Deprecated: "Please use `job validate` to validate jobs.\n" + migrationMessageSuffix,
+		Deprecated: "Please use `bacalhau job validate` to validate jobs.\n" + migrationMessageSuffix,
 		RunE:       func(cmd *cobra.Command, cmdArgs []string) error { return nil },
 	}
 }

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -11,22 +11,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/bacalhau-project/bacalhau/cmd/cli/agent"
+	"github.com/bacalhau-project/bacalhau/cmd/cli/deprecated"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/exec"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/job"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/node"
 
-	"github.com/bacalhau-project/bacalhau/cmd/cli/cancel"
 	configcli "github.com/bacalhau-project/bacalhau/cmd/cli/config"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/create"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/describe"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/devstack"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/docker"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/get"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/id"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/list"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/logs"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/serve"
-	"github.com/bacalhau-project/bacalhau/cmd/cli/validate"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/version"
 	"github.com/bacalhau-project/bacalhau/cmd/cli/wasm"
 	"github.com/bacalhau-project/bacalhau/cmd/util"
@@ -99,33 +92,31 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	// ====== Start a job
-
-	// Create job from file
-	RootCmd.AddCommand(create.NewCmd())
+	RootCmd.AddCommand(deprecated.NewCreateCmd())
 
 	// Plumbing commands (advanced usage)
 	RootCmd.AddCommand(docker.NewCmd())
 	RootCmd.AddCommand(wasm.NewCmd())
 
-	RootCmd.AddCommand(validate.NewCmd())
+	RootCmd.AddCommand(deprecated.NewValidateCmd())
 
 	RootCmd.AddCommand(version.NewCmd())
 
 	// ====== Get information or results about a job
 	// Describe a job
-	RootCmd.AddCommand(describe.NewCmd())
+	RootCmd.AddCommand(deprecated.NewDescribeCmd())
 
 	// Get logs
-	RootCmd.AddCommand(logs.NewCmd())
+	RootCmd.AddCommand(deprecated.NewLogsCmd())
 
 	// Get the results of a job
-	RootCmd.AddCommand(get.NewCmd())
+	RootCmd.AddCommand(deprecated.NewGetCmd())
 
 	// Cancel a job
-	RootCmd.AddCommand(cancel.NewCmd())
+	RootCmd.AddCommand(deprecated.NewCancelCmd())
 
 	// List jobs
-	RootCmd.AddCommand(list.NewCmd())
+	RootCmd.AddCommand(deprecated.NewListCmd())
 
 	// Register agent subcommands
 	RootCmd.AddCommand(agent.NewCmd())
@@ -143,7 +134,7 @@ func NewRootCmd() *cobra.Command {
 
 	// Serve commands
 	RootCmd.AddCommand(serve.NewCmd())
-	RootCmd.AddCommand(id.NewCmd())
+	RootCmd.AddCommand(deprecated.NewIDCmd())
 	RootCmd.AddCommand(devstack.NewCmd())
 
 	// config command...obviously

--- a/pkg/publicapi/endpoint/requester/endpoint.go
+++ b/pkg/publicapi/endpoint/requester/endpoint.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 
-	"github.com/bacalhau-project/bacalhau/cmd/cli/deprecated"
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
@@ -85,11 +84,11 @@ func registerDeprecatedLegacyMethods(group *echo.Group) {
 	group.GET("/websocket/events", methodGone())
 }
 
-const migrationGuideURL = deprecated.MigrationURL
+const MigrationGuideURL = "https://docs.bacalhau.org/references/cli-reference/command-migration"
 const deprecationMessage = `This endpoint is deprecated. See the migration guide at %s for more information`
 
 func methodGone() func(c echo.Context) error {
 	return func(c echo.Context) error {
-		return c.JSON(http.StatusGone, fmt.Sprintf(deprecationMessage, migrationGuideURL))
+		return c.JSON(http.StatusGone, fmt.Sprintf(deprecationMessage, MigrationGuideURL))
 	}
 }

--- a/pkg/publicapi/endpoint/requester/endpoint.go
+++ b/pkg/publicapi/endpoint/requester/endpoint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 
+	"github.com/bacalhau-project/bacalhau/cmd/cli/deprecated"
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
@@ -73,21 +74,22 @@ func NewEndpoint(params EndpointParams) *Endpoint {
 func registerDeprecatedLegacyMethods(group *echo.Group) {
 	// Legacy API Endpoints
 	// All return status 410 https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410
-	group.POST("/list", methodGone("https://docs.bacalhau.org/references/api/jobs#list-jobs"))
-	group.GET("/nodes", methodGone("https://docs.bacalhau.org/references/api/nodes#list-nodes"))
-	group.POST("/states", methodGone("https://docs.bacalhau.org/references/api/jobs#describe-job"))
-	group.POST("/results", methodGone("https://docs.bacalhau.org/references/api/jobs#describe-job"))
-	group.POST("/events", methodGone("https://docs.bacalhau.org/references/api/jobs#job-history"))
-	group.POST("/submit", methodGone("https://docs.bacalhau.org/references/api/jobs#create-job"))
-	group.POST("/cancel", methodGone("https://docs.bacalhau.org/references/api/jobs#stop-job"))
-	group.POST("/debug", methodGone("https://docs.bacalhau.org/references/api/nodes#describe-node"))
-	group.GET("/websocket/events", methodGone("https://docs.bacalhau.org/references/api/jobs#job-history"))
+	group.POST("/list", methodGone())
+	group.GET("/nodes", methodGone())
+	group.POST("/states", methodGone())
+	group.POST("/results", methodGone())
+	group.POST("/events", methodGone())
+	group.POST("/submit", methodGone())
+	group.POST("/cancel", methodGone())
+	group.POST("/debug", methodGone())
+	group.GET("/websocket/events", methodGone())
 }
 
-const deprecationMessage = "This endpoint is deprecated and no longer available. Please refer to %s for more information. If you encountered this error using the Bacalhau client or CLI, please update your node by following the instructions here: https://docs.bacalhau.org/getting-started/installation" //nolint:lll
+const migrationGuideURL = deprecated.MigrationURL
+const deprecationMessage = `This endpoint is deprecated. See the migration guide at %s for more information`
 
-func methodGone(docsLink string) func(c echo.Context) error {
+func methodGone() func(c echo.Context) error {
 	return func(c echo.Context) error {
-		return c.JSON(http.StatusGone, fmt.Sprintf(deprecationMessage, docsLink))
+		return c.JSON(http.StatusGone, fmt.Sprintf(deprecationMessage, migrationGuideURL))
 	}
 }


### PR DESCRIPTION
## Example API and CLI usage when on <= 1.3.2
```
→ curl 127.0.0.1:1234/api/v1/requester/nodes
"This endpoint is deprecated. See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information"
```

## Example CLI Usage when on 1.4
```
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ bacalhau create job.yaml
Command "create" is deprecated, Please use `job run` to create jobs.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

                                                                                                                                                                                                                                                                                                                                                 
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ echo hi | bacalhau create                  
Command "create" is deprecated, Please use `job run` to create jobs.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

                                                                                                                                                                                                                                                                                                                                                 
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ bacalhau id             
Command "id" is deprecated, Please use `agent node` to inspect bacalhau nodes.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

                                                                                                                                                                                                                                                                                                                                                 
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ bacalhau get                                       
Command "get" is deprecated, Please use `job get` to download results of a job.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

                                                                                                                                                                                                                                                                                                                                                 
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ bacalhau list 
Command "list" is deprecated, Please use `job list` to list jobs.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

                                                                                                                                                                                                                                                                                                                                                 
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ bacalhau logs
Command "logs" is deprecated, Please use `job logs` to follow job logs.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

                                                                                                                                                                                                                                                                                                                                                 
Walid-MacBook-5: ~/ProtocolLabs/workspace/bacalhau (main) ✗ 
[bacalhau]→ bacalhau validate                     
Command "validate" is deprecated, Please use `job validate` to validate jobs.
See the migration guide at https://docs.bacalhau.org/v/v.1.4.0/references/cli-reference/command-migration for more information.

```