### PR TITLE
Displaying Detailed Job Progress While Using Run Command

### DIFF
--- a/cmd/cli/docker/docker_run.go
+++ b/cmd/cli/docker/docker_run.go
@@ -158,7 +158,8 @@ func run(cmd *cobra.Command, args []string, api clientv2.API, opts *DockerRunOpt
 		helpers.PrintWarnings(cmd, resp.Warnings)
 	}
 
-	if err := printer.PrintJobExecution(ctx, job, resp.JobID, cmd, opts.RunTimeSettings, api); err != nil {
+	jobProgressPrinter := printer.NewJobProgressPrinter(api, opts.RunTimeSettings)
+	if err := jobProgressPrinter.PrintJobProgress(ctx, resp.JobID, cmd); err != nil {
 		return fmt.Errorf("failed to print job execution: %w", err)
 	}
 

--- a/cmd/cli/exec/exec.go
+++ b/cmd/cli/exec/exec.go
@@ -128,7 +128,8 @@ func exec(cmd *cobra.Command, cmdArgs []string, unknownArgs []string, api client
 		return fmt.Errorf("failed request: %w", err)
 	}
 
-	if err := printer.PrintJobExecution(cmd.Context(), job, resp.JobID, cmd, options.RunTimeSettings, api); err != nil {
+	jobProgressPrinter := printer.NewJobProgressPrinter(api, options.RunTimeSettings)
+	if err := jobProgressPrinter.PrintJobProgress(cmd.Context(), resp.JobID, cmd); err != nil {
 		return fmt.Errorf("failed to print job execution: %w", err)
 	}
 

--- a/cmd/cli/job/run.go
+++ b/cmd/cli/job/run.go
@@ -148,7 +148,8 @@ func (o *RunOptions) run(cmd *cobra.Command, args []string, api client.API) erro
 		o.printWarnings(cmd, resp.Warnings)
 	}
 
-	if err := printer.PrintJobExecution(ctx, j, resp.JobID, cmd, o.RunTimeSettings, api); err != nil {
+	jobProgressPrinter := printer.NewJobProgressPrinter(api, o.RunTimeSettings)
+	if err := jobProgressPrinter.PrintJobProgress(ctx, resp.JobID, cmd); err != nil {
 		return fmt.Errorf("failed to print job execution: %w", err)
 	}
 

--- a/cmd/cli/wasm/wasm_run.go
+++ b/cmd/cli/wasm/wasm_run.go
@@ -173,7 +173,8 @@ func run(cmd *cobra.Command, args []string, api clientv2.API, opts *WasmRunOptio
 		helpers.PrintWarnings(cmd, resp.Warnings)
 	}
 
-	if err := printer.PrintJobExecution(ctx, job, resp.JobID, cmd, opts.RunTimeSettings, api); err != nil {
+	jobProgressPrinter := printer.NewJobProgressPrinter(api, opts.RunTimeSettings)
+	if err := jobProgressPrinter.PrintJobProgress(ctx, resp.JobID, cmd); err != nil {
 		return fmt.Errorf("failed to print job execution: %w", err)
 	}
 

--- a/cmd/util/live_table_writer.go
+++ b/cmd/util/live_table_writer.go
@@ -106,7 +106,6 @@ func (w *LiveTableWriter) Listen() {
 			return
 		}
 	}
-
 }
 
 // Stop stops the listener that updates to terminal

--- a/cmd/util/live_table_writer.go
+++ b/cmd/util/live_table_writer.go
@@ -1,0 +1,121 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const DefaultRefreshInterval = time.Millisecond
+const ESC = 27
+
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+
+// LiveTableWriter is a buffered table writer that updates the terminal.
+// The contents of LiveTableWriter will be flushed on a timed interval or
+// when Flush is called.
+type LiveTableWriter struct {
+	// Out is the writer to write the table to.
+	Out io.Writer
+
+	// RefreshInterval is the time the UI should refresh
+	RefreshInterval time.Duration
+
+	ticker *time.Ticker
+	tdone  chan bool
+
+	buf      bytes.Buffer
+	mu       *sync.Mutex
+	rowCount int
+}
+
+// NewLiveTableWriter returns a new LiveTableWriter with defaults
+func NewLiveTableWriter() *LiveTableWriter {
+	return &LiveTableWriter{
+		Out:             io.Writer(os.Stdout),
+		RefreshInterval: DefaultRefreshInterval,
+		mu:              &sync.Mutex{},
+	}
+}
+
+// Flush writes out the table and resets the buffer. It should be called after
+// the last call to Write to ensure that any data buffered in the Writer is
+// written to the output. An error is returned if the contents of the buffer
+// cannot be written to the underlying output stream.
+func (w *LiveTableWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Do Nothing if the Buffer is Empty
+	if len(w.buf.Bytes()) == 0 {
+		return nil
+	}
+
+	w.clearRows()
+
+	rows := 0
+	for _, b := range w.buf.Bytes() {
+		if b == '\n' {
+			rows++
+		}
+	}
+	w.rowCount = rows
+	_, err := w.Out.Write(w.buf.Bytes())
+	w.buf.Reset()
+	return err
+}
+
+// Start starts the listener in a non-blocking manner.
+func (w *LiveTableWriter) Start() {
+	if w.ticker == nil {
+		w.ticker = time.NewTicker(w.RefreshInterval)
+		w.tdone = make(chan bool)
+	}
+
+	go w.Listen()
+}
+
+// Write saves the table contents of buf to the writer b.
+// The only errors are ones encountered while writing to the underlying buffer.
+func (w *LiveTableWriter) Write(buf []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(buf)
+}
+
+// Listen listens for updates to live table writer's buffer and flushes to output
+// provided.
+func (w *LiveTableWriter) Listen() {
+	for {
+		select {
+		case <-w.ticker.C:
+			if w.ticker != nil {
+				_ = w.Flush()
+			}
+		case <-w.tdone:
+			w.mu.Lock()
+			w.ticker.Stop()
+			w.ticker = nil
+			w.mu.Unlock()
+			close(w.tdone)
+			return
+		}
+	}
+
+}
+
+// Stop stops the listener that updates to terminal
+func (w *LiveTableWriter) Stop() {
+	_ = w.Flush()
+	w.tdone <- true
+	<-w.tdone
+}
+
+func (w *LiveTableWriter) clearRows() {
+	_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.rowCount))
+}

--- a/cmd/util/printer/job_progress_printer.go
+++ b/cmd/util/printer/job_progress_printer.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -242,7 +243,11 @@ To cancel the job, run:
 	}()
 
 	liveTableWriter := util.NewLiveTableWriter()
-	cmd.SetOut(liveTableWriter)
+	if quiet {
+		cmd.SetOut(io.Discard)
+	} else {
+		cmd.SetOut(liveTableWriter)
+	}
 
 	// goroutine for handling SIGINT from the signal channel, or context completion messages.
 	go func() {
@@ -351,13 +356,11 @@ To cancel the job, run:
 		for _, history := range jobHistoryResponse.Items {
 			timeFilter = history.Time.Unix()
 
-			if history.Type == models.JobHistoryTypeExecutionLevel {
-				jobProgressEvents[history.ExecutionID] = &jobProgressEvent{
-					jobID:       jobID,
-					occurred:    history.Occurred(),
-					executionID: history.ExecutionID,
-					event:       history.Event,
-				}
+			jobProgressEvents[history.ExecutionID] = &jobProgressEvent{
+				jobID:       jobID,
+				occurred:    history.Occurred(),
+				executionID: history.ExecutionID,
+				event:       history.Event,
 			}
 		}
 

--- a/cmd/util/printer/job_progress_printer.go
+++ b/cmd/util/printer/job_progress_printer.go
@@ -35,7 +35,6 @@ type jobProgressEvent struct {
 	jobID       string
 	occurred    time.Time
 	executionID string
-	eventTopic  models.EventTopic
 	event       models.Event
 }
 
@@ -231,8 +230,6 @@ To cancel the job, run:
 	}()
 
 	liveTableWriter := util.NewLiveTableWriter()
-	liveTableWriter.Start()
-	defer liveTableWriter.Stop()
 	cmd.SetOut(liveTableWriter)
 
 	// goroutine for handling SIGINT from the signal channel, or context completion messages.
@@ -347,7 +344,6 @@ To cancel the job, run:
 					jobID:       jobID,
 					occurred:    history.Occurred(),
 					executionID: history.ExecutionID,
-					eventTopic:  history.Event.Topic,
 					event:       history.Event,
 				}
 			}

--- a/cmd/util/printer/job_progress_printer.go
+++ b/cmd/util/printer/job_progress_printer.go
@@ -1,0 +1,320 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/cmd/util"
+	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
+	"github.com/bacalhau-project/bacalhau/cmd/util/output"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+)
+
+type JobProgressPrinter struct {
+	client          clientv2.API
+	runtimeSettings *cliflags.RunTimeSettings
+}
+
+type jobProgressEvent struct {
+	jobID          string
+	occurred       time.Time
+	executionID    string
+	nodeID         string
+	executionState models.ExecutionStateType
+	jobState       models.JobStateType
+	eventTopic     models.EventTopic
+	event          models.Event
+}
+
+var (
+	jobProgressEventTimeCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Time", WidthMax: len(time.StampMilli), WidthMaxEnforcer: output.ShortenTime},
+		Value:        func(j *jobProgressEvent) string { return j.occurred.Format(time.StampMilli) },
+	}
+
+	jobProgressEventExecIDCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Exec. ID", WidthMax: 10, WidthMaxEnforcer: text.WrapText},
+		Value:        func(j *jobProgressEvent) string { return idgen.ShortUUID(j.executionID) },
+	}
+
+	jobProgressEventNodeIDCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Node ID", WidthMax: 10, WidthMaxEnforcer: text.WrapText},
+		Value:        func(j *jobProgressEvent) string { return idgen.ShortNodeID(j.nodeID) },
+	}
+
+	jobProgressEventExecutionStateCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Exec. State", WidthMax: 30, WidthMaxEnforcer: text.WrapText},
+		Value: func(j *jobProgressEvent) string {
+			return j.executionState.String()
+		},
+	}
+
+	jobProgressEventJobStateCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Job. State", WidthMax: 25, WidthMaxEnforcer: text.WrapText},
+		Value: func(j *jobProgressEvent) string {
+			return j.jobState.String()
+		},
+	}
+
+	jobProgressEventTopicCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Topic", WidthMax: 20, WidthMaxEnforcer: text.WrapSoft},
+		Value: func(j *jobProgressEvent) string {
+			return string(j.event.Topic)
+		},
+	}
+
+	jobProgressEventEventCol = output.TableColumn[*jobProgressEvent]{
+		ColumnConfig: table.ColumnConfig{Name: "Event", WidthMax: 60, WidthMaxEnforcer: text.WrapText},
+		Value: func(j *jobProgressEvent) string {
+			res := j.event.Message
+
+			if j.event.Details != nil {
+				// if is error, then the event is in red
+				if j.event.Details[models.DetailsKeyIsError] == "true" {
+					res = output.RedStr(res)
+				}
+
+				// print hint in green
+				if j.event.Details[models.DetailsKeyHint] != "" {
+					res += "\n" + fmt.Sprintf(
+						"%s %s", output.BoldStr(output.GreenStr("* Hint:")), j.event.Details[models.DetailsKeyHint])
+				}
+			}
+			return res
+		},
+	}
+)
+
+var jobProgressEventCols = []output.TableColumn[*jobProgressEvent]{
+	jobProgressEventTimeCol,
+	jobProgressEventExecIDCol,
+	jobProgressEventNodeIDCol,
+	jobProgressEventExecutionStateCol,
+	jobProgressEventJobStateCol,
+	jobProgressEventTopicCol,
+	jobProgressEventEventCol,
+}
+
+func NewJobProgressPrinter(client clientv2.API, runtimeSettings *cliflags.RunTimeSettings) *JobProgressPrinter {
+	return &JobProgressPrinter{
+		client:          client,
+		runtimeSettings: runtimeSettings,
+	}
+}
+
+// PrintJobProgress displays the job progress depending upon on cli runtime
+// settings
+func (j *JobProgressPrinter) PrintJobProgress(ctx context.Context, jobID string, cmd *cobra.Command) error {
+
+	// If we are in `--wait=false` print the jobID and then exit.
+	// All the code after this point is to show the progress of the job.
+	if !j.runtimeSettings.WaitForJobToFinish {
+		cmd.Print(jobID + "\n")
+		return nil
+	}
+
+	// If we are n `id-only` mode - print the id
+	if j.runtimeSettings.PrintJobIDOnly {
+		cmd.Print(jobID + "\n")
+	}
+
+	// Follow Logs
+	if j.runtimeSettings.Follow {
+		return j.followLogs(jobID, cmd)
+	}
+
+
+	// If we are only printing the id, set the rest of the output to "quiet",
+	// i.e. don't print
+	quiet := j.runtimeSettings.PrintJobIDOnly
+
+	jobErr := j.followProgress(ctx, jobID, cmd, quiet)
+	if jobErr != nil {
+		if jobErr.Error() == PrintoutCanceledButRunningNormally {
+			return nil
+		}
+	}
+
+	if !quiet {
+		cmd.Println()
+		cmd.Println("To get more details about the run, execute:")
+		cmd.Println("\t" + os.Args[0] + " job describe " + jobID)
+
+		cmd.Println()
+		cmd.Println("To get more details about the run executions, execute:")
+		cmd.Println("\t" + os.Args[0] + " job executions " + jobID)
+	}
+
+	return nil
+
+}
+
+func (j *JobProgressPrinter) followLogs(jobID string, cmd *cobra.Command) error {
+	cmd.Printf("Job successfully submitted. Job ID: %s\n", jobID)
+	cmd.Printf("Waiting for logs... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
+
+	// Wait until the job has actually been accepted and started, otherwise this will fail waiting for
+	// the execution to appear.
+	for i := 0; i < 10; i++ {
+		resp, err := j.client.Jobs().Get(cmd.Context(), &apimodels.GetJobRequest{
+			JobID: jobID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed getting job: %w", err)
+		}
+		if resp.Job.State.StateType != models.JobStateTypePending {
+			break
+		}
+		// TODO: add exponential backoff if there were no state updates
+		time.Sleep(time.Duration(1) * time.Second)
+	}
+
+	return util.Logs(cmd, j.client, util.LogOptions{
+		JobID:  jobID,
+		Follow: true,
+	})
+
+}
+
+func (j *JobProgressPrinter) followProgress(ctx context.Context, jobID string, cmd *cobra.Command, quiet bool) error {
+	getMoreInfoString := fmt.Sprintf(`
+To get more information at any time, run:
+   bacalhau job describe %s`, jobID)
+
+	cancelString := fmt.Sprintf(`
+To cancel the job, run:
+   bacalhau job stop %s`, jobID)
+
+	if !quiet {
+		cmd.Printf("Job successfully submitted. Job ID: %s\n", jobID)
+		cmd.Print("Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
+	}
+
+	cmdShuttingDown := false
+	var returnError error = nil
+
+	// Capture Ctrl + C if the user wants to finish the job early
+	ctx, cancel := context.WithCancel(ctx)
+	signalChan := make(chan os.Signal, 2)
+	signal.Notify(signalChan, util.ShutdownSignals...)
+	defer func() {
+		signal.Stop(signalChan)
+		cancel()
+	}()
+
+	liveTableWriter := util.NewLiveTableWriter()
+	liveTableWriter.Start()
+	defer liveTableWriter.Stop()
+	cmd.SetOut(liveTableWriter)
+
+	// goroutine for handling SIGINT from the signal channel, or context completion messages.
+	go func() {
+		for {
+			select {
+			case s := <-signalChan:
+				log.Ctx(ctx).Debug().Msgf("Captured %v. Exiting...", s)
+				if s == os.Interrupt {
+					cmdShuttingDown = true
+
+					if !quiet {
+						cmd.Println("\n\n\rPrintout canceled (the job is still running).")
+						cmd.Println(getMoreInfoString)
+						cmd.Println(cancelString)
+					}
+					returnError = fmt.Errorf(PrintoutCanceledButRunningNormally)
+
+				} else {
+					cmd.Println("Unexpected signal received. Exiting.")
+				}
+				cancel()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	var currentJobState models.JobStateType
+	nextToken := ""
+	jobProgressEvents := make(map[string]*jobProgressEvent)
+	tableOptions := output.OutputOptions{
+		Format:  output.TableFormat,
+		NoStyle: true,
+		SortBy: []table.SortBy{
+			{
+				Name: "Exec. ID",
+				Mode: table.Asc,
+			},
+		},
+	}
+
+	timeFilter := time.Now().Unix()
+
+	for !cmdShuttingDown {
+
+		jobHistoryResponse, _ := j.client.Jobs().History(ctx, &apimodels.ListJobHistoryRequest{
+			JobID:     jobID,
+			EventType: "all",
+			Since:     timeFilter,
+			BaseListRequest: apimodels.BaseListRequest{
+				NextToken: nextToken,
+				Limit:     1,
+			},
+		})
+
+		nextToken = jobHistoryResponse.NextToken
+
+		if len(jobHistoryResponse.Items) != 0 {
+			history := jobHistoryResponse.Items[0]
+			timeFilter = history.Time.Unix()
+
+			if history.Type == models.JobHistoryTypeJobLevel {
+				currentJobState = history.JobState.New
+			} else if history.Type == models.JobHistoryTypeExecutionLevel {
+				jobProgressEvents[history.ExecutionID] = &jobProgressEvent{
+					jobID:          jobID,
+					occurred:       history.Occurred(),
+					executionID:    history.ExecutionID,
+					nodeID:         history.NodeID,
+					jobState:       currentJobState,
+					executionState: history.ExecutionState.New,
+					eventTopic:     history.Event.Topic,
+					event:          history.Event,
+				}
+			}
+			output.Output(cmd, jobProgressEventCols, tableOptions, lo.Values(jobProgressEvents))
+		} else {
+			timeFilter = time.Now().Unix()
+		}
+
+		if currentJobState.IsTerminal() {
+			if currentJobState != models.JobStateTypeCompleted {
+				returnError = errors.New("job failed")
+			}
+			cmdShuttingDown = true
+			break
+		}
+
+		// Have we been cancel(l)ed?
+		if condition := ctx.Err(); condition != nil {
+			break
+		}
+
+		time.Sleep(time.Millisecond * 500)
+
+	}
+
+	return returnError
+
+}

--- a/cmd/util/printer/job_progress_printer.go
+++ b/cmd/util/printer/job_progress_printer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -71,6 +72,17 @@ var (
 				if j.event.Details[models.DetailsKeyHint] != "" {
 					res += "\n" + fmt.Sprintf(
 						"%s %s", output.BoldStr(output.GreenStr("* Hint:")), j.event.Details[models.DetailsKeyHint])
+				}
+
+				// print all other details in debug mode
+				if zerolog.GlobalLevel() <= zerolog.DebugLevel {
+					for k, v := range j.event.Details {
+						// don't print hint and error since they are already represented
+						if k == models.DetailsKeyHint || k == models.DetailsKeyIsError {
+							continue
+						}
+						res += "\n" + fmt.Sprintf("* %s %s", output.BoldStr(k+":"), v)
+					}
 				}
 			}
 			return res

--- a/cmd/util/printer/print.go
+++ b/cmd/util/printer/print.go
@@ -1,388 +1,21 @@
 package printer
 
 import (
-	"context"
-	"fmt"
 	"math"
 	"os"
-	"os/signal"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/fatih/color"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/mitchellh/go-wordwrap"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/term"
 
-	"github.com/bacalhau-project/bacalhau/cmd/util"
-	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
-	"github.com/bacalhau-project/bacalhau/cmd/util/output"
-	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
-	libmath "github.com/bacalhau-project/bacalhau/pkg/lib/math"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
-	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/bacalhau-project/bacalhau/pkg/util/idgen"
 )
-
-const PrintoutCanceledButRunningNormally string = "printout canceled but running normally"
-
-var eventsWorthPrinting = map[models.JobStateType]eventStruct{
-	models.JobStateTypePending:   {Message: "Creating job for submission"},
-	models.JobStateTypeRunning:   {Message: "Job in progress"},
-	models.JobStateTypeFailed:    {Message: "Error while executing the job", IsTerminal: true, IsError: true},
-	models.JobStateTypeStopped:   {Message: "Job canceled", IsTerminal: true},
-	models.JobStateTypeCompleted: {Message: "Job finished", IsTerminal: true},
-}
-
-type eventStruct struct {
-	Message    string
-	IsTerminal bool
-	IsError    bool
-}
-
-// PrintJobExecution displays information about the execution of a job
-func PrintJobExecution(
-	ctx context.Context,
-	job *models.Job,
-	jobID string,
-	cmd *cobra.Command,
-	runtimeSettings *cliflags.RunTimeSettings,
-	client clientv2.API,
-) error {
-	// if we are in --wait=false - print the id then exit
-	// because all code after this point is related to
-	// "wait for the job to finish" (via waitForJobAndPrintResultsToUser)
-	if !runtimeSettings.WaitForJobToFinish {
-		cmd.Print(jobID + "\n")
-		return nil
-	}
-
-	// if we are in --id-only mode - print the id
-	if runtimeSettings.PrintJobIDOnly {
-		cmd.Print(jobID + "\n")
-	}
-
-	if runtimeSettings.Follow {
-		return followLogs(cmd, client, jobID, client)
-	}
-
-	// if we are only printing the id, set the rest of the output to "quiet",
-	// i.e. don't print
-	quiet := runtimeSettings.PrintJobIDOnly
-
-	jobErr := waitForJobAndPrintResultsToUser(ctx, cmd, jobID, quiet, client)
-	if jobErr != nil {
-		if jobErr.Error() == PrintoutCanceledButRunningNormally {
-			return nil
-		}
-
-		history, err := client.Jobs().History(ctx, &apimodels.ListJobHistoryRequest{
-			JobID:     jobID,
-			EventType: "execution",
-		})
-		if err != nil {
-			return fmt.Errorf("failed getting job history: %w", err)
-		}
-
-		historySummary := summariseHistoryEvents(history.Items)
-		if len(historySummary) > 0 {
-			for _, event := range historySummary {
-				printEvent(cmd, event)
-			}
-		} else {
-			printError(cmd, jobErr)
-		}
-	}
-
-	if runtimeSettings.PrintNodeDetails || jobErr != nil {
-		executions, err := client.Jobs().Executions(ctx, &apimodels.ListJobExecutionsRequest{
-			JobID: jobID,
-		})
-		if err != nil {
-			return fmt.Errorf("failed getting job executions: %w", err)
-		}
-		summary := summariseExecutions(executions.Items)
-		if len(summary) > 0 {
-			cmd.Println("\nJob Results By Node:")
-			for message, runs := range summary {
-				nodes := len(lo.Uniq(runs))
-				prefix := fmt.Sprintf("• Node %s: ", runs[0])
-				if len(runs) > 1 {
-					prefix = fmt.Sprintf("• %d runs on %d nodes: ", len(runs), nodes)
-				}
-				printIndentedString(cmd, prefix, strings.Trim(message, "\n"), none, 0)
-			}
-		} else {
-			cmd.Println()
-		}
-	}
-	if !quiet {
-		cmd.Println()
-		cmd.Println("To get more details about the run, execute:")
-		cmd.Println("\t" + os.Args[0] + " job describe " + jobID)
-
-		cmd.Println()
-		cmd.Println("To get more details about the run executions, execute:")
-		cmd.Println("\t" + os.Args[0] + " job executions " + jobID)
-
-		// only print help for downloading the job if it contained a publisher.
-		if !lo.IsEmpty(job.Task().Publisher.Type) {
-			cmd.Println()
-			cmd.Println("To download the results, execute:")
-			cmd.Println("\t" + os.Args[0] + " job get " + jobID)
-		}
-	}
-
-	return nil
-}
-
-func followLogs(cmd *cobra.Command, api clientv2.API, jobID string, client clientv2.API) error {
-	cmd.Printf("Job successfully submitted. Job ID: %s\n", jobID)
-	cmd.Printf("Waiting for logs... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
-
-	// Wait until the job has actually been accepted and started, otherwise this will fail waiting for
-	// the execution to appear.
-	for i := 0; i < 10; i++ {
-		resp, err := client.Jobs().Get(cmd.Context(), &apimodels.GetJobRequest{
-			JobID: jobID,
-		})
-		if err != nil {
-			return fmt.Errorf("failed getting job: %w", err)
-		}
-		if resp.Job.State.StateType != models.JobStateTypePending {
-			break
-		}
-		// TODO: add exponential backoff if there were no state updates
-		time.Sleep(time.Duration(1) * time.Second)
-	}
-
-	return util.Logs(cmd, api, util.LogOptions{
-		JobID:  jobID,
-		Follow: true,
-	})
-}
-
-// waitForJobAndPrintResultsToUser uses new job state  to decide what to output to the terminal
-// using a spinner to show long-running tasks. When the job is complete (or the user
-// triggers SIGINT) then the function will complete and stop outputting to the terminal.
-//
-//nolint:gocyclo,funlen
-func waitForJobAndPrintResultsToUser(
-	ctx context.Context, cmd *cobra.Command, jobID string, quiet bool, client clientv2.API,
-) error {
-	getMoreInfoString := fmt.Sprintf(`
-To get more information at any time, run:
-   bacalhau job describe %s`, jobID)
-
-	cancelString := fmt.Sprintf(`
-To cancel the job, run:
-   bacalhau job stop %s`, jobID)
-
-	if !quiet {
-		cmd.Printf("Job successfully submitted. Job ID: %s\n", jobID)
-		cmd.Printf("Checking job status... (Enter Ctrl+C to exit at any time, your job will continue running):\n\n")
-	}
-
-	// Create a map of job state types -> boolean, this is a record of what has been printed
-	// so far.
-	printedEventsTracker := make(map[models.JobStateType]bool)
-	for _, jobEventType := range models.JobStateTypes() {
-		printedEventsTracker[jobEventType] = false
-	}
-
-	// Inject "Job Initiated Event" to start - should we do this on the server?
-	// TODO: #1068 Should jobs auto add a "start event" on the client at creation?
-	// Faking an initial time (sometimes it happens too fast to see)
-	startMessage := "Communicating with the network"
-
-	widestString := len(startMessage)
-	for _, v := range eventsWorthPrinting {
-		widestString = libmath.Max(widestString, len(v.Message))
-	}
-
-	// Capture Ctrl+C if the user wants to finish early the job
-	ctx, cancel := context.WithCancel(ctx)
-	signalChan := make(chan os.Signal, 2)
-	signal.Notify(signalChan, util.ShutdownSignals...)
-	defer func() {
-		signal.Stop(signalChan)
-		cancel()
-	}()
-
-	cmdShuttingDown := false
-	var returnError error = nil
-
-	// goroutine for handling SIGINT from the signal channel, or context
-	// completion messages.
-	go func() {
-		for {
-			select {
-			case s := <-signalChan: // first signal, cancel context
-				log.Ctx(ctx).Debug().Msgf("Captured %v. Exiting...", s)
-				if s == os.Interrupt {
-					cmdShuttingDown = true
-
-					if !quiet {
-						cmd.Println("\n\n\rPrintout canceled (the job is still running).")
-						cmd.Println(getMoreInfoString)
-						cmd.Println(cancelString)
-					}
-					returnError = fmt.Errorf(PrintoutCanceledButRunningNormally)
-				} else {
-					cmd.Println("Unexpected signal received. Exiting.")
-				}
-				cancel()
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	nextToken := ""
-	i := 0
-	liveTableWriter := util.NewLiveTableWriter()
-	liveTableWriter.Start()
-	cmd.SetOut(liveTableWriter)
-
-	historyTimeCol := output.TableColumn[*models.JobHistory]{
-		ColumnConfig: table.ColumnConfig{Name: "Time", WidthMax: len(time.StampMilli), WidthMaxEnforcer: output.ShortenTime},
-		Value:        func(j *models.JobHistory) string { return j.Occurred().Format(time.StampMilli) },
-	}
-
-	historyExecIDCol := output.TableColumn[*models.JobHistory]{
-		ColumnConfig: table.ColumnConfig{Name: "Exec. ID", WidthMax: 10, WidthMaxEnforcer: text.WrapText},
-		Value:        func(j *models.JobHistory) string { return idgen.ShortUUID(j.ExecutionID) },
-	}
-
-	historyNodeIDCol := output.TableColumn[*models.JobHistory]{
-		ColumnConfig: table.ColumnConfig{Name: "Node ID", WidthMax: 10, WidthMaxEnforcer: text.WrapText},
-		Value:        func(j *models.JobHistory) string { return idgen.ShortNodeID(j.NodeID) },
-	}
-
-	historyStateCol := output.TableColumn[*models.JobHistory]{
-		ColumnConfig: table.ColumnConfig{Name: "Exec State", WidthMax: 20, WidthMaxEnforcer: text.WrapText},
-		Value: func(j *models.JobHistory) string {
-			return j.ExecutionState.New.String()
-		},
-	}
-
-	historyJobStateCol := output.TableColumn[*models.JobHistory]{
-		ColumnConfig: table.ColumnConfig{Name: "Job State", WidthMax: 20, WidthMaxEnforcer: text.WrapText},
-		Value: func(j *models.JobHistory) string {
-			return j.JobState.New.String()
-		},
-	}
-
-	jobHistoryCols := []output.TableColumn[*models.JobHistory]{
-		historyTimeCol,
-		historyExecIDCol,
-		historyNodeIDCol,
-		historyStateCol,
-		historyJobStateCol,
-	}
-
-	tableOptions := output.OutputOptions{
-		Format:  output.TableFormat,
-		NoStyle: true,
-		SortBy: []table.SortBy{
-			{
-				Name: "Exec. ID",
-				Mode: table.Asc,
-			},
-		},
-	}
-
-	historyByExecId := make(map[string]*models.JobHistory)
-
-	for !cmdShuttingDown {
-
-		resp, err := client.Jobs().Get(ctx, &apimodels.GetJobRequest{
-			JobID: jobID,
-		})
-
-		if err != nil {
-			if _, ok := err.(*bacerrors.ContextCanceledError); ok {
-				// We're done, the user canceled the job
-				cmdShuttingDown = true
-				continue
-			} else {
-				return errors.Wrap(err, "Error getting job")
-			}
-		}
-
-		jobState := resp.Job.State
-
-		if !quiet {
-			wasPrinted := printedEventsTracker[jobState.StateType]
-
-			// If it hasn't been printed yet, we'll print this event.
-			// We'll also skip lines where there's no message to print.
-			if !wasPrinted && eventsWorthPrinting[jobState.StateType].Message != "" {
-				printedEventsTracker[jobState.StateType] = true
-
-				// We shouldn't do anything with execution errors because there could
-				// be retries following, so for now we will
-			}
-		}
-
-		if resp.Job.IsTerminal() {
-			if jobState.StateType != models.JobStateTypeCompleted {
-				returnError = errors.New(jobState.Message)
-			}
-			cmdShuttingDown = true
-			break
-		}
-
-		// If the job is long running, and it's running, we can stop the spinner
-		if resp.Job.IsLongRunning() && resp.Job.State.StateType == models.JobStateTypeRunning {
-			cmdShuttingDown = true
-			break
-		}
-
-		// Have we been cancel(l)ed?
-		if condition := ctx.Err(); condition != nil {
-			break
-		}
-
-		if nextToken != "" || i == 0 {
-			jobHistoryResponse, _ := client.Jobs().History(ctx, &apimodels.ListJobHistoryRequest{
-				JobID:     jobID,
-				EventType: "all",
-				BaseListRequest: apimodels.BaseListRequest{
-					NextToken: nextToken,
-					Limit:     1,
-				},
-			})
-			nextToken = jobHistoryResponse.NextToken
-			if len(jobHistoryResponse.Items) != 0 {
-				history := jobHistoryResponse.Items[0]
-
-				if history.ExecutionID != "" {
-					history.JobState = &models.StateChange[models.JobStateType]{
-						New: jobState.StateType,
-					}
-					historyByExecId[history.ExecutionID] = history
-				}
-				output.Output(cmd, jobHistoryCols, tableOptions, lo.Values(historyByExecId))
-				time.Sleep(time.Millisecond * 25)
-			}
-		}
-
-		// TODO: add exponential backoff if there were no state updates
-		time.Sleep(time.Duration(500) * time.Millisecond) //nolint:gomnd // 500ms sleep
-		i += 1
-	}
-	liveTableWriter.Stop()
-	return returnError
-}
 
 var (
 	none  = color.New(color.Reset)
@@ -409,36 +42,20 @@ func getTerminalWidth(cmd *cobra.Command) uint {
 	return uint(terminalWidth)
 }
 
-func printEvent(cmd *cobra.Command, event models.Event) {
+func PrintEvent(cmd *cobra.Command, event models.Event) {
 	printIndentedString(cmd, errorPrefix, event.Message, red, 0)
 	if event.Details != nil && event.Details[models.DetailsKeyHint] != "" {
 		printIndentedString(cmd, hintPrefix, event.Details[models.DetailsKeyHint], green, uint(len(errorPrefix)))
 	}
 }
 
-func printError(cmd *cobra.Command, err error) {
+func PrintError(cmd *cobra.Command, err error) {
 	printIndentedString(cmd, errorPrefix, err.Error(), red, 0)
-}
-
-func printIndentedString(cmd *cobra.Command, prefix, msg string, prefixColor *color.Color, startIndent uint) {
-	maxWidth := getTerminalWidth(cmd)
-	blockIndent := int(startIndent) + len(prefix)
-	blockTextWidth := maxWidth - startIndent - uint(len(prefix))
-
-	cmd.PrintErrln()
-	cmd.PrintErr(strings.Repeat(" ", int(startIndent)))
-	prefixColor.Fprintf(cmd.ErrOrStderr(), prefix)
-	for i, line := range strings.Split(wordwrap.WrapString(msg, blockTextWidth), "\n") {
-		if i > 0 {
-			cmd.PrintErr(strings.Repeat(" ", blockIndent))
-		}
-		cmd.PrintErrln(line)
-	}
 }
 
 // Groups the executions in the job state, returning a map of printable messages
 // to node(s) that generated that message.
-func summariseExecutions(executions []*models.Execution) map[string][]string {
+func SummariseExecutions(executions []*models.Execution) map[string][]string {
 	results := make(map[string][]string, len(executions))
 	for _, execution := range executions {
 		var message string
@@ -461,7 +78,7 @@ func summariseExecutions(executions []*models.Execution) map[string][]string {
 	return results
 }
 
-func summariseHistoryEvents(history []*models.JobHistory) []models.Event {
+func SummariseHistoryEvents(history []*models.JobHistory) []models.Event {
 	slices.SortFunc(history, func(a, b *models.JobHistory) int {
 		return a.Occurred().Compare(b.Occurred())
 	})
@@ -477,4 +94,20 @@ func summariseHistoryEvents(history []*models.JobHistory) []models.Event {
 	}
 
 	return maps.Values(events)
+}
+
+func printIndentedString(cmd *cobra.Command, prefix, msg string, prefixColor *color.Color, startIndent uint) {
+	maxWidth := getTerminalWidth(cmd)
+	blockIndent := int(startIndent) + len(prefix)
+	blockTextWidth := maxWidth - startIndent - uint(len(prefix))
+
+	cmd.PrintErrln()
+	cmd.PrintErr(strings.Repeat(" ", int(startIndent)))
+	prefixColor.Fprintf(cmd.ErrOrStderr(), prefix)
+	for i, line := range strings.Split(wordwrap.WrapString(msg, blockTextWidth), "\n") {
+		if i > 0 {
+			cmd.PrintErr(strings.Repeat(" ", blockIndent))
+		}
+		cmd.PrintErrln(line)
+	}
 }


### PR DESCRIPTION
This PR aims at the following

- Introduce Live Table Writer
- Refactor Printer and split out Job Progress Printer Logic
- Get History Events and Print All Job Progress in Table Format

closes #4233 