### PR TITLE
Fix MakeFile for Releasing Python API Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ build-python: build-python-apiclient build-python-sdk build-bacalhau-airflow
 ################################################################################
 .PHONY: release-python-apiclient
 release-python-apiclient: resolve-earthly
-	cd clients && ${MAKE} pypi-upload
+	cd clients && ${EARTHLY} --push +pypi-upload --PYPI_TOKEN=${PYPI_TOKEN}
 	@echo "Python API client pushed to PyPi."
 
 ################################################################################


### PR DESCRIPTION
This PR aims at the following
- Fix Makefile to correctly release python api client


closes #4202 