### PR TITLE
feat: generate an instanceID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/davecgh/go-spew v1.1.1
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/docker v25.0.4+incompatible
 	github.com/dylibso/observe-sdk/go v0.0.0-20231201014635-141351c24659
 	github.com/fatih/structs v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5il
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
 github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
 github.com/dgraph-io/badger/v3 v3.2103.5 h1:ylPa6qzbjYRQMU6jokoj4wzcaweHylt//CH0AKt0akg=

--- a/pkg/repo/fs.go
+++ b/pkg/repo/fs.go
@@ -119,7 +119,7 @@ func (fsr *FsRepo) Init(c config.ReadWriter) error {
 	// TODO this should be a part of the config.
 	telemetry.SetupFromEnvs()
 
-	// attempt to derive an set an instanceID
+	// attempt to derive and set an instanceID
 	fsr.maybePersistInstanceID()
 
 	return fsr.WriteVersion(Version4)
@@ -173,13 +173,8 @@ func (fsr *FsRepo) Open(c config.ReadWriter) error {
 	// TODO this should be a part of the config.
 	telemetry.SetupFromEnvs()
 
-	// if the instanceID is unset attempted to derive and set it.
-	maybeInstanceID, err := fsr.ReadInstanceID()
-	if err == nil {
-		if maybeInstanceID == "" {
-			fsr.maybePersistInstanceID()
-		}
-	}
+	// attempt to derive and set an instanceID
+	fsr.maybePersistInstanceID()
 
 	return nil
 }

--- a/pkg/repo/instanceid.go
+++ b/pkg/repo/instanceid.go
@@ -1,0 +1,99 @@
+package repo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+// GenerateInstanceID creates a unique, anonymous identifier for the instance of bacalhau.
+// It combines the machine ID and MAC address to ensure uniqueness across different
+// environments, including virtual machines and cloud instances.
+//
+// The function aims to produce consistent results on repeated calls on the same host,
+// but there are scenarios where the result may differ:
+//
+//  1. Network Configuration Changes: If network interfaces are added, removed, or their
+//     order changes, a different MAC address might be selected.
+//  2. Virtual Environments: In VMs or containers, network configurations might change
+//     between runs, affecting the selected MAC address.
+//  3. MAC Address Randomization: Some systems implement MAC address randomization for
+//     privacy, which could cause the function to return different results.
+//  4. Hardware Changes: Adding or removing network adapters could alter the result.
+//  5. System Updates: Major system updates might affect how machine IDs are generated
+//     or how network interfaces are enumerated.
+//
+// The function uses SHA-256 hashing to maintain user anonymity by not exposing actual
+// hardware identifiers. The resulting ID is a 64-character hexadecimal string.
+func GenerateInstanceID() (string, error) {
+	var elements []string
+
+	// Get machine ID, which provides a consistent identifier for the device
+	machineID, err := machineid.ID()
+	if err != nil {
+		return "", fmt.Errorf("failed to get machine ID: %w", err)
+	}
+	elements = append(elements, machineID)
+
+	// Get MAC address to add another layer of uniqueness, especially useful in virtualized environments
+	// or cloned disk images which share a machineID.
+	macAddr, err := getMacAddress()
+	if err != nil {
+		return "", fmt.Errorf("failed to get MAC address: %w", err)
+	}
+	elements = append(elements, macAddr)
+
+	// Combine all elements into a single string
+	combined := strings.Join(elements, "|")
+
+	// Generate SHA-256 hash of the combined string
+	// SHA-256 is used for several reasons:
+	// 1. It provides a fixed-length output (64 hexadecimal characters), regardless of input size
+	// 2. It's a one-way function, ensuring the original machine ID and MAC address can't be reversed
+	// 3. It helps maintain user anonymity by not exposing actual hardware identifiers
+	hash := sha256.New()
+	hash.Write([]byte(combined))
+	installID := hex.EncodeToString(hash.Sum(nil))
+
+	return installID, nil
+}
+
+// getMacAddress retrieves the MAC address of the first available non-loopback network interface.
+// This function is used to add an additional layer of uniqueness to the instance ID.
+//
+// Note: The returned MAC address may vary if network configurations change or in
+// virtualized environments. See GenerateInstanceID comments for more details on variability.
+func getMacAddress() (string, error) {
+	// Get all network interfaces
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	// Iterate through interfaces to find a suitable one
+	for _, iface := range interfaces {
+		// Check if the interface is up and not a loopback
+		if iface.Flags&net.FlagUp != 0 && iface.Flags&net.FlagLoopback == 0 {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				continue
+			}
+			// Look for an IPv4 address
+			for _, addr := range addrs {
+				if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+					if ipnet.IP.To4() != nil {
+						// Return the MAC address of the first suitable interface found
+						return iface.HardwareAddr.String(), nil
+					}
+				}
+			}
+		}
+	}
+
+	// If no suitable interface is found, return an error
+	return "", fmt.Errorf("no suitable MAC address found")
+}

--- a/pkg/repo/sysmeta.go
+++ b/pkg/repo/sysmeta.go
@@ -38,6 +38,7 @@ const SystemMetadataFile = "system_metadata.yaml"
 type SystemMetadata struct {
 	RepoVersion     int       `yaml:"RepoVersion"`
 	InstallationID  string    `yaml:"InstallationID"`
+	InstanceID      string    `yaml:"InstanceID"`
 	LastUpdateCheck time.Time `yaml:"LastUpdateCheck"`
 }
 
@@ -99,6 +100,24 @@ func (fsr *FsRepo) WriteInstallationID(id string) error {
 	return fsr.updateExistingMetadata(func(sysmeta *SystemMetadata) {
 		sysmeta.InstallationID = id
 	})
+}
+
+// WriteInstanceID updates the InstanceID in the metadata.
+// It fails if the metadata file doesn't exist.
+func (fsr *FsRepo) WriteInstanceID(id string) error {
+	return fsr.updateExistingMetadata(func(metadata *SystemMetadata) {
+		metadata.InstanceID = id
+	})
+}
+
+// ReadInstanceID returns the instanceID value from system_metadata.yaml
+// It fails if the metadata file doesn't exist.
+func (fsr *FsRepo) ReadInstanceID() (string, error) {
+	meta, err := fsr.readMetadata()
+	if err != nil {
+		return "", err
+	}
+	return meta.InstanceID, nil
 }
 
 // readMetadata unmarshals the content of SystemMedataFile into SystemMetadata and returns it.


### PR DESCRIPTION
- The ID is based on the host running the bacalhau node, and is deterministic across re-installs and node initalization. There is no guarantee setting the ID will succeed, its a best effort.