### PR TITLE
[DRAFT] v2 config and node construction

### DIFF
--- a/pkg/compute/capacity/system/provider.go
+++ b/pkg/compute/capacity/system/provider.go
@@ -31,6 +31,7 @@ func NewPhysicalCapacityProvider(path string) *PhysicalCapacityProvider {
 	}
 }
 
+// TODO this method should return a pointer
 func (p *PhysicalCapacityProvider) GetAvailableCapacity(ctx context.Context) (models.Resources, error) {
 	totalCapacity, err := p.GetTotalCapacity(ctx)
 	if err != nil {
@@ -46,6 +47,7 @@ func (p *PhysicalCapacityProvider) GetAvailableCapacity(ctx context.Context) (mo
 	}, nil
 }
 
+// TODO this method should return a pointer
 func (p *PhysicalCapacityProvider) GetTotalCapacity(ctx context.Context) (models.Resources, error) {
 	diskSpace, err := getFreeDiskSpace(p.path)
 	if err != nil {

--- a/pkg/compute/results_path.go
+++ b/pkg/compute/results_path.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
 	"github.com/rs/zerolog/log"
+
+	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
 )
 
 type ResultsPath struct {
@@ -13,8 +14,16 @@ type ResultsPath struct {
 	ResultsDir string
 }
 
-func NewResultsPath() (*ResultsPath, error) {
-	dir, err := os.MkdirTemp("", "bacalhau-results")
+func NewResultsPath(root string) (*ResultsPath, error) {
+	var (
+		dir string
+		err error
+	)
+	if root != "" {
+		dir, err = os.MkdirTemp(root, "bacalhau-results")
+	} else {
+		dir, err = os.MkdirTemp("", "bacalhau-results")
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/types/gen_paths/generate.go
+++ b/pkg/config/types/gen_paths/generate.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
 )
 
 // generateConstants is a recursive function that iterates through the fields of a given reflect.Type representing
@@ -67,10 +67,10 @@ func generateConstants(t reflect.Type, prefix string, file *os.File) {
 }
 
 func main() {
-	config := types.BacalhauConfig{}
+	config := v2.Bacalhau{}
 
 	// Open a file for writing
-	file, err := os.Create("generated_constants.go")
+	file, err := os.Create("v2/generated_constants.go")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/types/v2/compute.go
+++ b/pkg/config/types/v2/compute.go
@@ -16,8 +16,8 @@ type Compute struct {
 	Orchestrators []string
 	// TLS specifies the TLS configuration used to connect to orchestrators.
 	TLS types.TLS
-	// Labels specifies a list of labels the compute node will advertise to orchestrators.
-	Labels []string
+	// Labels specifies a map of key value pairs the compute node will advertise to orchestrators.
+	Labels map[string]string
 	// Heartbeat specifies the compute node's heartbeat configuration.
 	Heartbeat Heartbeat
 	// Store specifies the compute node's store configuration.
@@ -25,11 +25,11 @@ type Compute struct {
 	// Capacity specifies the compute node's capacity configuration.
 	Capacity Capacity
 	// Publishers specifies the configuration of publishers the compute node provides.
-	Publishers executor.Providers
+	Publishers publisher.Providers
 	// InputSources specifies the configuration of input sources the compute node provides.
 	InputSources storage.Providers
 	// Executors specifies the configuration of executors the compute node provides.
-	Executors publisher.Providers
+	Executors executor.Providers
 	// Policy specifies the configuration of the compute node's job selection policy.
 	Policy SelectionPolicy
 }
@@ -56,37 +56,15 @@ type ComputeStore struct {
 type Capacity struct {
 	// Total when specified overrides the auto-detected capacity of the compute node.
 	// When provided, the Allocated capacity will be ignored.
-	Total types.Resource
+	Total types.ResourceConfig
 	// Allocated specifies the percentage of the total capacity that can be allocated to jobs on the compute node.
-	Allocated types.Resource
+	Allocated types.ResourceScalerConfig
 }
 
 // SelectionPolicy represents the job selection policy configuration for the compute node.
 type SelectionPolicy struct {
-	// Batch specifies the selection policy for batch jobs.
-	Batch BatchPolicy
-	// Daemon specifies the selection policy for daemon jobs.
-	Daemon DaemonPolicy
-}
-
-// BatchPolicy represents the selection policy configuration for batch jobs on the compute node.
-type BatchPolicy struct {
-	// Enabled when set to true instructs the compute node to accept 'batch' jobs.
-	Enabled bool
-	// Networked when set to true allows the compute node to accept batch jobs requiring network access.
+	// Networked when set to true allows the compute node to accept jobs requiring network access.
 	Networked bool
-	// MaxDuration specifies the maximum execution time for a batch job.
-	MaxDuration types.Duration
-	// Capacity specifies the percentage of the total capacity that can be allocated to batch jobs on the compute node.
-	Capacity types.Resource
-}
-
-// DaemonPolicy represents the selection policy configuration for daemon jobs on the compute node.
-type DaemonPolicy struct {
-	// Enabled when set to true instructs the compute node to accept 'daemon' jobs.
-	Enabled bool
-	// Networked when set to true allows the compute node to accept daemon jobs requiring network access.
-	Networked bool
-	// Capacity specifies the percentage of the total capacity that can be allocated to daemon jobs on the compute node.
-	Capacity types.Resource
+	// Local when set to true instructs the compute node to only accept jobs whose inputs it has locally.
+	Local bool
 }

--- a/pkg/config/types/v2/compute.go
+++ b/pkg/config/types/v2/compute.go
@@ -1,0 +1,92 @@
+package v2
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/storage"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
+)
+
+// Compute represents the configuration for the compute service on the Bacalhau node.
+// It includes settings for enabling the service, connecting to orchestrators, TLS, heartbeat, store, capacity, and more.
+type Compute struct {
+	// Enabled when set to true will enable the compute service on the Bacalhau node.
+	Enabled bool
+	// Orchestrators specifies a list of orchestrators the compute node will connect to.
+	Orchestrators []string
+	// TLS specifies the TLS configuration used to connect to orchestrators.
+	TLS types.TLS
+	// Labels specifies a list of labels the compute node will advertise to orchestrators.
+	Labels []string
+	// Heartbeat specifies the compute node's heartbeat configuration.
+	Heartbeat Heartbeat
+	// Store specifies the compute node's store configuration.
+	Store ComputeStore
+	// Capacity specifies the compute node's capacity configuration.
+	Capacity Capacity
+	// Publishers specifies the configuration of publishers the compute node provides.
+	Publishers executor.Providers
+	// InputSources specifies the configuration of input sources the compute node provides.
+	InputSources storage.Providers
+	// Executors specifies the configuration of executors the compute node provides.
+	Executors publisher.Providers
+	// Policy specifies the configuration of the compute node's job selection policy.
+	Policy SelectionPolicy
+}
+
+// Heartbeat represents the configuration settings for the compute node's heartbeat messages.
+type Heartbeat struct {
+	// MessageInterval specifies the duration at which the compute node sends heartbeat messages to the orchestrators.
+	MessageInterval types.Duration
+	// ResourceInterval specifies the duration at which the compute node sends resource messages to the orchestrators.
+	ResourceInterval types.Duration
+	// InfoInterval specifies the duration at which the compute node sends info messages to the orchestrators.
+	InfoInterval types.Duration
+}
+
+// ComputeStore represents the configuration settings for the compute node's storage backend.
+type ComputeStore struct {
+	// Type specifies the backend type of the ComputeStore. One of: boltdb.
+	Type string
+	// ExecutionGC specifies the garbage collection policy for executions in the ComputeStore.
+	ExecutionGC types.TimeGC
+}
+
+// Capacity represents the capacity configuration settings for the compute node.
+type Capacity struct {
+	// Total when specified overrides the auto-detected capacity of the compute node.
+	// When provided, the Allocated capacity will be ignored.
+	Total types.Resource
+	// Allocated specifies the percentage of the total capacity that can be allocated to jobs on the compute node.
+	Allocated types.Resource
+}
+
+// SelectionPolicy represents the job selection policy configuration for the compute node.
+type SelectionPolicy struct {
+	// Batch specifies the selection policy for batch jobs.
+	Batch BatchPolicy
+	// Daemon specifies the selection policy for daemon jobs.
+	Daemon DaemonPolicy
+}
+
+// BatchPolicy represents the selection policy configuration for batch jobs on the compute node.
+type BatchPolicy struct {
+	// Enabled when set to true instructs the compute node to accept 'batch' jobs.
+	Enabled bool
+	// Networked when set to true allows the compute node to accept batch jobs requiring network access.
+	Networked bool
+	// MaxDuration specifies the maximum execution time for a batch job.
+	MaxDuration types.Duration
+	// Capacity specifies the percentage of the total capacity that can be allocated to batch jobs on the compute node.
+	Capacity types.Resource
+}
+
+// DaemonPolicy represents the selection policy configuration for daemon jobs on the compute node.
+type DaemonPolicy struct {
+	// Enabled when set to true instructs the compute node to accept 'daemon' jobs.
+	Enabled bool
+	// Networked when set to true allows the compute node to accept daemon jobs requiring network access.
+	Networked bool
+	// Capacity specifies the percentage of the total capacity that can be allocated to daemon jobs on the compute node.
+	Capacity types.Resource
+}

--- a/pkg/config/types/v2/config.go
+++ b/pkg/config/types/v2/config.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"github.com/bacalhau-project/bacalhau/pkg/authn"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
 )
 
@@ -31,6 +33,8 @@ type Server struct {
 	Port int
 	// TLS specifies the TLS configuration for the server.
 	TLS types.TLS
+
+	Auth AuthConfig
 }
 
 // Client represents the configuration settings for the Bacalhau client.
@@ -61,4 +65,45 @@ type JobDownloaders struct {
 	S3 storage.S3
 	// HTTP specifies the configuration for the HTTP job downloader.
 	HTTP storage.HTTP
+}
+
+// AuthenticatorConfig is config for a specific named authentication method,
+// specifying the type of authentication and the path to a policy file that
+// controls the method. Some implementation types may require policies that meet
+// a certain interface beyond the default – see the documentation on that type
+// for more info.
+type AuthenticatorConfig struct {
+	Type       authn.MethodType `yaml:"Type"`
+	PolicyPath string           `yaml:"PolicyPath,omitempty"`
+}
+
+// AuthConfig is config that controls user authentication and authorization.
+type AuthConfig struct {
+	// TokensPath is the location where a state file of tokens will be stored.
+	// By default it will be local to the Bacalhau repo, but can be any location
+	// in the host filesystem. Tokens are sensitive and should be stored in a
+	// location that is only readable to the current user.
+	TokensPath string `yaml:"TokensPath"`
+
+	// Methods maps "method names" to authenticator implementations. A method
+	// name is a human-readable string chosen by the person configuring the
+	// system that is shown to users to help them pick the authentication method
+	// they want to use. There can be multiple usages of the same Authenticator
+	// *type* but with different configs and parameters, each identified with a
+	// unique method name.
+	//
+	// For example, if an implementation wants to allow users to log in with
+	// Github or Bitbucket, they might both use an authenticator implementation
+	// of type "oidc", and each would appear once on this provider with key /
+	// method name "github" and "bitbucket".
+	//
+	// By default, only a single authentication method that accepts
+	// authentication via client keys will be enabled.
+	Methods map[string]AuthenticatorConfig `yaml:"Methods"`
+
+	// AccessPolicyPath is the path to a file or directory that will be loaded as
+	// the policy to apply to all inbound API requests. If unspecified, a policy
+	// that permits access to all API endpoints to both authenticated and
+	// unauthenticated users (the default as of v1.2.0) will be used.
+	AccessPolicyPath string `yaml:"AccessPolicyPath"`
 }

--- a/pkg/config/types/v2/config.go
+++ b/pkg/config/types/v2/config.go
@@ -1,0 +1,64 @@
+package v2
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
+)
+
+// Bacalhau represents the configuration for the Bacalhau system,
+// including client, server, orchestrator, compute service, and telemetry settings.
+type Bacalhau struct {
+	// Repo specifies a path on the filesystem where Bacalhau will persist its state.
+	Repo string
+	// Name specifies the name the Bacalhau node will advertise on the network.
+	Name string
+	// Client specifies the configuration of the Bacalhau client.
+	Client Client
+	// Server specifies the configuration of the Bacalhau server.
+	Server Server
+	// Orchestrator specifies the configuration of the Bacalhau orchestration service.
+	Orchestrator Orchestrator
+	// Compute specifies the configuration of the Bacalhau compute service.
+	Compute Compute
+	// Telemetry specifies the configuration of the Bacalhau node's telemetry system.
+	Telemetry Telemetry
+}
+
+// Server represents the configuration settings for the Bacalhau server.
+type Server struct {
+	// Address specifies the endpoint Bacalhau will serve on.
+	Address string
+	// Port specifies the port Bacalhau will serve on.
+	Port int
+	// TLS specifies the TLS configuration for the server.
+	TLS types.TLS
+}
+
+// Client represents the configuration settings for the Bacalhau client.
+type Client struct {
+	// Address specifies the endpoint the Bacalhau client will connect to a Bacalhau API on.
+	Address string
+	// Certificate specifies the path of a certificate file (primarily for self-signed server certs) the client will use for API requests.
+	Certificate string
+	// Insecure when true instructs the client not to verify the certificate of the server.
+	Insecure bool
+}
+
+// WebUI represents the configuration settings for the Bacalhau WebUI.
+type WebUI struct {
+	// Enabled when true enables the WebUI on the Bacalhau node.
+	Enabled bool
+	// Server specifies the configuration of the server for the WebUI.
+	Server Server
+}
+
+// JobDownloaders represents the configuration settings for job downloaders in Bacalhau.
+type JobDownloaders struct {
+	// Timeout specifies the duration after which job downloads will time out.
+	Timeout types.Duration
+	// IPFS specifies the configuration for the IPFS job downloader.
+	IPFS storage.IPFS
+	// S3 specifies the configuration for the S3 job downloader.
+	S3 storage.S3
+	// HTTP specifies the configuration for the HTTP job downloader.
+	HTTP storage.HTTP
+}

--- a/pkg/config/types/v2/executor/providers.go
+++ b/pkg/config/types/v2/executor/providers.go
@@ -26,7 +26,7 @@ type Docker struct {
 // DockerManifestCache represents the configuration settings for the Docker manifest cache.
 type DockerManifestCache struct {
 	// Size specifies the size of the Docker manifest cache.
-	Size string
+	Size uint64
 	// TTL specifies the time-to-live duration for cache entries.
 	TTL types.Duration
 	// Refresh specifies the refresh interval for cache entries.

--- a/pkg/config/types/v2/executor/providers.go
+++ b/pkg/config/types/v2/executor/providers.go
@@ -1,0 +1,40 @@
+package executor
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
+)
+
+// Providers represents the configuration for different runtime providers.
+// It includes settings for Docker and WASM providers.
+type Providers struct {
+	// Docker is the configuration for the Docker runtime provider.
+	Docker Docker
+	// WASM is the configuration for the WASM runtime provider.
+	WASM WASM
+}
+
+// Docker represents the configuration settings for the Docker runtime provider.
+type Docker struct {
+	// Enabled specifies whether the Docker provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint URI for the Docker daemon.
+	Endpoint string
+	// ManifestCache specifies the settings for the Docker manifest cache.
+	ManifestCache DockerManifestCache
+}
+
+// DockerManifestCache represents the configuration settings for the Docker manifest cache.
+type DockerManifestCache struct {
+	// Size specifies the size of the Docker manifest cache.
+	Size string
+	// TTL specifies the time-to-live duration for cache entries.
+	TTL types.Duration
+	// Refresh specifies the refresh interval for cache entries.
+	Refresh types.Duration
+}
+
+// WASM represents the configuration settings for the WASM runtime provider.
+type WASM struct {
+	// Enabled specifies whether the WASM provider is enabled.
+	Enabled bool
+}

--- a/pkg/config/types/v2/orchestrator.go
+++ b/pkg/config/types/v2/orchestrator.go
@@ -10,10 +10,16 @@ type Orchestrator struct {
 	// Enabled specifies whether the orchestration service is enabled on the Bacalhau node.
 	Enabled bool
 
-	// Listen specifies the endpoint the orchestration service will listen on for connections from compute nodes.
+	// Listen specifies the address the orchestration service will listen on for connections from compute nodes.
 	Listen string
+	// Port specifies the port the orchestration service will listen for connections from compute nodes.
+	Port int
 	// Advertise specifies the endpoint the orchestration service will advertise to the network for connections from compute nodes.
 	Advertise string
+	// AuthSecret is a secret string that clients must use to connect. NATS servers
+	// must supply this value, while clients can also supply it as the user part
+	// of their Orchestrator URL.
+	AuthSecret string
 	// TLS specifies the TLS configuration of the orchestration service.
 	TLS types.TLS
 
@@ -31,8 +37,12 @@ type Orchestrator struct {
 
 // Cluster represents the configuration settings for the orchestration service NATs cluster.
 type Cluster struct {
+	// Name specifies the name of the cluster the orchestration service will connect to.
+	Name string
 	// Listen specifies the address the orchestration service will listen on for connections from other orchestration services.
 	Listen string
+	// Port specifies the port the orchestration service will listen on for connections from other orchestration services.
+	Port int
 	// Advertise specifies the endpoint the orchestration service will advertise to the network for connections from other orchestration services.
 	Advertise string
 	// Peers specifies the list of peer orchestration services.

--- a/pkg/config/types/v2/orchestrator.go
+++ b/pkg/config/types/v2/orchestrator.go
@@ -1,0 +1,81 @@
+package v2
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
+)
+
+// Orchestrator represents the configuration for the orchestration service on the Bacalhau node.
+// It includes settings for enabling the service, network endpoints, TLS configuration, and various subsystems.
+type Orchestrator struct {
+	// Enabled specifies whether the orchestration service is enabled on the Bacalhau node.
+	Enabled bool
+
+	// Listen specifies the endpoint the orchestration service will listen on for connections from compute nodes.
+	Listen string
+	// Advertise specifies the endpoint the orchestration service will advertise to the network for connections from compute nodes.
+	Advertise string
+	// TLS specifies the TLS configuration of the orchestration service.
+	TLS types.TLS
+
+	// Cluster specifies the cluster configuration of the orchestration service.
+	Cluster Cluster
+	// NodeManager specifies the node manager configuration of the orchestration service.
+	NodeManager NodeManager
+	// Store specifies the store configuration of the orchestration service.
+	Store OrchestratorStore
+	// Scheduler specifies the scheduler configuration of the orchestration service.
+	Scheduler Scheduler
+	// Broker specifies the evaluation broker configuration of the orchestration service.
+	Broker EvaluationBroker
+}
+
+// Cluster represents the configuration settings for the orchestration service NATs cluster.
+type Cluster struct {
+	// Listen specifies the address the orchestration service will listen on for connections from other orchestration services.
+	Listen string
+	// Advertise specifies the endpoint the orchestration service will advertise to the network for connections from other orchestration services.
+	Advertise string
+	// Peers specifies the list of peer orchestration services.
+	Peers []string
+	// TLS specifies the TLS configuration for connections from orchestration services.
+	TLS types.TLS
+}
+
+// NodeManager represents the configuration settings for the node manager within the orchestration service.
+type NodeManager struct {
+	// DisconnectTimeout specifies the duration after which nodes will be considered disconnected if no heartbeat message is received.
+	DisconnectTimeout types.Duration
+	// AutoApprove specifies whether to automatically approve a node's membership when a connection is established.
+	// When set to false, sets a node's approval status to 'pending' when a connection is established.
+	AutoApprove bool
+	// GC specifies the garbage collection configuration of the node manager.
+	GC types.TimeGC
+}
+
+// OrchestratorStore represents the configuration settings for the storage backend of the orchestration service.
+type OrchestratorStore struct {
+	// Type specifies the backend type of the orchestrator store. One of: boltdb.
+	Type string
+	// JobGC specifies the garbage collection policy for jobs in the orchestrator store.
+	JobGC types.TimeGC
+	// EvaluationGC specifies the garbage collection policy for evaluations in the orchestrator store.
+	EvaluationGC types.TimeGC
+}
+
+// Scheduler represents the configuration settings for the scheduler within the orchestration service.
+type Scheduler struct {
+	// Workers specifies the number of workers the scheduler will run.
+	Workers int
+	// HousekeepingInterval specifies the interval at which housekeeping tasks are performed.
+	HousekeepingInterval types.Duration
+	// HousekeepingTimeout specifies the timeout duration for housekeeping tasks.
+	HousekeepingTimeout types.Duration
+}
+
+// EvaluationBroker represents the configuration settings for the evaluation broker within the orchestration service.
+type EvaluationBroker struct {
+	// VisibilityTimeout specifies the duration after which an unprocessed evaluation is re-queued.
+	VisibilityTimeout types.Duration
+	// MaxRetries specifies the maximum number of retries for processing an evaluation.
+	MaxRetries int
+}

--- a/pkg/config/types/v2/publisher/providers.go
+++ b/pkg/config/types/v2/publisher/providers.go
@@ -1,0 +1,60 @@
+package publisher
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
+)
+
+// Providers represents the configuration for different storage providers.
+// It includes settings for IPFS, S3, Local, and HTTP providers.
+type Providers struct {
+	// IPFS is the configuration for the IPFS provider.
+	IPFS IPFS
+	// S3 is the configuration for the S3 provider.
+	S3 S3
+	// Local is the configuration for the Local provider.
+	Local Local
+	// HTTP is the configuration for the HTTP provider.
+	HTTP HTTP
+}
+
+// IPFS represents the configuration settings for the IPFS storage provider.
+type IPFS struct {
+	// Enabled specifies whether the IPFS provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint Multiaddress for the IPFS provider.
+	Endpoint string
+}
+
+// S3 represents the configuration settings for the S3 storage provider.
+type S3 struct {
+	// Enabled specifies whether the S3 provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint URL for the S3 provider.
+	Endpoint string
+	// AccessKey specifies the access key for the S3 provider.
+	AccessKey string
+	// SecretKey specifies the secret key for the S3 provider.
+	SecretKey string
+	// PreSignedURLEnabled specifies whether pre-signed URLs are enabled for the S3 provider.
+	PreSignedURLEnabled bool
+	// PreSignedURLExpiration specifies the duration before a pre-signed URL expires.
+	PreSignedURLExpiration types.Duration
+}
+
+// Local represents the configuration settings for the Local storage provider.
+type Local struct {
+	// Enabled specifies whether the Local provider is enabled.
+	Enabled bool
+	// Volumes specifies the list of local volumes available for storage.
+	Volumes []types.Volume
+}
+
+// HTTP represents the configuration settings for the HTTP storage provider.
+type HTTP struct {
+	// Enabled specifies whether the HTTP provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint URL for the HTTP provider.
+	Endpoint string
+	// Headers specifies the HTTP headers to be included in requests to the HTTP provider.
+	Headers map[string]string
+}

--- a/pkg/config/types/v2/publisher/providers.go
+++ b/pkg/config/types/v2/publisher/providers.go
@@ -15,6 +15,8 @@ type Providers struct {
 	Local Local
 	// HTTP is the configuration for the HTTP provider.
 	HTTP HTTP
+
+	LocalHTTPServer LocalHTTPServer
 }
 
 // IPFS represents the configuration settings for the IPFS storage provider.
@@ -57,4 +59,10 @@ type HTTP struct {
 	Endpoint string
 	// Headers specifies the HTTP headers to be included in requests to the HTTP provider.
 	Headers map[string]string
+}
+
+type LocalHTTPServer struct {
+	Enabled bool
+	Host    string
+	Port    int
 }

--- a/pkg/config/types/v2/storage/providers.go
+++ b/pkg/config/types/v2/storage/providers.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types/v2/types"
+)
+
+// Providers represents the configuration for various storage providers.
+// It includes settings for HTTP, IPFS, Local, and S3 providers.
+type Providers struct {
+	// HTTP is the configuration for the HTTP storage provider.
+	HTTP HTTP
+	// IPFS is the configuration for the IPFS storage provider.
+	IPFS IPFS
+	// Local is the configuration for the Local storage provider.
+	Local Local
+	// S3 is the configuration for the S3 storage provider.
+	S3 S3
+}
+
+// IPFS represents the configuration settings for the IPFS storage provider.
+type IPFS struct {
+	// Enabled specifies whether the IPFS provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint URL for the IPFS provider.
+	Endpoint string
+}
+
+// S3 represents the configuration settings for the S3 storage provider.
+type S3 struct {
+	// Enabled specifies whether the S3 provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint URL for the S3 provider.
+	Endpoint string
+	// AccessKey specifies the access key for the S3 provider.
+	AccessKey string
+	// SecretKey specifies the secret key for the S3 provider.
+	SecretKey string
+}
+
+// Local represents the configuration settings for the Local storage provider.
+type Local struct {
+	// Enabled specifies whether the Local provider is enabled.
+	Enabled bool
+	// Volumes specifies the list of local volumes available for storage.
+	Volumes []types.Volume
+}
+
+// HTTP represents the configuration settings for the HTTP storage provider.
+type HTTP struct {
+	// Enabled specifies whether the HTTP provider is enabled.
+	Enabled bool
+	// Endpoint specifies the endpoint URL for the HTTP provider.
+	Endpoint string
+	// Headers specifies the HTTP headers to be included in requests to the HTTP provider.
+	Headers map[string]string
+}

--- a/pkg/config/types/v2/telemetry.go
+++ b/pkg/config/types/v2/telemetry.go
@@ -1,0 +1,32 @@
+package v2
+
+// Telemetry represents the configuration for telemetry components,
+// including logging, metrics, and tracing.
+type Telemetry struct {
+	// Logging is the configuration for logging settings.
+	Logging Logging
+	// Metrics is the configuration for OpenTelemetry (OTel) metrics settings.
+	Metrics Metrics
+	// Tracing is the configuration for OpenTelemetry (OTel) tracing settings.
+	Tracing Tracing
+}
+
+// Logging represents the configuration settings for logging.
+type Logging struct {
+	// Level specifies the logging level (one of: "trace" "debug", "info", "warn", "error", "fatal", "panic").
+	Level string
+	// Format specifies the format of the logs (one of:., "console", "color", or "json").
+	Format string
+}
+
+// Metrics represents the configuration settings for OpenTelemetry (OTel) metrics collection.
+type Metrics struct {
+	// Endpoint specifies the OpenTelemetry (OTel) endpoint URL for metrics collection.
+	Endpoint string
+}
+
+// Tracing represents the configuration settings for OpenTelemetry (OTel) tracing.
+type Tracing struct {
+	// Endpoint specifies the OpenTelemetry (OTel) endpoint URL for tracing data.
+	Endpoint string
+}

--- a/pkg/config/types/v2/types/duration.go
+++ b/pkg/config/types/v2/types/duration.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"time"
+)
+
+// Duration is a wrapper type for time.Duration
+// for decoding and encoding from/to YAML, etc.
+type Duration time.Duration
+
+// UnmarshalText implements interface for YAML decoding
+func (dur *Duration) UnmarshalText(text []byte) error {
+	d, err := time.ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+	*dur = Duration(d)
+	return err
+}
+
+func (dur Duration) MarshalText() ([]byte, error) {
+	d := time.Duration(dur)
+	return []byte(d.String()), nil
+}
+
+func (dur Duration) String() string {
+	return time.Duration(dur).String()
+}
+
+/*
+AsTimeDuration returns Duration as a time.Duration type.
+It is only called in the code gen to set viper defaults.
+This method exists for the following reasons:
+ 1. our config file is yaml, and we want to use durations for configuring things, printed in a human-readable format.
+ 2. time.Duration does not, and will not implement MarshalText/UnmarshalText
+    - https://github.com/golang/go/issues/16039
+ 3. viper.GetDuration doesn't return an error, and instead returns `0` if it fails to cast
+    - https://github.com/spf13/viper/blob/master/viper.go#L1048
+    - https://github.com/spf13/cast/blob/master/caste.go#L61
+    viper.GetDuration is unable to cast a types.Duration to a time.Duration (see second link), so it returns 0.
+
+To meet the 3 constraints above we write durations into viper as a time.Duration, but cast them
+to a types.Duration when they are added to our config structure. This allows us to:
+1. Have human-readable times in out config file.
+2. Have type safety on out cli, i.e. config set <duration_key> 10s
+3. Return durations instead of `0` from viper.GetDuration.
+*/
+func (dur Duration) AsTimeDuration() time.Duration {
+	return time.Duration(dur)
+}

--- a/pkg/config/types/v2/types/gc.go
+++ b/pkg/config/types/v2/types/gc.go
@@ -1,0 +1,8 @@
+package types
+
+type TimeGC struct {
+	// Threshold specifies the duration that data must exist before it becomes eligible for garbage collection.
+	Threshold Duration
+	// Interval specifies the frequency at which the garbage collection process runs.
+	Interval Duration
+}

--- a/pkg/config/types/v2/types/resource.go
+++ b/pkg/config/types/v2/types/resource.go
@@ -1,0 +1,14 @@
+package types
+
+// Resource represents allocated computing resources.
+// The resource values are specified in Kubernetes format.
+type Resource struct {
+	// CPU specifies the amount of CPU allocated, in Kubernetes format (e.g., "100m" for 100 millicores).
+	CPU string
+	// Memory specifies the amount of memory allocated, in Kubernetes format (e.g., "1Gi" for 1 Gibibyte).
+	Memory string
+	// Disk specifies the amount of disk space allocated, in Kubernetes format (e.g., "10Gi" for 10 Gibibytes).
+	Disk string
+	// GPU specifies the amount of GPU resources allocated, in Kubernetes format (e.g., "1" for 1 GPU).
+	GPU string
+}

--- a/pkg/config/types/v2/types/resource.go
+++ b/pkg/config/types/v2/types/resource.go
@@ -1,8 +1,14 @@
 package types
 
-// Resource represents allocated computing resources.
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ResourceConfig represents allocated computing resources.
 // The resource values are specified in Kubernetes format.
-type Resource struct {
+type ResourceConfig struct {
 	// CPU specifies the amount of CPU allocated, in Kubernetes format (e.g., "100m" for 100 millicores).
 	CPU string
 	// Memory specifies the amount of memory allocated, in Kubernetes format (e.g., "1Gi" for 1 Gibibyte).
@@ -11,4 +17,87 @@ type Resource struct {
 	Disk string
 	// GPU specifies the amount of GPU resources allocated, in Kubernetes format (e.g., "1" for 1 GPU).
 	GPU string
+}
+
+func (r *ResourceConfig) IsZero() bool {
+	return r.CPU == "" && r.Memory == "" && r.Disk == "" && r.GPU == ""
+}
+
+// Normalize normalizes the resources
+func (r *ResourceConfig) Normalize() {
+	if r == nil {
+		return
+	}
+	sanitizeResourceString := func(s string) string {
+		// lower case and remove spaces
+		s = strings.ToLower(s)
+		s = strings.ReplaceAll(s, " ", "")
+		s = strings.ReplaceAll(s, "\n", "")
+		return s
+	}
+
+	r.CPU = sanitizeResourceString(r.CPU)
+	r.Memory = sanitizeResourceString(r.Memory)
+	r.Disk = sanitizeResourceString(r.Disk)
+	r.GPU = sanitizeResourceString(r.GPU)
+}
+
+type ResourceScalerConfig struct {
+	// CPU specifies the amount of CPU allocated as a percentage.
+	CPU PercentageValue `yaml:"CPU"`
+	// Memory specifies the amount of Memory allocated as a percentage.
+	Memory PercentageValue `yaml:"Memory"`
+	// Disk specifies the amount of Disk space allocated as a percentage.
+	Disk PercentageValue `yaml:"Disk"`
+	// GPU specifies the amount of GPU allocated as a percentage.
+	GPU PercentageValue `yaml:"GPU"`
+}
+
+func (r *ResourceScalerConfig) IsZero() bool {
+	return r.CPU == "" && r.Memory == "" && r.Disk == "" && r.GPU == ""
+}
+
+func (r *ResourceScalerConfig) Validate() error {
+	fields := map[string]PercentageValue{
+		"CPU":    r.CPU,
+		"Memory": r.Memory,
+		"Disk":   r.Disk,
+		"GPU":    r.GPU,
+	}
+
+	for field, value := range fields {
+		if value != "" {
+			if _, err := value.Parse(); err != nil {
+				return fmt.Errorf("invalid %s percentage: %w", field, err)
+			}
+		}
+	}
+	return nil
+}
+
+type PercentageValue string
+
+func (pv PercentageValue) Parse() (float64, error) {
+	// if the percentage is empty then it means the user didn't provide a config
+	// value, and we shouldn't scale. Returning 1 will result in no scaling.
+	if pv == "" {
+		return 1, nil
+	}
+	s := strings.TrimSpace(string(pv))
+	s = strings.TrimSuffix(s, "%")
+
+	value, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid percentage format: %w", err)
+	}
+
+	if value != float64(int(value)) {
+		return 0, fmt.Errorf("percentage must be a whole number")
+	}
+
+	if value < 1 || value > 100 {
+		return 0, fmt.Errorf("percentage must be between 1 and 100")
+	}
+
+	return value / 100, nil
 }

--- a/pkg/config/types/v2/types/tls.go
+++ b/pkg/config/types/v2/types/tls.go
@@ -1,0 +1,15 @@
+package types
+
+// TLS represents the configuration settings for TLS (Transport Layer Security).
+// It includes options for automatic certificate management as well as manually specified certificates.
+type TLS struct {
+	// AutoCert specifies a domain name for a certificate to be obtained via ACME (Automated Certificate Management Environment).
+	AutoCert string
+	// AutoCertCachePath specifies the path where the ACME client will cache certificates to avoid rate limits.
+	AutoCertCachePath string
+
+	// Certificate specifies the path to a TLS certificate file to be used.
+	Certificate string
+	// Key specifies the path to the private key file corresponding to the TLS certificate.
+	Key string
+}

--- a/pkg/config/types/v2/types/volume.go
+++ b/pkg/config/types/v2/types/volume.go
@@ -1,0 +1,13 @@
+package types
+
+// Volume represents a location on disk with specific attributes.
+// It includes a name for reference, the path on the filesystem,
+// and a flag indicating if the volume is writable.
+type Volume struct {
+	// Name is the identifier used to refer to this volume.
+	Name string
+	// Path is the filesystem location of the volume on disk.
+	Path string
+	// Write indicates whether the volume has write permissions.
+	Write bool
+}

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -67,7 +67,7 @@ func NewComputeNode(
 	})
 	enqueuedUsageTracker := capacity.NewLocalUsageTracker()
 
-	resultsPath, err := compute.NewResultsPath()
+	resultsPath, err := compute.NewResultsPath("")
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func NewComputeNode(
 
 	// Node labels
 	labelsProvider := models.MergeLabelsInOrder(
-		&ConfigLabelsProvider{staticLabels: configuredLabels},
+		&ConfigLabelsProvider{StaticLabels: configuredLabels},
 		&RuntimeLabelsProvider{},
 		capacity.NewGPULabelsProvider(config.TotalResourceLimits),
 	)

--- a/pkg/node/heartbeat/server.go
+++ b/pkg/node/heartbeat/server.go
@@ -77,6 +77,7 @@ func (h *HeartbeatServer) Start(ctx context.Context) error {
 
 	log.Ctx(ctx).Info().Msg("Heartbeat server started")
 
+	// TODO use a wait group
 	tickerStartCh := make(chan struct{})
 
 	go func(ctx context.Context) {

--- a/pkg/node/labels.go
+++ b/pkg/node/labels.go
@@ -20,9 +20,9 @@ func (*RuntimeLabelsProvider) GetLabels(context.Context) map[string]string {
 var _ models.LabelsProvider = (*RuntimeLabelsProvider)(nil)
 
 type ConfigLabelsProvider struct {
-	staticLabels map[string]string
+	StaticLabels map[string]string
 }
 
 func (p *ConfigLabelsProvider) GetLabels(context.Context) map[string]string {
-	return p.staticLabels
+	return p.StaticLabels
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -159,7 +159,7 @@ func NewNode(
 		}
 
 		labelsProvider = models.MergeLabelsInOrder(
-			&ConfigLabelsProvider{staticLabels: config.Labels},
+			&ConfigLabelsProvider{StaticLabels: config.Labels},
 			&RuntimeLabelsProvider{},
 		)
 		debugInfoProviders = append(debugInfoProviders, requesterNode.debugInfoProviders...)

--- a/pkg/node/v2/auth.go
+++ b/pkg/node/v2/auth.go
@@ -1,0 +1,52 @@
+package v2
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/authn"
+	"github.com/bacalhau-project/bacalhau/pkg/authn/ask"
+	"github.com/bacalhau-project/bacalhau/pkg/authn/challenge"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/policy"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
+)
+
+func SetupAuthenticators(privKey *rsa.PrivateKey, cfg v2.Bacalhau) (authn.Provider, error) {
+	var allErr error
+	authns := make(map[string]authn.Authenticator, len(cfg.Server.Auth.Methods))
+	for name, authnConfig := range cfg.Server.Auth.Methods {
+		switch authnConfig.Type {
+		case authn.MethodTypeChallenge:
+			methodPolicy, err := policy.FromPathOrDefault(authnConfig.PolicyPath, challenge.AnonymousModePolicy)
+			if err != nil {
+				allErr = errors.Join(allErr, err)
+				continue
+			}
+
+			authns[name] = challenge.NewAuthenticator(
+				methodPolicy,
+				challenge.NewStringMarshaller(cfg.Name),
+				privKey,
+				cfg.Name,
+			)
+		case authn.MethodTypeAsk:
+			methodPolicy, err := policy.FromPath(authnConfig.PolicyPath)
+			if err != nil {
+				allErr = errors.Join(allErr, err)
+				continue
+			}
+
+			authns[name] = ask.NewAuthenticator(
+				methodPolicy,
+				privKey,
+				cfg.Name,
+			)
+		default:
+			allErr = errors.Join(allErr, fmt.Errorf("unknown authentication type: %q", authnConfig.Type))
+		}
+	}
+
+	return provider.NewMappedProvider(authns), allErr
+}

--- a/pkg/node/v2/compute/api.go
+++ b/pkg/node/v2/compute/api.go
@@ -1,0 +1,158 @@
+package compute
+
+import (
+	"net/url"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/resource"
+	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy/semantic"
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/sensors"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	modelsutils "github.com/bacalhau-project/bacalhau/pkg/models/utils"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+	compute_endpoint "github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+)
+
+type EndpointProvider interface {
+	Compute() *compute_endpoint.Endpoint
+	Bidding() compute.BaseEndpoint
+}
+
+func NewComputeEndpointProvider(
+	name string,
+	transport *nats_transport.NATSTransport,
+	server *publicapi.Server,
+	cfg v2.SelectionPolicy,
+	storages storage.StorageProvider,
+	engines executor.ExecutorProvider,
+	publishers publisher.PublisherProvider,
+	executor ExecutorProvider,
+	capacity CapacityProvider,
+) (*ComputeEndpointProvider, error) {
+
+	bidder := compute.NewBidder(compute.BidderParams{
+		NodeID:           name,
+		Callback:         transport.CallbackProxy(),
+		Store:            executor.Store(),
+		Executor:         executor.Executor(),
+		UsageCalculator:  capacity.Calculator(),
+		GetApproveURL:    func() *url.URL { return server.GetURI().JoinPath("/api/v1/compute/approve") },
+		SemanticStrategy: setupSemanticBidStrategies(cfg, storages, engines, publishers),
+		ResourceStrategy: setupResourceBidStrategies(capacity),
+	})
+
+	logserver := logstream.NewServer(logstream.ServerParams{
+		ExecutionStore: executor.Store(),
+		Executors:      engines,
+		// NB(forrest) this is taken from a default value
+		Buffer: 10,
+	})
+
+	baseEndpoint := compute.NewBaseEndpoint(compute.BaseEndpointParams{
+		ID:              name,
+		UsageCalculator: capacity.Calculator(),
+		Executor:        executor.Executor(),
+		ExecutionStore:  executor.Store(),
+		Bidder:          bidder,
+		LogServer:       logserver,
+	})
+
+	debugInfoProviders := []models.DebugInfoProvider{
+		executor.DebugProvider(),
+		sensors.NewCompletedJobs(executor.Store()),
+	}
+
+	// register compute public http apis
+	computeEndpoint := compute_endpoint.NewEndpoint(compute_endpoint.EndpointParams{
+		Router:             server.Router,
+		Bidder:             bidder,
+		Store:              executor.Store(),
+		DebugInfoProviders: debugInfoProviders,
+	})
+
+	return &ComputeEndpointProvider{
+		compute: computeEndpoint,
+		bidding: baseEndpoint,
+	}, nil
+
+}
+
+func setupResourceBidStrategies(provider CapacityProvider) []bidstrategy.ResourceBidStrategy {
+	return []bidstrategy.ResourceBidStrategy{
+		resource.NewMaxCapacityStrategy(resource.MaxCapacityStrategyParams{
+			MaxJobRequirements: provider.Capacity(),
+		}),
+	}
+}
+
+func setupSemanticBidStrategies(
+	cfg v2.SelectionPolicy,
+	storages storage.StorageProvider,
+	executors executor.ExecutorProvider,
+	publishers publisher.PublisherProvider,
+) []bidstrategy.SemanticBidStrategy {
+	localityPolicy := semantic.Anywhere
+	if cfg.Local {
+		localityPolicy = semantic.Local
+	}
+	return []bidstrategy.SemanticBidStrategy{
+		semantic.NewProviderInstalledStrategy(
+			publishers,
+			func(j *models.Job) string { return j.Task().Publisher.Type },
+		),
+		semantic.NewProviderInstalledStrategy(
+			executors,
+			func(j *models.Job) string { return j.Task().Engine.Type },
+		),
+		semantic.NewProviderInstalledArrayStrategy(
+			storages,
+			func(j *models.Job) []string {
+				return modelsutils.AllInputSourcesTypes(j)
+			},
+		),
+		semantic.NewInputLocalityStrategy(semantic.InputLocalityStrategyParams{
+			Locality: localityPolicy,
+			Storages: storages,
+		}),
+		semantic.NewNetworkingStrategy(cfg.Networked),
+	}
+	// NB(forrest): we have stated we are discarding these configurations and thus policies:
+	// https://www.notion.so/expanso/Rethinking-Configuration-435fbe87419148b4bbc5119d413786eb?pvs=4#106588c3e3c94c8191e1983084e00f0f
+	/*
+		semantic.NewTimeoutStrategy(semantic.TimeoutStrategyParams{
+			MaxJobExecutionTimeout:                config.MaxJobExecutionTimeout,
+			MinJobExecutionTimeout:                config.MinJobExecutionTimeout,
+			JobExecutionTimeoutClientIDBypassList: config.JobExecutionTimeoutClientIDBypassList,
+		}),
+		semantic.NewStatelessJobStrategy(semantic.StatelessJobStrategyParams{
+			RejectStatelessJobs: config.JobSelectionPolicy.RejectStatelessJobs,
+		}),
+		semantic.NewExternalCommandStrategy(semantic.ExternalCommandStrategyParams{
+			Command: config.JobSelectionPolicy.ProbeExec,
+		}),
+		semantic.NewExternalHTTPStrategy(semantic.ExternalHTTPStrategyParams{
+			URL: config.JobSelectionPolicy.ProbeHTTP,
+		}),
+
+	*/
+}
+
+type ComputeEndpointProvider struct {
+	compute *compute_endpoint.Endpoint
+	bidding compute.BaseEndpoint
+}
+
+func (c *ComputeEndpointProvider) Compute() *compute_endpoint.Endpoint {
+	return c.compute
+}
+
+func (c *ComputeEndpointProvider) Bidding() compute.BaseEndpoint {
+	return c.bidding
+}

--- a/pkg/node/v2/compute/capacity.go
+++ b/pkg/node/v2/compute/capacity.go
@@ -1,0 +1,138 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute/capacity"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/capacity/disk"
+	compute_system "github.com/bacalhau-project/bacalhau/pkg/compute/capacity/system"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+)
+
+type CapacityProvider interface {
+	Capacity() models.Resources
+	RunningTracker() capacity.Tracker
+	QueuedTracker() capacity.UsageTracker
+	Calculator() capacity.UsageCalculator
+}
+
+func NewCapacityProvider(
+	ctx context.Context,
+	path string,
+	cfg v2.Capacity,
+	storages storage.StorageProvider,
+) (*ComputeCapacityProvider, error) {
+	resources, err := setupCapacity(ctx, compute_system.NewPhysicalCapacityProvider(path), cfg)
+	if err != nil {
+		return nil, err
+	}
+	calculator := capacity.NewChainedUsageCalculator(capacity.ChainedUsageCalculatorParams{
+		Calculators: []capacity.UsageCalculator{
+			// TODO(forrest) this merges the job defaults with the specified defaults.
+			// It appears the side affect of this method is that it returns whatever is greater, the defaults, or
+			// the job resources for subsequent bidding decisions in the bidder.
+			capacity.NewDefaultsUsageCalculator(capacity.DefaultsUsageCalculatorParams{
+				// the default resource to assign to jobs missing a resource config is the capacity of the compute node.
+				Defaults: *resources,
+			}),
+			disk.NewDiskUsageCalculator(disk.DiskUsageCalculatorParams{
+				Storages: storages,
+			}),
+		},
+	})
+	enqueuedUsageTracker := capacity.NewLocalUsageTracker()
+	runningCapacityTracker := capacity.NewLocalTracker(capacity.LocalTrackerParams{
+		MaxCapacity: *resources,
+	})
+
+	return &ComputeCapacityProvider{
+		capacity:               *resources,
+		calculator:             calculator,
+		runningCapacityTracker: runningCapacityTracker,
+		enqueuedUsageTracker:   enqueuedUsageTracker,
+	}, nil
+}
+
+type ComputeCapacityProvider struct {
+	capacity               models.Resources
+	calculator             capacity.UsageCalculator
+	runningCapacityTracker capacity.Tracker
+	enqueuedUsageTracker   capacity.UsageTracker
+}
+
+func (c *ComputeCapacityProvider) Capacity() models.Resources {
+	return c.capacity
+}
+
+func (c *ComputeCapacityProvider) RunningTracker() capacity.Tracker {
+	return c.runningCapacityTracker
+}
+
+func (c *ComputeCapacityProvider) QueuedTracker() capacity.UsageTracker {
+	return c.enqueuedUsageTracker
+}
+
+func (c *ComputeCapacityProvider) Calculator() capacity.UsageCalculator {
+	return c.calculator
+}
+
+// SetupCapacity determines the compute capacity based on system capabilities and user configuration.
+// It handles three scenarios:
+//
+// 1. If both Total and Allocated capacities are set in the config:
+//   - Logs a warning that Allocated capacity will be ignored.
+//   - Proceeds with Total capacity.
+//
+// 2. If only Allocated capacity is set:
+//   - Scales the system capacity by the Allocated percentage.
+//   - Returns the scaled capacity.
+//
+// 3. If only Total capacity is set:
+//   - Parses the configured Total capacity.
+//   - Verifies it doesn't exceed system capacity.
+//   - Returns the configured capacity if valid.
+//
+// The method scales the system capacity when using Allocated settings, but does not
+// scale the configured Total capacity. It returns an error if the configured Total
+// capacity exceeds the system capacity.
+func setupCapacity(ctx context.Context, provider *compute_system.PhysicalCapacityProvider, cfg v2.Capacity) (*models.Resources, error) {
+	// TODO(forrest) [question] do we want to scale the configured total capacity by the allocated capacity?
+	// Should we consider the configuration invalid if a user provides both an allocated and total capacity?
+	// The latter could happen when merging several configuration files, maybe log a warning and state
+	// the allocated capacity will be ignored since a total capacity was specified?
+	if !cfg.Total.IsZero() && !cfg.Allocated.IsZero() {
+		log.Warn().Msg("both allocated and total capacity are configured, ignoring allocated capacity scaler")
+	}
+
+	// determine the physical capacity of the host running the compute node
+	systemCapacity, err := provider.GetTotalCapacity(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("calculating system capacity: %w", err)
+	}
+
+	// if total capacity isn't configured, scale the capacity based on allocation
+	if cfg.Total.IsZero() {
+		scaledCapacity, err := systemCapacity.Scale(cfg.Allocated)
+		if err != nil {
+			return nil, fmt.Errorf("scaling system capacity by allocated capacity: %w", err)
+		}
+		log.Info().Stringer("capacity", scaledCapacity).Msg("scaled compute capacity")
+		return scaledCapacity, nil
+	}
+	// else the user specified a total capacity
+	configuredCapacity, err := models.ParseResourceConfig(cfg.Total)
+	if err != nil {
+		return nil, fmt.Errorf("parsing total capacity configuration: %w", err)
+	}
+	// if the user has requested a total capacity greater than the system capacity fail?
+	if !configuredCapacity.LessThanEq(systemCapacity) {
+		return nil, fmt.Errorf("configured total capaity (%s) cannot be greater than system capacity (%s)",
+			configuredCapacity, &systemCapacity)
+	}
+	return configuredCapacity, nil
+}

--- a/pkg/node/v2/compute/execution.go
+++ b/pkg/node/v2/compute/execution.go
@@ -1,0 +1,149 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/sensors"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/store/boltdb"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+)
+
+type ExecutorProvider interface {
+	Store() store.ExecutionStore
+	Executor() *compute.ExecutorBuffer
+	DebugProvider() models.DebugInfoProvider
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+}
+
+func NewExecutorProvider(
+	ctx context.Context,
+	name string,
+	r *repo.FsRepo,
+	transport *nats_transport.NATSTransport,
+	engines executor.ExecutorProvider,
+	storages storage.StorageProvider,
+	publishers publisher.PublisherProvider,
+	capacity CapacityProvider,
+) (*ComputeExecutorProvider, error) {
+
+	// .bacalhau/compute_store/executions.db
+	executionStorePath, err := r.ExecutionStorePath()
+	if err != nil {
+		return nil, err
+	}
+	executionStore, err := boltdb.NewStore(ctx, executionStorePath)
+	if err != nil {
+		return nil, fmt.Errorf("createing execution store: %w", err)
+	}
+
+	// .bacalhau/compute_store/executor_results/
+	resultRoot, err := r.ExecutorResultPath()
+	if err != nil {
+		return nil, err
+	}
+	resultsPath, err := compute.NewResultsPath(resultRoot)
+	if err != nil {
+		return nil, fmt.Errorf("creating results path: %w", err)
+	}
+
+	// .bacalhau/compute_store/executor_storages/
+	executorStorage, err := r.ExecutorStoragePath()
+	if err != nil {
+		return nil, fmt.Errorf("creating executor storage path: %w", err)
+	}
+
+	baseExecutor := compute.NewBaseExecutor(compute.BaseExecutorParams{
+		Callback:    transport.CallbackProxy(),
+		ID:          name,
+		Store:       executionStore,
+		Storages:    storages,
+		Executors:   engines,
+		Publishers:  publishers,
+		ResultsPath: *resultsPath,
+
+		StorageDirectory: executorStorage,
+
+		// TODO(forrest) [correctness] this is leaking a testing attribute into core code. Don't do this
+		//FailureInjectionConfig: config.FailureInjectionConfig,
+	})
+
+	bufferRunner := compute.NewExecutorBuffer(compute.ExecutorBufferParams{
+		ID:                     name,
+		Callback:               transport.CallbackProxy(),
+		DelegateExecutor:       baseExecutor,
+		RunningCapacityTracker: capacity.RunningTracker(),
+		EnqueuedUsageTracker:   capacity.QueuedTracker(),
+		// TODO(forrest) [correctness] this field doesn't make sense and should be removed:
+		// It doesn't make sense for a compute node operator to set a default timeout on the executor
+		// and disregard the value during bidding. There shouldn't be a default timeout, instead compute
+		// nodes should timeout based on the values specified in the job. If the job doesn't specify a timeout
+		// then the compute node should happily run it till the end of time, or until its canceled by an operator/client
+		DefaultJobExecutionTimeout: models.NoTimeout,
+	})
+
+	runningInfoProvider := sensors.NewRunningExecutionsInfoProvider(sensors.RunningExecutionsInfoProviderParams{
+		Name:          "ActiveJobs",
+		BackendBuffer: bufferRunner,
+	})
+	return &ComputeExecutorProvider{
+		executionStore: executionStore,
+		executor:       bufferRunner,
+		debugInfo:      runningInfoProvider,
+		resultsPath:    resultsPath,
+		loggingSensor: sensors.NewLoggingSensor(sensors.LoggingSensorParams{
+			InfoProvider: runningInfoProvider,
+			// NB(forrest): value pulled from NewDefaultComputeParams
+			Interval: time.Second * 10,
+		}),
+	}, nil
+}
+
+type ComputeExecutorProvider struct {
+	executionStore store.ExecutionStore
+	executor       *compute.ExecutorBuffer
+	debugInfo      models.DebugInfoProvider
+	resultsPath    *compute.ResultsPath
+	loggingSensor  *sensors.LoggingSensor
+}
+
+func (c *ComputeExecutorProvider) Store() store.ExecutionStore {
+	return c.executionStore
+}
+
+func (c *ComputeExecutorProvider) Executor() *compute.ExecutorBuffer {
+	return c.executor
+}
+
+func (c *ComputeExecutorProvider) DebugProvider() models.DebugInfoProvider {
+	return c.debugInfo
+}
+
+func (c *ComputeExecutorProvider) Start(ctx context.Context) error {
+	if err := compute.NewStartup(c.executionStore, c.executor).Execute(ctx); err != nil {
+		return fmt.Errorf("failed to execute compute node startup tasks: %w", err)
+	}
+	go c.loggingSensor.Start(ctx)
+	return nil
+}
+
+func (c *ComputeExecutorProvider) Stop(ctx context.Context) error {
+	var err error
+	if err := c.executionStore.Close(ctx); err != nil {
+		err = errors.Join(err, fmt.Errorf("closing execution store: %w", err))
+	}
+	if err := c.resultsPath.Close(); err != nil {
+		err = errors.Join(err, fmt.Errorf("closing results path: %w", err))
+	}
+	return err
+}

--- a/pkg/node/v2/compute/management.go
+++ b/pkg/node/v2/compute/management.go
@@ -1,0 +1,63 @@
+package compute
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/node/heartbeat"
+	"github.com/bacalhau-project/bacalhau/pkg/repo"
+)
+
+const (
+	HeartbeatTopic = "heartbeat"
+)
+
+func SetupNetworkClient(
+	name string,
+	r *repo.FsRepo,
+	cfg v2.Heartbeat,
+	transport *nats_transport.NATSTransport,
+	capacityProvider CapacityProvider,
+	labelsProvider models.LabelsProvider,
+	decorator models.NodeInfoDecorator,
+) (*compute.ManagementClient, error) {
+	computePath, err := r.ComputePath()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Make the registration lock folder a config option so that we have it
+	// available and don't have to depend on getting the repo folder.
+	regFilename := fmt.Sprintf("%s.registration.lock", name)
+	regFilename = filepath.Join(computePath, regFilename)
+
+	heartbeatClient, err := heartbeat.NewClient(transport.Client(), name, HeartbeatTopic)
+	if err != nil {
+		return nil, fmt.Errorf("creating heartbeat client: %w", err)
+	}
+
+	// Set up the management client which will attempt to register this node
+	// with the requester node, and then if successful will send regular node
+	// info updates.
+	return compute.NewManagementClient(&compute.ManagementClientParams{
+		NodeID:                   name,
+		LabelsProvider:           labelsProvider,
+		ManagementProxy:          transport.ManagementProxy(),
+		NodeInfoDecorator:        decorator,
+		RegistrationFilePath:     regFilename,
+		AvailableCapacityTracker: capacityProvider.RunningTracker(),
+		QueueUsageTracker:        capacityProvider.QueuedTracker(),
+		HeartbeatClient:          heartbeatClient,
+		ControlPlaneSettings: types.ComputeControlPlaneConfig{
+			InfoUpdateFrequency:     types.Duration(cfg.InfoInterval),
+			ResourceUpdateFrequency: types.Duration(cfg.ResourceInterval),
+			HeartbeatFrequency:      types.Duration(cfg.MessageInterval),
+			HeartbeatTopic:          HeartbeatTopic,
+		},
+	}), nil
+}

--- a/pkg/node/v2/compute/node.go
+++ b/pkg/node/v2/compute/node.go
@@ -1,0 +1,212 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/compute/capacity"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/node"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+)
+
+// TODO we need to expose this back to the caller as an interface
+// this will allow a node to be created with a mocked out compute node and real requester.
+// will also prevent callers from modifying an active compute node.
+
+type Node struct {
+	Name      string
+	Transport *nats_transport.NATSTransport
+	Server    *publicapi.Server
+	Repo      *repo.FsRepo
+	Config    v2.Compute
+
+	EngineProvider    executor.ExecutorProvider
+	PublisherProvider publisher.PublisherProvider
+	StorageProvider   storage.StorageProvider
+	CapacityProvider  CapacityProvider
+	ExecutorService   ExecutorProvider
+	EndpointProvider  EndpointProvider
+	ManagementClient  *compute.ManagementClient
+	LabelsProvider    models.LabelsProvider
+	NodeInfoDecorator models.NodeInfoDecorator
+}
+
+func SetupNode(
+	ctx context.Context,
+	fsr *repo.FsRepo,
+	server *publicapi.Server,
+	transport *nats_transport.NATSTransport,
+	name string,
+	cfg v2.Compute,
+) (*Node, error) {
+
+	// .bacalhau/compute_store
+	computePath, err := fsr.ComputePath()
+	if err != nil {
+		return nil, fmt.Errorf("opening compute storage path: %w", err)
+	}
+	// .bacalhau/compute_store/publishers
+	publisherPath, err := fsr.PublisherPath()
+	if err != nil {
+		return nil, fmt.Errorf("opening executor storage path: %w", err)
+	}
+
+	engineProvider, err := NewEngineProvider(name, cfg.Executors)
+	if err != nil {
+		return nil, fmt.Errorf("creating executor provider: %w", err)
+	}
+
+	storageProvider, err := NewStorageProvider(cfg.InputSources)
+	if err != nil {
+		return nil, fmt.Errorf("creating storage provider: %w", err)
+	}
+
+	capacityProvider, err := NewCapacityProvider(ctx, computePath, cfg.Capacity, storageProvider)
+	if err != nil {
+		return nil, fmt.Errorf("creating capacity provider: %w", err)
+	}
+
+	publisherProvider, err := NewPublisherProvider(publisherPath, cfg.Publishers)
+	if err != nil {
+		return nil, fmt.Errorf("creating publisher provider: %w", err)
+	}
+
+	executorProvider, err := NewExecutorProvider(
+		ctx,
+		name,
+		fsr,
+		transport,
+		engineProvider,
+		storageProvider,
+		publisherProvider,
+		capacityProvider,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating executor provider: %w", err)
+	}
+
+	endpointProvider, err := NewComputeEndpointProvider(
+		name,
+		transport,
+		server,
+		cfg.Policy,
+		storageProvider,
+		engineProvider,
+		publisherProvider,
+		executorProvider,
+		capacityProvider,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating endpoint provider: %w", err)
+	}
+
+	labelsProvider := models.MergeLabelsInOrder(
+		&node.ConfigLabelsProvider{StaticLabels: cfg.Labels},
+		&node.RuntimeLabelsProvider{},
+		capacity.NewGPULabelsProvider(capacityProvider.Capacity()),
+	)
+
+	nodeInfoDecorator := compute.NewNodeInfoDecorator(compute.NodeInfoDecoratorParams{
+		Executors:              engineProvider,
+		Publisher:              publisherProvider,
+		Storages:               storageProvider,
+		MaxJobRequirements:     capacityProvider.Capacity(),
+		RunningCapacityTracker: capacityProvider.RunningTracker(),
+		QueueCapacityTracker:   capacityProvider.QueuedTracker(),
+		ExecutorBuffer:         executorProvider.Executor(),
+	})
+
+	managementClient, err := SetupNetworkClient(
+		name,
+		fsr,
+		cfg.Heartbeat,
+		transport,
+		capacityProvider,
+		labelsProvider,
+		nodeInfoDecorator,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating management client: %w", err)
+	}
+
+	return NewNode(
+		name,
+		cfg,
+		fsr,
+		server,
+		transport,
+		WithEngineProvider(engineProvider),
+		WithPublisherProvider(publisherProvider),
+		WithStorageProvider(storageProvider),
+		WithCapacityProvider(capacityProvider),
+		WithExecutorProvider(executorProvider),
+		WithEndpointProvider(endpointProvider),
+		WithManagementClient(managementClient),
+		WithLabelsProvider(labelsProvider),
+		WithNodeInfoDecorator(nodeInfoDecorator),
+	)
+}
+
+func NewNode(
+	name string,
+	cfg v2.Compute,
+	fsr *repo.FsRepo,
+	server *publicapi.Server,
+	transport *nats_transport.NATSTransport,
+	opts ...Option,
+) (*Node, error) {
+	computeNode := &Node{
+		Name:      name,
+		Transport: transport,
+		Server:    server,
+		Repo:      fsr,
+		Config:    cfg,
+	}
+	// Apply options
+	for _, opt := range opts {
+		if err := opt(computeNode); err != nil {
+			return nil, err
+		}
+	}
+
+	// Validate and return
+	if err := computeNode.validate(); err != nil {
+		return nil, err
+	}
+	return computeNode, nil
+}
+
+func (n *Node) Start(ctx context.Context) error {
+	if err := n.ExecutorService.Start(ctx); err != nil {
+		return fmt.Errorf("starting executor service: %w", err)
+	}
+	if err := n.ManagementClient.RegisterNode(ctx); err != nil {
+		return fmt.Errorf("registering compute node with orchestrator: %s", err)
+	}
+	go n.ManagementClient.Start(ctx)
+
+	return nil
+}
+
+func (n *Node) Stop(ctx context.Context) error {
+	var stopErr error
+	n.ManagementClient.Stop()
+	if err := n.ExecutorService.Stop(ctx); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("stopping executor service: %w", err))
+	}
+
+	return stopErr
+}
+
+func (n *Node) validate() error {
+	return nil
+}

--- a/pkg/node/v2/compute/options.go
+++ b/pkg/node/v2/compute/options.go
@@ -1,0 +1,74 @@
+package compute
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+)
+
+type Option func(*Node) error
+
+func WithEngineProvider(p executor.ExecutorProvider) Option {
+	return func(n *Node) error {
+		n.EngineProvider = p
+		return nil
+	}
+}
+
+func WithPublisherProvider(p publisher.PublisherProvider) Option {
+	return func(n *Node) error {
+		n.PublisherProvider = p
+		return nil
+	}
+}
+
+func WithStorageProvider(p storage.StorageProvider) Option {
+	return func(n *Node) error {
+		n.StorageProvider = p
+		return nil
+	}
+}
+
+func WithCapacityProvider(p CapacityProvider) Option {
+	return func(n *Node) error {
+		n.CapacityProvider = p
+		return nil
+	}
+}
+
+func WithExecutorProvider(p ExecutorProvider) Option {
+	return func(n *Node) error {
+		n.ExecutorService = p
+		return nil
+	}
+}
+
+func WithEndpointProvider(p EndpointProvider) Option {
+	return func(n *Node) error {
+		n.EndpointProvider = p
+		return nil
+	}
+}
+
+func WithManagementClient(c *compute.ManagementClient) Option {
+	return func(n *Node) error {
+		n.ManagementClient = c
+		return nil
+	}
+}
+
+func WithLabelsProvider(p models.LabelsProvider) Option {
+	return func(n *Node) error {
+		n.LabelsProvider = p
+		return nil
+	}
+}
+
+func WithNodeInfoDecorator(d models.NodeInfoDecorator) Option {
+	return func(n *Node) error {
+		n.NodeInfoDecorator = d
+		return nil
+	}
+}

--- a/pkg/node/v2/compute/providers.go
+++ b/pkg/node/v2/compute/providers.go
@@ -1,0 +1,180 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/bacalhau-project/bacalhau/pkg/executor"
+	"github.com/bacalhau-project/bacalhau/pkg/executor/docker"
+	"github.com/bacalhau-project/bacalhau/pkg/executor/wasm"
+	ipfs_client "github.com/bacalhau-project/bacalhau/pkg/ipfs"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher/ipfs"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher/local"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher/s3"
+	s3pub "github.com/bacalhau-project/bacalhau/pkg/publisher/s3"
+	s3helper "github.com/bacalhau-project/bacalhau/pkg/s3"
+	"github.com/bacalhau-project/bacalhau/pkg/storage"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/inline"
+	ipfs_storage "github.com/bacalhau-project/bacalhau/pkg/storage/ipfs"
+	localdirectory "github.com/bacalhau-project/bacalhau/pkg/storage/local_directory"
+	s3strg "github.com/bacalhau-project/bacalhau/pkg/storage/s3"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/url/urldownload"
+
+	executor_config "github.com/bacalhau-project/bacalhau/pkg/config/types/v2/executor"
+	publisher_config "github.com/bacalhau-project/bacalhau/pkg/config/types/v2/publisher"
+	storage_config "github.com/bacalhau-project/bacalhau/pkg/config/types/v2/storage"
+)
+
+func NewEngineProvider(name string, cfg executor_config.Providers) (executor.ExecutorProvider, error) {
+	providers := make(map[string]executor.Executor)
+	if cfg.Docker.Enabled {
+		cacheCfg := cfg.Docker.ManifestCache
+		// TODO we need to pass the endpoint down to the executor via cfg.Docker.Endpoint
+		// currently docker is configured from system environment variables.
+		dockerExecutor, err := docker.NewExecutor(name, types.DockerCacheConfig{
+			Size:      cacheCfg.Size,
+			Duration:  types.Duration(cacheCfg.TTL),
+			Frequency: types.Duration(cacheCfg.Refresh),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating docker executor: %w", err)
+		}
+		providers[models.EngineDocker] = dockerExecutor
+	}
+	if cfg.WASM.Enabled {
+		wasmExecutor, err := wasm.NewExecutor()
+		if err != nil {
+			return nil, fmt.Errorf("creating wasm executor: %w", err)
+		}
+		providers[models.EngineWasm] = wasmExecutor
+	}
+
+	return provider.NewMappedProvider(providers), nil
+}
+
+func NewStorageProvider(cfg storage_config.Providers) (storage.StorageProvider, error) {
+	providers := make(map[string]storage.Storage)
+
+	// TODO(forrest) [unsure]: do we intend to continue supporting inlinde data?
+	// for the sake of compatibility, we'll keep this here for now.
+	providers[models.StorageSourceInline] = inline.NewStorage()
+
+	// NB(forrest): these params are the existing defaults
+	maxRetries := 3
+	getVolumeTimeout := time.Minute * 2
+
+	if cfg.HTTP.Enabled {
+		providers[models.StorageSourceURL] = urldownload.NewStorage(getVolumeTimeout, maxRetries)
+	}
+	if cfg.Local.Enabled {
+		volumes := make([]localdirectory.AllowedPath, len(cfg.Local.Volumes))
+		for i, v := range cfg.Local.Volumes {
+			volumes[i] = localdirectory.AllowedPath{
+				Path:      v.Path,
+				ReadWrite: v.Write,
+				// TODO this isn't currently a supported field
+				// Name: v.Name
+			}
+		}
+		localStrg, err := localdirectory.NewStorageProvider(localdirectory.StorageProviderParams{
+			AllowedPaths: volumes,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating local storage provider: %w", err)
+		}
+		providers[models.StorageSourceLocalDirectory] = localStrg
+	}
+	if cfg.S3.Enabled {
+		s3cfg, err := s3helper.DefaultAWSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("reading S3 credentials: %w", err)
+		}
+		clientProvider := s3helper.NewClientProvider(s3helper.ClientProviderParams{
+			AWSConfig: s3cfg,
+		})
+		providers[models.StorageSourceS3] = s3strg.NewStorage(getVolumeTimeout, clientProvider)
+	}
+	if cfg.IPFS.Enabled {
+		ipfsClient, err := ipfs_client.NewClient(context.Background(), cfg.IPFS.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+		ipfsStorage, err := ipfs_storage.NewStorage(*ipfsClient, getVolumeTimeout)
+		if err != nil {
+			return nil, err
+		}
+		providers[models.StorageSourceIPFS] = ipfsStorage
+	}
+
+	return provider.NewMappedProvider(providers), nil
+}
+
+func NewPublisherProvider(path string, cfg publisher_config.Providers) (publisher.PublisherProvider, error) {
+	providers := make(map[string]publisher.Publisher)
+	ctx := context.TODO()
+
+	if cfg.S3.Enabled {
+		dir, err := os.MkdirTemp(path, "bacalhau-s3-publisher")
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO cleaning up the publisher paths can be the responsibility of the node during shutdown.
+		/*
+			cm.RegisterCallback(func() error {
+				if err := os.RemoveAll(dir); err != nil {
+					return fmt.Errorf("unable to clean up S3 publisher directory: %w", err)
+				}
+				return nil
+			})
+		*/
+
+		// TODO the new config has many fields to configure s3, but we can't use them here
+		// or will with interfere with existing behavior of fetching s3 credentials.
+		awsCfg, err := s3helper.DefaultAWSConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		providers[models.PublisherS3] = s3pub.NewPublisher(s3.PublisherParams{
+			LocalDir: dir,
+			ClientProvider: s3helper.NewClientProvider(s3helper.ClientProviderParams{
+				AWSConfig: awsCfg,
+			}),
+		})
+	}
+
+	// TODO(forrest) [fubar] well this is all sorts of @#$!%#
+	if cfg.LocalHTTPServer.Enabled {
+		dir, err := os.MkdirTemp(path, "bacalhau-localHTTPServer-publisher")
+		if err != nil {
+			return nil, err
+		}
+		providers[models.PublisherLocal] = local.NewLocalPublisher(
+			ctx,
+			dir,
+			cfg.LocalHTTPServer.Host,
+			cfg.LocalHTTPServer.Port,
+		)
+	}
+
+	if cfg.IPFS.Enabled {
+		ipfsClient, err := ipfs_client.NewClient(ctx, cfg.IPFS.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("creating ipfs publisher client: %w", err)
+		}
+		ipfsPublisher, err := ipfs.NewIPFSPublisher(ctx, *ipfsClient)
+		if err != nil {
+			return nil, fmt.Errorf("creatiiing ipfs publisher provider: %w", err)
+		}
+		providers[models.PublisherIPFS] = ipfsPublisher
+	}
+
+	return provider.NewMappedProvider(providers), nil
+}

--- a/pkg/node/v2/node.go
+++ b/pkg/node/v2/node.go
@@ -1,0 +1,173 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	node2 "github.com/bacalhau-project/bacalhau/pkg/node"
+	"github.com/bacalhau-project/bacalhau/pkg/node/v2/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/node/v2/orchestrator"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/agent"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/shared"
+	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/routing"
+	"github.com/bacalhau-project/bacalhau/pkg/version"
+)
+
+type Node struct {
+	Transport    *nats_transport.NATSTransport
+	Server       *publicapi.Server
+	Compute      *compute.Node
+	Orchestrator *orchestrator.Node
+	Config       v2.Bacalhau
+}
+
+func (n *Node) Start(ctx context.Context) error {
+	if n.Config.Orchestrator.Enabled {
+		if err := n.Orchestrator.Start(ctx); err != nil {
+			return fmt.Errorf("starting orcherstrator service: %w", err)
+		}
+	}
+	if n.Config.Compute.Enabled {
+		if err := n.Compute.Start(ctx); err != nil {
+			return fmt.Errorf("starting compute service: %w", err)
+		}
+	}
+	if err := n.Server.ListenAndServe(ctx); err != nil {
+		return fmt.Errorf("starting server: %w", err)
+	}
+
+	return nil
+}
+
+func (n *Node) Stop(ctx context.Context) error {
+	var stopErr error
+	if n.Config.Compute.Enabled {
+		if err := n.Compute.Stop(ctx); err != nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("stopping compute service: %w", err))
+		}
+	}
+	if n.Config.Orchestrator.Enabled {
+		if err := n.Orchestrator.Stop(ctx); err != nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("stopping orchestrator service: %w", err))
+		}
+	}
+	if err := n.Transport.Close(ctx); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("stopping transport service: %w", err))
+	}
+	if err := n.Server.Shutdown(ctx); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("shutting down server: %w", err))
+	}
+	return stopErr
+}
+
+// Should be simplified when moving to FX
+func New(
+	ctx context.Context,
+	fsr *repo.FsRepo,
+	cfg v2.Bacalhau,
+) (*Node, error) {
+
+	userKey, err := fsr.LoadUserKey()
+	if err != nil {
+		return nil, fmt.Errorf("loading user key from repo: %w", err)
+	}
+	server, err := SetupAPIServer(userKey.PublicKey(), cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating api server: %w", err)
+	}
+
+	transport, err := SetupTransport(cfg.Name, fsr, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating NATS transport: %w", err)
+	}
+	node := &Node{
+		Transport: transport,
+		Server:    server,
+		Config:    cfg,
+	}
+
+	var debugInfoProviders []models.DebugInfoProvider
+	debugInfoProviders = append(debugInfoProviders, transport.DebugInfoProviders()...)
+	var labelsProvider models.LabelsProvider
+
+	if cfg.Orchestrator.Enabled {
+		authProvider, err := SetupAuthenticators(userKey.PrivateKey(), cfg)
+		if err != nil {
+			return nil, fmt.Errorf("setting up auth provider")
+		}
+		node.Orchestrator, err = orchestrator.SetupNode(ctx, cfg.Name, cfg.Orchestrator, fsr, server, transport, authProvider)
+		if err != nil {
+			return nil, fmt.Errorf("creating orchestrator service: %w", err)
+		}
+		labelsProvider = models.MergeLabelsInOrder(
+			// TODO this seems wrong, but taken from existing code as found.
+			&node2.ConfigLabelsProvider{StaticLabels: cfg.Compute.Labels},
+			&node2.RuntimeLabelsProvider{},
+		)
+		debugInfoProviders = append(debugInfoProviders, node.Orchestrator.DebugInfoProvider...)
+	}
+
+	if cfg.Compute.Enabled {
+		node.Compute, err = compute.SetupNode(ctx, fsr, server, transport, cfg.Name, cfg.Compute)
+		if err != nil {
+			return nil, fmt.Errorf("creating compute service: %w", err)
+		}
+
+		err = transport.RegisterComputeEndpoint(ctx, node.Compute.EndpointProvider.Bidding())
+		if err != nil {
+			return nil, err
+		}
+
+		labelsProvider = node.Compute.LabelsProvider
+		debugInfoProviders = append(debugInfoProviders, node.Compute.ExecutorService.DebugProvider())
+	}
+
+	// TODO(forrest): understand this code
+
+	// Create a node info provider for NATS, and specify the default node approval state
+	// of Approved to avoid confusion as approval state is not used for this transport type.
+	nodeInfoProvider := routing.NewNodeStateProvider(routing.NodeStateProviderParams{
+		NodeID:              cfg.Name,
+		LabelsProvider:      labelsProvider,
+		BacalhauVersion:     *version.Get(),
+		DefaultNodeApproval: models.NodeMembership.APPROVED,
+	})
+	nodeInfoProvider.RegisterNodeInfoDecorator(transport.NodeInfoDecorator())
+	if cfg.Compute.Enabled {
+		nodeInfoProvider.RegisterNodeInfoDecorator(node.Compute.NodeInfoDecorator)
+	}
+
+	shared.NewEndpoint(shared.EndpointParams{
+		Router:            server.Router,
+		NodeID:            cfg.Name,
+		NodeStateProvider: nodeInfoProvider,
+	})
+
+	agent.NewEndpoint(agent.EndpointParams{
+		Router:             server.Router,
+		NodeStateProvider:  nodeInfoProvider,
+		DebugInfoProviders: debugInfoProviders,
+	})
+
+	// We want to register the current requester node to the node store
+	// TODO (walid): revisit self node registration of requester node
+	if cfg.Orchestrator.Enabled {
+		nodeState := nodeInfoProvider.GetNodeState(ctx)
+		// TODO what is the liveness here? We are adding ourselves so I assume connected?
+		nodeState.Membership = models.NodeMembership.APPROVED
+		if err := node.Orchestrator.NodeInfoStore.Add(ctx, nodeState); err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("failed to add requester node to the node store")
+			return nil, fmt.Errorf("registering node to the node store: %w", err)
+		}
+	}
+
+	return node, nil
+}

--- a/pkg/node/v2/orchestrator/managment.go
+++ b/pkg/node/v2/orchestrator/managment.go
@@ -1,0 +1,71 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	pkgerrors "github.com/pkg/errors"
+
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/node/heartbeat"
+	"github.com/bacalhau-project/bacalhau/pkg/node/manager"
+	"github.com/bacalhau-project/bacalhau/pkg/routing"
+	"github.com/bacalhau-project/bacalhau/pkg/routing/kvstore"
+	"github.com/bacalhau-project/bacalhau/pkg/routing/tracing"
+)
+
+const (
+	HeartbeatTopic = "heartbeat"
+)
+
+func SetupNodeManager(
+	ctx context.Context,
+	transportLayer *nats_transport.NATSTransport,
+	nodeInfoStore routing.NodeInfoStore,
+	cfg v2.Orchestrator,
+) (*manager.NodeManager, error) {
+	// heartbeat service
+	heartbeatParams := heartbeat.HeartbeatServerParams{
+		Client: transportLayer.Client(),
+		Topic:  HeartbeatTopic,
+		// NB(forrest): this was pulled from the default config
+		CheckFrequency:        time.Second * 30,
+		NodeDisconnectedAfter: time.Duration(cfg.NodeManager.DisconnectTimeout),
+	}
+	heartbeatSvr, err := heartbeat.NewServer(heartbeatParams)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "failed to create heartbeat server using NATS transport connection info")
+	}
+
+	defaultMembership := models.NodeMembership.PENDING
+	if cfg.NodeManager.AutoApprove {
+		defaultMembership = models.NodeMembership.APPROVED
+	}
+
+	// node manager
+	// Create a new node manager to keep track of compute nodes connecting
+	// to the network. Provide it with a mechanism to lookup (and enhance)
+	// node info, and a reference to the heartbeat server
+	return manager.NewNodeManager(manager.NodeManagerParams{
+		NodeInfo:             nodeInfoStore,
+		Heartbeats:           heartbeatSvr,
+		DefaultApprovalState: defaultMembership,
+	}), nil
+}
+
+func SetupNodeInfoStore(ctx context.Context, transportLayer *nats_transport.NATSTransport) (routing.NodeInfoStore, error) {
+	// nodeInfoStore
+	nodeInfoStore, err := kvstore.NewNodeStore(ctx, kvstore.NodeStoreParams{
+		BucketName: kvstore.BucketNameCurrent,
+		Client:     transportLayer.Client(),
+	})
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "failed to create node info store using NATS transport connection info")
+	}
+
+	tracingInfoStore := tracing.NewNodeStore(nodeInfoStore)
+
+	return tracingInfoStore, nil
+}

--- a/pkg/node/v2/orchestrator/node.go
+++ b/pkg/node/v2/orchestrator/node.go
@@ -1,0 +1,242 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/bacalhau-project/bacalhau/pkg/authn"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/eventhandler"
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	boltjobstore "github.com/bacalhau-project/bacalhau/pkg/jobstore/boltdb"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/node/manager"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/retry"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/selection/discovery"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/transformer"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+	auth_endpoint "github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/auth"
+	orchestrator_endpoint "github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/orchestrator"
+	requester_endpoint "github.com/bacalhau-project/bacalhau/pkg/publicapi/endpoint/requester"
+	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/requester"
+	"github.com/bacalhau-project/bacalhau/pkg/routing"
+)
+
+type Node struct {
+	Name                  string
+	Transport             *nats_transport.NATSTransport
+	Server                *publicapi.Server
+	Repo                  *repo.FsRepo
+	Config                v2.Orchestrator
+	Scheduler             *SchedulerService
+	Store                 jobstore.Store
+	Endpoint              *requester.BaseEndpoint
+	NodeManager           *manager.NodeManager
+	NodeInfoStore         routing.NodeInfoStore
+	TracerContextProvider *eventhandler.TracerContextProvider
+	EventTracer           *eventhandler.Tracer
+	DebugInfoProvider     []models.DebugInfoProvider
+}
+
+func (n *Node) Start(ctx context.Context) error {
+	if err := n.Transport.RegisterNodeInfoConsumer(ctx, n.NodeInfoStore); err != nil {
+		return fmt.Errorf("registering node info store on transport: %w", err)
+	}
+	if err := n.NodeManager.Start(ctx); err != nil {
+		return fmt.Errorf("starting node manager: %w", err)
+	}
+	if err := n.Transport.RegisterManagementEndpoint(n.NodeManager); err != nil {
+		return fmt.Errorf("registering node manager on transport: %w", err)
+	}
+	if err := n.Transport.RegisterComputeCallback(n.Endpoint); err != nil {
+		return fmt.Errorf("registering endpoint on transport: %w", err)
+	}
+	if err := n.Scheduler.Start(ctx); err != nil {
+		return fmt.Errorf("starting scheduler service: %w", err)
+	}
+	return nil
+}
+
+func (n *Node) Stop(ctx context.Context) error {
+	var stopErr error
+	if err := n.Scheduler.Stop(ctx); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("stopping scheduler service: %w", err))
+	}
+	if err := n.TracerContextProvider.Shutdown(); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("stopping tracer context provider: %w", err))
+	}
+	if err := n.EventTracer.Shutdown(); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("stopping event tracer: %w", err))
+	}
+	if err := n.Store.Close(ctx); err != nil {
+		stopErr = errors.Join(stopErr, fmt.Errorf("closing job store: %w", err))
+	}
+
+	return stopErr
+}
+
+func (n *Node) validate() error {
+	return nil
+}
+
+func SetupNode(
+	ctx context.Context,
+	name string,
+	cfg v2.Orchestrator,
+	fsr *repo.FsRepo,
+	server *publicapi.Server,
+	transport *nats_transport.NATSTransport,
+	authProvider authn.Provider,
+) (*Node, error) {
+	// .bacalhau/orchestrator_store/jobs.db
+	jobStorePath, err := fsr.JobStorePath()
+	if err != nil {
+		return nil, fmt.Errorf("opening job store: %w", err)
+	}
+	jobStore, err := boltjobstore.NewBoltJobStore(jobStorePath)
+	if err != nil {
+		return nil, fmt.Errorf("creating job store: %w", err)
+	}
+
+	nodeInfoStore, err := SetupNodeInfoStore(ctx, transport)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeManager, err := SetupNodeManager(ctx, transport, nodeInfoStore, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating node manager: %w", err)
+	}
+
+	// prepare event handlers
+	tracerContextProvider := eventhandler.NewTracerContextProvider(name)
+	localJobEventConsumer := eventhandler.NewChainedJobEventHandler(tracerContextProvider)
+
+	eventEmitter := orchestrator.NewEventEmitter(orchestrator.EventEmitterParams{
+		EventConsumer: localJobEventConsumer,
+	})
+
+	scheduler, err := SetupSchedulerService(
+		name,
+		cfg,
+		transport.ComputeProxy(),
+		jobStore,
+		eventEmitter,
+		nodeManager,
+		// TODO this will need to be an option on the node
+		retry.NewFixedStrategy(retry.FixedStrategyParams{ShouldRetry: true}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating scheduler service: %w", err)
+	}
+
+	// result transformers that are applied to the result before it is returned to the user
+	resultTransformers := transformer.ChainedTransformer[*models.SpecConfig]{}
+
+	jobTransformers := transformer.ChainedTransformer[*models.Job]{
+		transformer.JobFn(transformer.IDGenerator),
+		transformer.NameOptional(),
+		//transformer.DefaultsApplier(requesterConfig.JobDefaults),
+		transformer.RequesterInfo(name),
+	}
+
+	endpointV2 := orchestrator.NewBaseEndpoint(&orchestrator.BaseEndpointParams{
+		ID:                name,
+		Store:             jobStore,
+		EventEmitter:      eventEmitter,
+		ComputeProxy:      transport.ComputeProxy(),
+		JobTransformer:    jobTransformers,
+		TaskTranslator:    nil,
+		ResultTransformer: resultTransformers,
+	})
+
+	// TODO: delete this when we are ready to stop serving a deprecation notice.
+	requester_endpoint.NewEndpoint(server.Router)
+
+	orchestrator_endpoint.NewEndpoint(orchestrator_endpoint.EndpointParams{
+		Router:       server.Router,
+		Orchestrator: endpointV2,
+		JobStore:     jobStore,
+		NodeManager:  nodeManager,
+	})
+
+	auth_endpoint.BindEndpoint(ctx, server.Router, authProvider)
+
+	// TODO is there any point is making this thing?
+	eventTracer, err := eventhandler.NewTracer(os.DevNull)
+	if err != nil {
+		return nil, err
+	}
+
+	// order of event handlers is important as triggering some handlers might depend on the state of others.
+	localJobEventConsumer.AddHandlers(
+		// ends the span for the job if received a terminal event
+		tracerContextProvider,
+		// record the event in a log
+		eventTracer,
+	)
+
+	// This endpoint implements the protocol formerly known as `bprotocol`.
+	// It provides the compute call back endpoints for interacting with compute nodes.
+	// e.g. bidding, job completions, cancellations, and failures
+	endpoint := requester.NewBaseEndpoint(&requester.BaseEndpointParams{
+		ID:           name,
+		EventEmitter: eventEmitter,
+		Store:        jobStore,
+	})
+
+	// register debug info providers for the /debug endpoint
+	debugInfoProviders := []models.DebugInfoProvider{
+		discovery.NewDebugInfoProvider(nodeManager),
+	}
+
+	return NewNode(
+		name,
+		cfg,
+		fsr,
+		server,
+		transport,
+		WithScheduler(scheduler),
+		WithEndpoint(endpoint),
+		WithTracerContextProvider(tracerContextProvider),
+		WithDebugInfoProvider(debugInfoProviders...),
+		WithNodeInfoStore(nodeInfoStore),
+		WithNodeManer(nodeManager),
+		WithJobStore(jobStore),
+		WithEventTracer(eventTracer),
+	)
+}
+
+func NewNode(
+	name string,
+	cfg v2.Orchestrator,
+	fsr *repo.FsRepo,
+	server *publicapi.Server,
+	transport *nats_transport.NATSTransport,
+	opts ...Option,
+) (*Node, error) {
+	orchestratorNode := &Node{
+		Name:      name,
+		Transport: transport,
+		Server:    server,
+		Repo:      fsr,
+		Config:    cfg,
+	}
+	// Apply options
+	for _, opt := range opts {
+		if err := opt(orchestratorNode); err != nil {
+			return nil, err
+		}
+	}
+
+	// Validate and return
+	if err := orchestratorNode.validate(); err != nil {
+		return nil, err
+	}
+	return orchestratorNode, nil
+}

--- a/pkg/node/v2/orchestrator/options.go
+++ b/pkg/node/v2/orchestrator/options.go
@@ -1,0 +1,68 @@
+package orchestrator
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/eventhandler"
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/node/manager"
+	"github.com/bacalhau-project/bacalhau/pkg/requester"
+	"github.com/bacalhau-project/bacalhau/pkg/routing"
+)
+
+type Option func(*Node) error
+
+func WithScheduler(s *SchedulerService) Option {
+	return func(n *Node) error {
+		n.Scheduler = s
+		return nil
+	}
+}
+
+func WithEndpoint(e *requester.BaseEndpoint) Option {
+	return func(n *Node) error {
+		n.Endpoint = e
+		return nil
+	}
+}
+
+func WithTracerContextProvider(t *eventhandler.TracerContextProvider) Option {
+	return func(n *Node) error {
+		n.TracerContextProvider = t
+		return nil
+	}
+}
+
+func WithDebugInfoProvider(p ...models.DebugInfoProvider) Option {
+	return func(n *Node) error {
+		n.DebugInfoProvider = p
+		return nil
+	}
+}
+
+func WithNodeInfoStore(s routing.NodeInfoStore) Option {
+	return func(n *Node) error {
+		n.NodeInfoStore = s
+		return nil
+	}
+}
+
+func WithNodeManer(m *manager.NodeManager) Option {
+	return func(n *Node) error {
+		n.NodeManager = m
+		return nil
+	}
+}
+
+func WithJobStore(s jobstore.Store) Option {
+	return func(n *Node) error {
+		n.Store = s
+		return nil
+	}
+}
+
+func WithEventTracer(t *eventhandler.Tracer) Option {
+	return func(n *Node) error {
+		n.EventTracer = t
+		return nil
+	}
+}

--- a/pkg/node/v2/orchestrator/scheduler.go
+++ b/pkg/node/v2/orchestrator/scheduler.go
@@ -1,0 +1,224 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	boltjobstore "github.com/bacalhau-project/bacalhau/pkg/jobstore/boltdb"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/backoff"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/evaluation"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/planner"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/scheduler"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/selection/ranking"
+	"github.com/bacalhau-project/bacalhau/pkg/orchestrator/selection/selector"
+)
+
+type SchedulerService struct {
+	Broker       *evaluation.InMemoryBroker
+	Watcher      *evaluation.Watcher
+	Workers      []*orchestrator.Worker
+	Housekeeping *orchestrator.Housekeeping
+}
+
+// TODO we need to enable overriding of the rety strategy in testing
+/*
+
+	retryStrategy := requesterConfig.RetryStrategy
+	if retryStrategy == nil {
+		// retry strategy
+		retryStrategyChain := retry.NewChain()
+		retryStrategyChain.Add(
+			retry.NewFixedStrategy(retry.FixedStrategyParams{ShouldRetry: true}),
+		)
+		retryStrategy = retryStrategyChain
+	}
+*/
+
+func SetupSchedulerService(
+	name string,
+	cfg v2.Orchestrator,
+	computeEndpoint compute.Endpoint,
+	jobStore *boltjobstore.BoltJobStore,
+	eventEmitter orchestrator.EventEmitter,
+	discoverer orchestrator.NodeDiscoverer,
+	retryStrategy orchestrator.RetryStrategy,
+) (*SchedulerService, error) {
+
+	// evaluation broker
+	broker, err := evaluation.NewInMemoryBroker(evaluation.InMemoryBrokerParams{
+		VisibilityTimeout: time.Duration(cfg.Broker.VisibilityTimeout),
+		MaxReceiveCount:   cfg.Broker.MaxRetries,
+		// NB(forrest): pulled from the default config
+		InitialRetryDelay: time.Second,
+		// NB(forrest): pulled from the default config
+		SubsequentRetryDelay: time.Second * 30,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating evaluation broker: %w", err)
+	}
+
+	// evaluations watcher
+	watcher := evaluation.NewWatcher(jobStore, broker)
+
+	// planners that execute the proposed plan by the scheduler
+	// order of the planners is important as they are executed in order
+	planners := planner.NewChain(
+		// planner that persist the desired state as defined by the scheduler
+		planner.NewStateUpdater(jobStore),
+
+		// planner that forwards the desired state to the compute nodes,
+		// and updates the observed state if the compute node accepts the desired state
+		planner.NewComputeForwarder(planner.ComputeForwarderParams{
+			ID:             name,
+			ComputeService: computeEndpoint,
+			JobStore:       jobStore,
+		}),
+
+		// planner that publishes events on job completion or failure
+		planner.NewEventEmitter(planner.EventEmitterParams{
+			ID:           name,
+			EventEmitter: eventEmitter,
+		}),
+
+		// logs job completion or failure
+		planner.NewLoggingPlanner(),
+	)
+
+	// node selector
+	nodeRanker, err := createNodeRanker(jobStore)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeSelector := selector.NewNodeSelector(
+		discoverer,
+		nodeRanker,
+		// selector constraints: require nodes be online and approved to schedule
+		orchestrator.NodeSelectionConstraints{
+			RequireConnected: true,
+			RequireApproval:  true,
+		},
+	)
+
+	// scheduler provider
+	batchServiceJobScheduler := scheduler.NewBatchServiceJobScheduler(scheduler.BatchServiceJobSchedulerParams{
+		JobStore:      jobStore,
+		Planner:       planners,
+		NodeSelector:  nodeSelector,
+		RetryStrategy: retryStrategy,
+		// TODO this value depends on the config, testing uses seconds, production uses this.
+		QueueBackoff: time.Minute,
+	})
+	schedulerProvider := orchestrator.NewMappedSchedulerProvider(map[string]orchestrator.Scheduler{
+		models.JobTypeBatch:   batchServiceJobScheduler,
+		models.JobTypeService: batchServiceJobScheduler,
+		models.JobTypeOps: scheduler.NewOpsJobScheduler(scheduler.OpsJobSchedulerParams{
+			JobStore:     jobStore,
+			Planner:      planners,
+			NodeSelector: nodeSelector,
+		}),
+		models.JobTypeDaemon: scheduler.NewDaemonJobScheduler(scheduler.DaemonJobSchedulerParams{
+			JobStore:     jobStore,
+			Planner:      planners,
+			NodeSelector: nodeSelector,
+		}),
+	})
+
+	workers := make([]*orchestrator.Worker, 0, cfg.Scheduler.Workers)
+	for i := 1; i <= cfg.Scheduler.Workers; i++ {
+		// worker config the polls from the broker
+		worker := orchestrator.NewWorker(orchestrator.WorkerParams{
+			SchedulerProvider: schedulerProvider,
+			EvaluationBroker:  broker,
+			// TODO this value depends on the config, testing uses second, production uses this
+			DequeueTimeout: time.Second * 5,
+			// NB(forrest): values taken from default config
+			DequeueFailureBackoff: backoff.NewExponential(time.Second, time.Second*30),
+		})
+		workers = append(workers, worker)
+	}
+
+	housekeeping, err := orchestrator.NewHousekeeping(orchestrator.HousekeepingParams{
+		JobStore:      jobStore,
+		Interval:      time.Duration(cfg.Scheduler.HousekeepingInterval),
+		TimeoutBuffer: time.Duration(cfg.Scheduler.HousekeepingTimeout),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating house keeping service: %w", err)
+	}
+
+	return &SchedulerService{
+		Broker:       broker,
+		Watcher:      watcher,
+		Workers:      workers,
+		Housekeeping: housekeeping,
+	}, nil
+}
+
+func (s *SchedulerService) Start(ctx context.Context) error {
+	s.Broker.SetEnabled(true)
+	if err := s.Watcher.Backfill(ctx); err != nil {
+		return fmt.Errorf("failed to backfill evaluations: %w", err)
+	}
+	s.Watcher.Start(ctx)
+	for i, worker := range s.Workers {
+		log.Info().Msgf("starting worker %d", i)
+		worker.Start(ctx)
+	}
+	s.Housekeeping.Start(ctx)
+	return nil
+}
+
+func (s *SchedulerService) Stop(ctx context.Context) error {
+	s.Housekeeping.Stop(ctx)
+	for _, worker := range s.Workers {
+		worker.Stop()
+	}
+	s.Broker.SetEnabled(false)
+	s.Watcher.Stop()
+	return nil
+}
+
+func createNodeRanker(jobStore jobstore.Store) (orchestrator.NodeRanker, error) {
+	// NB(forrest) 1.5 is from a default
+	overSubscriptionNodeRanker, err := ranking.NewOverSubscriptionNodeRanker(1.5)
+	if err != nil {
+		return nil, err
+	}
+	// compute node ranker
+	nodeRankerChain := ranking.NewChain()
+	nodeRankerChain.Add(
+		// rankers that act as filters and give a -1 score to nodes that do not match the filter
+		ranking.NewEnginesNodeRanker(),
+		ranking.NewPublishersNodeRanker(),
+		ranking.NewStoragesNodeRanker(),
+		ranking.NewLabelsNodeRanker(),
+		ranking.NewMaxUsageNodeRanker(),
+		overSubscriptionNodeRanker,
+		ranking.NewMinVersionNodeRanker(ranking.MinVersionNodeRankerParams{
+			// NB(forrest) taken from default
+			// TODO does this value make sense, its a very old version.
+			MinVersion: models.BuildVersionInfo{
+				Major:      "1",
+				Minor:      "0",
+				GitVersion: "v1.0.4",
+			},
+		}),
+		ranking.NewPreviousExecutionsNodeRanker(ranking.PreviousExecutionsNodeRankerParams{JobStore: jobStore}),
+		ranking.NewAvailableCapacityNodeRanker(),
+		// arbitrary rankers
+		ranking.NewRandomNodeRanker(ranking.RandomNodeRankerParams{
+			// NB(forrest): this is taken from the default
+			RandomnessRange: 5,
+		}),
+	)
+	return nodeRankerChain, nil
+}

--- a/pkg/node/v2/server.go
+++ b/pkg/node/v2/server.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	"crypto/rsa"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/bacalhau-project/bacalhau/pkg/authz"
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/policy"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi"
+	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
+	"github.com/bacalhau-project/bacalhau/pkg/version"
+)
+
+func SetupAPIServer(signingKey *rsa.PublicKey, cfg v2.Bacalhau) (*publicapi.Server, error) {
+	authzPolicy, err := policy.FromPathOrDefault(cfg.Server.Auth.AccessPolicyPath, authz.AlwaysAllowPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	serverVersion := version.Get()
+	serverParams := publicapi.ServerParams{
+		Router:  echo.New(),
+		Address: cfg.Server.Address,
+		Port:    uint16(cfg.Server.Port),
+		HostID:  cfg.Name,
+		// NB(forrest) [breadcrumb] this used to happen in pkg/node.prepareConfig
+		Config: publicapi.DefaultConfig(),
+
+		Authorizer: authz.NewPolicyAuthorizer(authzPolicy, signingKey, cfg.Name),
+		Headers: map[string]string{
+			apimodels.HTTPHeaderBacalhauGitVersion: serverVersion.GitVersion,
+			apimodels.HTTPHeaderBacalhauGitCommit:  serverVersion.GitCommit,
+			apimodels.HTTPHeaderBacalhauBuildDate:  serverVersion.BuildDate.UTC().String(),
+			apimodels.HTTPHeaderBacalhauBuildOS:    serverVersion.GOOS,
+			apimodels.HTTPHeaderBacalhauArch:       serverVersion.GOARCH,
+		},
+	}
+
+	// Only allow autocert for requester nodes
+	if cfg.Orchestrator.Enabled {
+		serverParams.AutoCertDomain = cfg.Server.TLS.AutoCert
+		serverParams.AutoCertCache = cfg.Server.TLS.AutoCertCachePath
+		serverParams.TLSCertificateFile = cfg.Server.TLS.Certificate
+		serverParams.TLSKeyFile = cfg.Server.TLS.Key
+	}
+
+	apiServer, err := publicapi.NewAPIServer(serverParams)
+	if err != nil {
+		return nil, err
+	}
+	return apiServer, nil
+}

--- a/pkg/node/v2/transport.go
+++ b/pkg/node/v2/transport.go
@@ -1,0 +1,40 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+
+	v2 "github.com/bacalhau-project/bacalhau/pkg/config/types/v2"
+	nats_transport "github.com/bacalhau-project/bacalhau/pkg/nats/transport"
+	"github.com/bacalhau-project/bacalhau/pkg/repo"
+)
+
+func SetupTransport(name string, r *repo.FsRepo, cfg v2.Bacalhau) (*nats_transport.NATSTransport, error) {
+	networkStorePath, err := r.NetworkTransportStorePath()
+	if err != nil {
+		return nil, fmt.Errorf("reading network transport path: %w", err)
+	}
+
+	// TODO the context passed here is only used for logging
+	transport, err := nats_transport.NewNATSTransport(context.TODO(),
+		&nats_transport.NATSTransportConfig{
+			NodeID:                   name,
+			StoreDir:                 networkStorePath,
+			Port:                     cfg.Orchestrator.Port,
+			AdvertisedAddress:        cfg.Orchestrator.Advertise,
+			IsRequesterNode:          cfg.Orchestrator.Enabled,
+			AuthSecret:               cfg.Orchestrator.AuthSecret,
+			ClusterName:              cfg.Orchestrator.Cluster.Name,
+			ClusterPort:              cfg.Orchestrator.Cluster.Port,
+			ClusterAdvertisedAddress: cfg.Orchestrator.Cluster.Advertise,
+			ClusterPeers:             cfg.Orchestrator.Cluster.Peers,
+
+			// TODO we need different setup code for client vs server, Orchestrators is usually a client value
+			Orchestrators: cfg.Compute.Orchestrators,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create NATS transport: %w", err)
+	}
+	return transport, nil
+}

--- a/pkg/publicapi/config.go
+++ b/pkg/publicapi/config.go
@@ -42,7 +42,7 @@ var defaultConfig = Config{
 	MaxBytesToReadInBody:  "10MB",
 	ThrottleLimit:         1000,
 	Protocol:              "http",
-	LogLevel:              "info",
+	LogLevel:              "debug",
 }
 
 // DefaultConfig returns the default configuration for the public API server.

--- a/pkg/publicapi/middleware/version.go
+++ b/pkg/publicapi/middleware/version.go
@@ -42,12 +42,15 @@ func VersionNotifyLogger(logger *zerolog.Logger, serverVersion semver.Version) e
 
 			defer func() {
 				if notif.Message != "" {
-					logger.WithLevel(zerolog.WarnLevel).
-						Str("ClientID", notif.ClientID).
-						Str("RequestID", notif.RequestID).
-						Str("ClientVersion", notif.ClientVersion).
-						Str("ServerVersion", notif.ServerVersion).
-						Msg(notif.Message)
+					/*
+						logger.WithLevel(zerolog.WarnLevel).
+							Str("ClientID", notif.ClientID).
+							Str("RequestID", notif.RequestID).
+							Str("ClientVersion", notif.ClientVersion).
+							Str("ServerVersion", notif.ServerVersion).
+							Msg(notif.Message)
+
+					*/
 				}
 			}()
 


### PR DESCRIPTION
Supports: https://github.com/bacalhau-project/bacalhau/issues/4014

In this PR I have implemented a v2 config type and v2 node package that consumes the new config when constructing a node. Further, it has decoupled paths in the config from the repo. The result this is a new package that may be used to construct a bacalhau node based on the new config; Creating a functioning bacalhau node that operates as expected.
- It doesn't pass tests - primarily because our old configuration structure is deeply woven into our test setup, pseudo-dependency-injection, and because we are removing/changing many fields in the new config e.g.
  - We currently have several (too many) different config types that are used to construct a node - types.BacalhauConfig, types.RequesterConfig, types.ComputeConfig , node.NodeConfig, node.RequesterConfig, node.ComputeConfig, node.NetworkConfig plus each package implements it's own default version and testing version of is respective config. 
    - For example, the current node construction code accepts both types.BacalhauConfig and node.NodeConfig using fields from each for various configuration.
  - When writing tests we modify various fields of these config to affect the node construction necessitated by the test.
  - We include testing fields in our configs, like FailureInjectionConfig which are not present in our new config struct (and shouldn't be)
  - We've removed many fields in the new config like JobExecutionTimeoutClientIDBypassList, RejectStatelessJobs, ProbeExec, ProbeHTTP , MaxJobExecutionTimeout,  MinJobExecutionTimeout, etc. which we have test coverage for that needs to be removed.

The high level plan here is to start pulling pieces out of this large PR into smaller ones:
- decouple config paths from repo paths https://github.com/bacalhau-project/bacalhau/pull/4330
- remove deprecated config fields
- migrate bacalhau nodes with an old config to use the new one
