### PR TITLE
feat: implement configv2, types, and tests

### DIFF
--- a/pkg/configv2/config.go
+++ b/pkg/configv2/config.go
@@ -1,0 +1,171 @@
+package configv2
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	environmentVariablePrefix = "BACALHAU"
+	inferConfigTypes          = true
+)
+
+var (
+	environmentVariableReplace = strings.NewReplacer(".", "_")
+	DecoderHook                = viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc())
+)
+
+type Configurable interface {
+	Validate() error
+}
+
+type Config[C Configurable] struct {
+	// viper instance for holding user provided configuration.
+	base *viper.Viper
+	// the default configuration values to initialize with.
+	defaultCfg C
+
+	// paths to configuration files merged from [0] to [N]
+	// e.g. file at index 1 overrides index 0, index 2 overrides index 1 and 0, etc.
+	paths []string
+
+	flags map[string]*pflag.Flag
+
+	environmentVariables map[string][]string
+
+	// values to inject into the config, taking highest precedence.
+	values map[string]any
+}
+
+type Option = func(s *Config[Configurable])
+
+// WithDefault sets the default config to be used when no values are provided.
+func WithDefault(cfg Configurable) Option {
+	return func(c *Config[Configurable]) {
+		c.defaultCfg = cfg
+	}
+}
+
+// WithPaths sets paths to configuration files to be loaded
+// paths to configuration files merged from [0] to [N]
+// e.g. file at index 1 overrides index 0, index 2 overrides index 1 and 0, etc.
+func WithPaths(path ...string) Option {
+	return func(c *Config[Configurable]) {
+		c.paths = append(c.paths, path...)
+	}
+}
+
+func WithFlags(flags map[string]*pflag.Flag) Option {
+	return func(s *Config[Configurable]) {
+		s.flags = flags
+	}
+}
+
+func WithEnvironmentVariables(ev map[string][]string) Option {
+	return func(s *Config[Configurable]) {
+		s.environmentVariables = ev
+	}
+}
+
+// WithValues sets values to be injected into the config, taking precedence over all other options.
+func WithValues(values map[string]any) Option {
+	return func(c *Config[Configurable]) {
+		c.values = values
+	}
+}
+
+// New returns a configuration with the provided options applied. If no options are provided, the returned config
+// contains only the default values.
+func New(opts ...Option) (*Config[Configurable], error) {
+	base := viper.New()
+	base.SetEnvPrefix(environmentVariablePrefix)
+	base.SetTypeByDefaultValue(inferConfigTypes)
+	base.AutomaticEnv()
+	base.SetEnvKeyReplacer(environmentVariableReplace)
+
+	c := &Config[Configurable]{
+		base:       base,
+		defaultCfg: Default,
+		paths:      make([]string, 0),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	var defaultMap map[string]interface{}
+	err := mapstructure.Decode(c.defaultCfg, &defaultMap)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.base.MergeConfigMap(defaultMap); err != nil {
+		return nil, err
+	}
+
+	// merge the config files in the order they were passed.
+	for _, path := range c.paths {
+		if err := c.Merge(path); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("the specified configuration file %q doesn't exist", path)
+			}
+			return nil, fmt.Errorf("opening config file %q: %w", path, err)
+		}
+	}
+
+	for name, values := range c.environmentVariables {
+		if err := c.base.BindEnv(append([]string{name}, values...)...); err != nil {
+			return nil, fmt.Errorf("binding environment variable %q to config: %w", name, err)
+		}
+	}
+
+	for name, flag := range c.flags {
+		if err := c.base.BindPFlag(name, flag); err != nil {
+			return nil, fmt.Errorf("binding flag %q to config: %w", name, err)
+		}
+	}
+
+	// merge the passed values last as they take highest precedence
+	for name, value := range c.values {
+		c.base.Set(name, value)
+	}
+
+	return c, nil
+}
+
+// Load reads in the configuration file specified by `path` overriding any previously set configuration with the values
+// from the read config file.
+// Load returns an error if the file cannot be read.
+func (c *Config[C]) Load(path string) error {
+	log.Debug().Msgf("loading config file: %q", path)
+	c.base.SetConfigFile(path)
+	if err := c.base.ReadInConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Merge merges a new configuration file specified by `path` with the existing config.
+// Merge returns an error if the file cannot be read
+func (c *Config[C]) Merge(path string) error {
+	log.Debug().Msgf("loading config file: %q", path)
+	c.base.SetConfigFile(path)
+	if err := c.base.MergeInConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Current returns the current configuration.
+// Current returns an error if the configuration cannot be unmarshalled.
+func (c *Config[C]) Unmarshal(out C) error {
+	if err := c.base.Unmarshal(&out, DecoderHook); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/configv2/config_test.go
+++ b/pkg/configv2/config_test.go
@@ -1,0 +1,599 @@
+//go:build unit || !integration
+
+package configv2_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bacalhau-project/bacalhau/pkg/configv2"
+	"github.com/bacalhau-project/bacalhau/pkg/configv2/types"
+)
+
+func TestConfigWithDefaults(t *testing.T) {
+	expected := configv2.Default
+
+	cfg, err := configv2.New(
+		configv2.WithDefault(expected),
+	)
+	require.NoError(t, err)
+
+	var actual types.Bacalhau
+	err = cfg.Unmarshal(&actual)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestConfigWithValueOverrides(t *testing.T) {
+	overrideRepo := "overrideRepo"
+	overrideName := "overrideName"
+	overrideClientAddress := "overrideAddress"
+	overrideClientCert := "overrideCert"
+
+	defaultConfig := types.Bacalhau{
+		Repo: "defaultRepo",
+		Name: "defaultName",
+		Client: types.Client{
+			Address:     "defaultAddress",
+			Certificate: "defaultCert",
+		},
+	}
+	overrideValues := map[string]any{
+		"repo":               overrideRepo,
+		"name":               overrideName,
+		"client.address":     overrideClientAddress,
+		"client.certificate": overrideClientCert,
+	}
+
+	cfg, err := configv2.New(
+		configv2.WithDefault(defaultConfig),
+		configv2.WithValues(overrideValues),
+	)
+	require.NoError(t, err)
+
+	var actual types.Bacalhau
+	err = cfg.Unmarshal(&actual)
+	require.NoError(t, err)
+
+	assert.Equal(t, overrideRepo, actual.Repo)
+	assert.Equal(t, overrideName, actual.Name)
+	assert.Equal(t, overrideClientAddress, actual.Client.Address)
+	assert.Equal(t, overrideClientCert, actual.Client.Certificate)
+	assert.Empty(t, actual.Server)
+	assert.Empty(t, actual.Orchestrator)
+	assert.Empty(t, actual.Compute)
+	assert.Empty(t, actual.Telemetry)
+}
+
+type TestConfig struct {
+	StringValue string
+	IntValue    int
+	BoolValue   bool
+}
+
+func (c TestConfig) Validate() error {
+	return nil
+}
+
+func TestNew(t *testing.T) {
+	t.Run("Default Configuration", func(t *testing.T) {
+		cfg, err := configv2.New(configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    42,
+			BoolValue:   true,
+		}))
+		require.NoError(t, err)
+
+		var testCfg TestConfig
+		err = cfg.Unmarshal(&testCfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "default", testCfg.StringValue)
+		assert.Equal(t, 42, testCfg.IntValue)
+		assert.True(t, testCfg.BoolValue)
+	})
+
+	t.Run("With Configuration File", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "config*.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tempFile.Name())
+
+		_, err = tempFile.WriteString(`
+stringValue: "from_file"
+intValue: 100
+boolValue: false
+`)
+		require.NoError(t, err)
+		tempFile.Close()
+
+		cfg, err := configv2.New(
+			configv2.WithDefault(TestConfig{
+				StringValue: "default",
+				IntValue:    42,
+				BoolValue:   true,
+			}),
+			configv2.WithPaths(tempFile.Name()),
+		)
+		require.NoError(t, err)
+
+		var testCfg TestConfig
+		err = cfg.Unmarshal(&testCfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "from_file", testCfg.StringValue)
+		assert.Equal(t, 100, testCfg.IntValue)
+		assert.False(t, testCfg.BoolValue)
+	})
+
+	t.Run("With Flags", func(t *testing.T) {
+		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flagSet.String("stringValue", "default", "test string value")
+		flagSet.Int("intValue", 42, "test int value")
+		flagSet.Bool("boolValue", true, "test bool value")
+
+		err := flagSet.Parse([]string{"--stringValue=from_flag", "--intValue=200", "--boolValue=false"})
+		require.NoError(t, err)
+
+		flags := make(map[string]*pflag.Flag)
+		flagSet.VisitAll(func(f *pflag.Flag) {
+			flags[f.Name] = f
+		})
+
+		cfg, err := configv2.New(
+			configv2.WithDefault(TestConfig{
+				StringValue: "default",
+				IntValue:    42,
+				BoolValue:   true,
+			}),
+			configv2.WithFlags(flags),
+		)
+		require.NoError(t, err)
+
+		var testCfg TestConfig
+		err = cfg.Unmarshal(&testCfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "from_flag", testCfg.StringValue)
+		assert.Equal(t, 200, testCfg.IntValue)
+		assert.False(t, testCfg.BoolValue)
+	})
+
+	t.Run("With Environment Variables", func(t *testing.T) {
+		os.Setenv("BACALHAU_STRING_VALUE", "from_env")
+		os.Setenv("BACALHAU_INT_VALUE", "300")
+		os.Setenv("BACALHAU_BOOL_VALUE", "true")
+		defer func() {
+			os.Unsetenv("BACALHAU_STRING_VALUE")
+			os.Unsetenv("BACALHAU_INT_VALUE")
+			os.Unsetenv("BACALHAU_BOOL_VALUE")
+		}()
+
+		envVars := map[string][]string{
+			"stringValue": {"BACALHAU_STRING_VALUE"},
+			"intValue":    {"BACALHAU_INT_VALUE"},
+			"boolValue":   {"BACALHAU_BOOL_VALUE"},
+		}
+
+		cfg, err := configv2.New(
+			configv2.WithDefault(TestConfig{
+				StringValue: "default",
+				IntValue:    42,
+				BoolValue:   false,
+			}),
+			configv2.WithEnvironmentVariables(envVars),
+		)
+		require.NoError(t, err)
+
+		var testCfg TestConfig
+		err = cfg.Unmarshal(&testCfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "from_env", testCfg.StringValue)
+		assert.Equal(t, 300, testCfg.IntValue)
+		assert.True(t, testCfg.BoolValue)
+	})
+
+	t.Run("With Values", func(t *testing.T) {
+		values := map[string]interface{}{
+			"stringValue": "from_values",
+			"intValue":    400,
+			"boolValue":   false,
+		}
+
+		cfg, err := configv2.New(
+			configv2.WithDefault(TestConfig{
+				StringValue: "default",
+				IntValue:    42,
+				BoolValue:   true,
+			}),
+			configv2.WithValues(values),
+		)
+		require.NoError(t, err)
+
+		var testCfg TestConfig
+		err = cfg.Unmarshal(&testCfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "from_values", testCfg.StringValue)
+		assert.Equal(t, 400, testCfg.IntValue)
+		assert.False(t, testCfg.BoolValue)
+	})
+}
+
+func TestLoad(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "config*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString(`
+stringValue: "loaded"
+intValue: 500
+boolValue: true
+`)
+	require.NoError(t, err)
+	tempFile.Close()
+
+	cfg, err := configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    42,
+			BoolValue:   false,
+		}),
+	)
+	require.NoError(t, err)
+
+	err = cfg.Load(tempFile.Name())
+	require.NoError(t, err)
+
+	var testCfg TestConfig
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "loaded", testCfg.StringValue)
+	assert.Equal(t, 500, testCfg.IntValue)
+	assert.True(t, testCfg.BoolValue)
+}
+
+func TestMerge(t *testing.T) {
+	tempFile1, err := os.CreateTemp("", "config1*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tempFile1.Name())
+
+	_, err = tempFile1.WriteString(`
+stringValue: "first"
+intValue: 100
+`)
+	require.NoError(t, err)
+	tempFile1.Close()
+
+	tempFile2, err := os.CreateTemp("", "config2*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tempFile2.Name())
+
+	_, err = tempFile2.WriteString(`
+intValue: 200
+boolValue: true
+`)
+	require.NoError(t, err)
+	tempFile2.Close()
+
+	cfg, err := configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    42,
+			BoolValue:   false,
+		}),
+		configv2.WithPaths(tempFile1.Name()),
+	)
+	require.NoError(t, err)
+
+	err = cfg.Merge(tempFile2.Name())
+	require.NoError(t, err)
+
+	var testCfg TestConfig
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "first", testCfg.StringValue)
+	assert.Equal(t, 200, testCfg.IntValue)
+	assert.True(t, testCfg.BoolValue)
+}
+
+func TestConfigurationPrecedence(t *testing.T) {
+	// Create a temporary config file
+	tempFile, err := os.CreateTemp("", "config*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString(`
+stringValue: "from_file"
+intValue: 100
+boolValue: false
+`)
+	require.NoError(t, err)
+	tempFile.Close()
+
+	// Set up environment variables
+	os.Setenv("BACALHAU_STRING_VALUE", "from_env")
+	os.Setenv("BACALHAU_INT_VALUE", "200")
+	os.Setenv("BACALHAU_BOOL_VALUE", "true")
+	defer func() {
+		os.Unsetenv("BACALHAU_STRING_VALUE")
+		os.Unsetenv("BACALHAU_INT_VALUE")
+		os.Unsetenv("BACALHAU_BOOL_VALUE")
+	}()
+
+	// Set up flags
+	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flagSet.String("stringValue", "", "test string value")
+	flagSet.Int("intValue", 0, "test int value")
+	flagSet.Bool("boolValue", false, "test bool value")
+
+	err = flagSet.Parse([]string{"--stringValue=from_flag", "--intValue=300", "--boolValue=false"})
+	require.NoError(t, err)
+
+	flags := make(map[string]*pflag.Flag)
+	flagSet.VisitAll(func(f *pflag.Flag) {
+		flags[f.Name] = f
+	})
+
+	// Set up explicit values
+	values := map[string]interface{}{
+		"stringValue": "from_values",
+		"intValue":    400,
+		"boolValue":   true,
+	}
+
+	// Create the configuration
+	cfg, err := configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    50,
+			BoolValue:   false,
+		}),
+		configv2.WithPaths(tempFile.Name()),
+		configv2.WithEnvironmentVariables(map[string][]string{
+			"stringValue": {"BACALHAU_STRING_VALUE"},
+			"intValue":    {"BACALHAU_INT_VALUE"},
+			"boolValue":   {"BACALHAU_BOOL_VALUE"},
+		}),
+		configv2.WithFlags(flags),
+		configv2.WithValues(values),
+	)
+	require.NoError(t, err)
+
+	var testCfg TestConfig
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	// Assert the final configuration values
+	assert.Equal(t, "from_values", testCfg.StringValue, "StringValue should be overridden by explicit values")
+	assert.Equal(t, 400, testCfg.IntValue, "IntValue should be overridden by explicit values")
+	assert.True(t, testCfg.BoolValue, "BoolValue should be overridden by explicit values")
+
+	// Now, let's remove the explicit values and check the precedence of flags
+	cfg, err = configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    50,
+			BoolValue:   false,
+		}),
+		configv2.WithPaths(tempFile.Name()),
+		configv2.WithEnvironmentVariables(map[string][]string{
+			"stringValue": {"BACALHAU_STRING_VALUE"},
+			"intValue":    {"BACALHAU_INT_VALUE"},
+			"boolValue":   {"BACALHAU_BOOL_VALUE"},
+		}),
+		configv2.WithFlags(flags),
+	)
+	require.NoError(t, err)
+
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from_flag", testCfg.StringValue, "StringValue should be overridden by flags")
+	assert.Equal(t, 300, testCfg.IntValue, "IntValue should be overridden by flags")
+	assert.False(t, testCfg.BoolValue, "BoolValue should be overridden by flags")
+
+	// Remove flags and check precedence of environment variables
+	cfg, err = configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    50,
+			BoolValue:   false,
+		}),
+		configv2.WithPaths(tempFile.Name()),
+		configv2.WithEnvironmentVariables(map[string][]string{
+			"stringValue": {"BACALHAU_STRING_VALUE"},
+			"intValue":    {"BACALHAU_INT_VALUE"},
+			"boolValue":   {"BACALHAU_BOOL_VALUE"},
+		}),
+	)
+	require.NoError(t, err)
+
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from_env", testCfg.StringValue, "StringValue should be overridden by environment variables")
+	assert.Equal(t, 200, testCfg.IntValue, "IntValue should be overridden by environment variables")
+	assert.True(t, testCfg.BoolValue, "BoolValue should be overridden by environment variables")
+
+	// Remove environment variables and check precedence of configuration file
+	os.Unsetenv("BACALHAU_STRING_VALUE")
+	os.Unsetenv("BACALHAU_INT_VALUE")
+	os.Unsetenv("BACALHAU_BOOL_VALUE")
+
+	cfg, err = configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    50,
+			BoolValue:   true,
+		}),
+		configv2.WithPaths(tempFile.Name()),
+	)
+	require.NoError(t, err)
+
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from_file", testCfg.StringValue, "StringValue should be overridden by configuration file")
+	assert.Equal(t, 100, testCfg.IntValue, "IntValue should be overridden by configuration file")
+	assert.False(t, testCfg.BoolValue, "BoolValue should be overridden by configuration file")
+
+	// Finally, check default values
+	cfg, err = configv2.New(
+		configv2.WithDefault(TestConfig{
+			StringValue: "default",
+			IntValue:    50,
+			BoolValue:   true,
+		}),
+	)
+	require.NoError(t, err)
+
+	err = cfg.Unmarshal(&testCfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", testCfg.StringValue, "StringValue should be set to default")
+	assert.Equal(t, 50, testCfg.IntValue, "IntValue should be set to default")
+	assert.True(t, testCfg.BoolValue, "BoolValue should be set to default")
+}
+
+type LargeConfig struct {
+	Database struct {
+		Host     string
+		Port     int
+		Username string
+		Password string
+	}
+	Server struct {
+		Host string
+		Port int
+	}
+	Logging struct {
+		Level  string
+		Format string
+	}
+}
+
+func (c LargeConfig) Validate() error {
+	return nil
+}
+
+type DatabaseConfig struct {
+	Database struct {
+		Host     string
+		Port     int
+		Username string
+		Password string
+	}
+}
+
+func (c DatabaseConfig) Validate() error {
+	return nil
+}
+
+type ServerLoggingConfig struct {
+	Server struct {
+		Host string
+		Port int
+	}
+	Logging struct {
+		Level string
+	}
+}
+
+func (c ServerLoggingConfig) Validate() error {
+	return nil
+}
+
+type ExtendedServerConfig struct {
+	Server struct {
+		Host    string
+		Port    int
+		Timeout int // This field is not in the original config
+	}
+}
+
+func (c ExtendedServerConfig) Validate() error {
+	return nil
+}
+
+// TestUnmarshalSubset tests that config.Unmarshal works correctly with subsets of a larger configuration
+func TestUnmarshalSubset(t *testing.T) {
+
+	// Create a temporary config file with all settings
+	tempFile, err := os.CreateTemp("", "large_config*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString(`
+database:
+  host: "localhost"
+  port: 5432
+  username: "user"
+  password: "password"
+server:
+  host: "0.0.0.0"
+  port: 8080
+logging:
+  level: "info"
+  format: "json"
+`)
+	require.NoError(t, err)
+	tempFile.Close()
+
+	// Create the configuration
+	cfg, err := configv2.New(
+		configv2.WithPaths(tempFile.Name()),
+	)
+	require.NoError(t, err)
+
+	// Test unmarshaling the entire configuration
+	var fullConfig LargeConfig
+	err = cfg.Unmarshal(&fullConfig)
+	require.NoError(t, err)
+	require.NoError(t, fullConfig.Validate())
+
+	assert.Equal(t, "localhost", fullConfig.Database.Host)
+	assert.Equal(t, 5432, fullConfig.Database.Port)
+	assert.Equal(t, "user", fullConfig.Database.Username)
+	assert.Equal(t, "password", fullConfig.Database.Password)
+	assert.Equal(t, "0.0.0.0", fullConfig.Server.Host)
+	assert.Equal(t, 8080, fullConfig.Server.Port)
+	assert.Equal(t, "info", fullConfig.Logging.Level)
+	assert.Equal(t, "json", fullConfig.Logging.Format)
+
+	// dbConfig is a subset, ensure we can unmarshal into it.
+	var dbConfig DatabaseConfig
+	err = cfg.Unmarshal(&dbConfig)
+	require.NoError(t, err)
+	require.NoError(t, dbConfig.Validate())
+
+	assert.Equal(t, "localhost", dbConfig.Database.Host)
+	assert.Equal(t, 5432, dbConfig.Database.Port)
+	assert.Equal(t, "user", dbConfig.Database.Username)
+	assert.Equal(t, "password", dbConfig.Database.Password)
+
+	var slConfig ServerLoggingConfig
+	err = cfg.Unmarshal(&slConfig)
+	require.NoError(t, err)
+	require.NoError(t, slConfig.Validate())
+
+	assert.Equal(t, "0.0.0.0", slConfig.Server.Host)
+	assert.Equal(t, 8080, slConfig.Server.Port)
+	assert.Equal(t, "info", slConfig.Logging.Level)
+
+	var extConfig ExtendedServerConfig
+	err = cfg.Unmarshal(&extConfig)
+	require.NoError(t, err)
+	require.NoError(t, extConfig.Validate())
+
+	assert.Equal(t, "0.0.0.0", extConfig.Server.Host)
+	assert.Equal(t, 8080, extConfig.Server.Port)
+	assert.Zero(t, extConfig.Server.Timeout, "Timeout should be zero as it's not in the original config")
+}

--- a/pkg/configv2/default.go
+++ b/pkg/configv2/default.go
@@ -1,0 +1,92 @@
+package configv2
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/configv2/types"
+)
+
+var Default = types.Bacalhau{
+	Repo: "~/.bacalhau",
+	Name: "",
+	Client: types.Client{
+		Address: "http://0.0.0.0:1234",
+	},
+	Server: types.Server{
+		Address: "0.0.0.0",
+		Port:    1234,
+		TLS:     types.TLS{},
+		Auth: types.AuthConfig{
+			Methods: map[string]types.AuthenticatorConfig{
+				"ClientKey": {
+					Type: "challenge",
+				},
+			},
+		},
+	},
+	Orchestrator: types.Orchestrator{
+		Enabled:   true,
+		Listen:    "0.0.0.0",
+		Port:      4222,
+		Advertise: "0.0.0.0",
+		NodeManager: types.NodeManager{
+			DisconnectTimeout: types.Duration(time.Second * 30),
+			AutoApprove:       true,
+		},
+		Scheduler: types.Scheduler{
+			Workers:              runtime.NumCPU(),
+			HousekeepingInterval: types.Duration(time.Second * 30),
+			HousekeepingTimeout:  types.Duration(time.Minute * 2),
+		},
+		Broker: types.EvaluationBroker{
+			VisibilityTimeout: types.Duration(time.Minute),
+			MaxRetries:        10,
+		},
+	},
+	Compute: types.Compute{
+		Enabled:       true,
+		Orchestrators: []string{"0.0.0.0:4222"},
+		Heartbeat: types.Heartbeat{
+			MessageInterval:  types.Duration(time.Second * 30),
+			ResourceInterval: types.Duration(time.Second * 30),
+			InfoInterval:     types.Duration(time.Second * 30),
+		},
+		Capacity: types.Capacity{
+			Allocated: types.ResourceScaler{
+				CPU:    "80%",
+				Memory: "80%",
+				Disk:   "80%",
+				GPU:    "100%",
+			},
+		},
+		Storages: types.Storage{
+			HTTP: types.HTTPStorage{
+				Enabled: true,
+			},
+		},
+		Engines: types.Engine{
+			Docker: types.Docker{
+				Enabled: true,
+				ManifestCache: types.DockerManifestCache{
+					Size:    5 << 30, // 5GB
+					TTL:     types.Duration(time.Hour * 24),
+					Refresh: types.Duration(time.Hour * 24),
+				},
+			},
+			WASM: types.WASM{
+				Enabled: true,
+			},
+		},
+		Policy: types.SelectionPolicy{
+			Networked: true,
+			Local:     false,
+		},
+	},
+	Telemetry: types.Telemetry{
+		Logging: types.Logging{
+			Level:  "info",
+			Format: "console",
+		},
+	},
+}

--- a/pkg/configv2/types/auth.go
+++ b/pkg/configv2/types/auth.go
@@ -1,0 +1,42 @@
+package types
+
+// AuthenticatorConfig is config for a specific named authentication method,
+// specifying the type of authentication and the path to a policy file that
+// controls the method. Some implementation types may require policies that meet
+// a certain interface beyond the default – see the documentation on that type
+// for more info.
+type AuthenticatorConfig struct {
+	Type       string `yaml:"Type,omitempty"`
+	PolicyPath string `yaml:"PolicyPath,omitempty"`
+}
+
+// AuthConfig is config that controls user authentication and authorization.
+type AuthConfig struct {
+	// TokensPath is the location where a state file of tokens will be stored.
+	// By default it will be local to the Bacalhau repo, but can be any location
+	// in the host filesystem. Tokens are sensitive and should be stored in a
+	// location that is only readable to the current user.
+	TokensPath string `yaml:"TokensPath,omitempty"`
+
+	// Methods maps "method names" to authenticator implementations. A method
+	// name is a human-readable string chosen by the person configuring the
+	// system that is shown to users to help them pick the authentication method
+	// they want to use. There can be multiple usages of the same Authenticator
+	// *type* but with different configs and parameters, each identified with a
+	// unique method name.
+	//
+	// For example, if an implementation wants to allow users to log in with
+	// Github or Bitbucket, they might both use an authenticator implementation
+	// of type "oidc", and each would appear once on this provider with key /
+	// method name "github" and "bitbucket".
+	//
+	// By default, only a single authentication method that accepts
+	// authentication via client keys will be enabled.
+	Methods map[string]AuthenticatorConfig `yaml:"Methods,omitempty"`
+
+	// AccessPolicyPath is the path to a file or directory that will be loaded as
+	// the policy to apply to all inbound API requests. If unspecified, a policy
+	// that permits access to all API endpoints to both authenticated and
+	// unauthenticated users (the default as of v1.2.0) will be used.
+	AccessPolicyPath string `yaml:"AccessPolicyPath,omitempty"`
+}

--- a/pkg/configv2/types/bacalhau.go
+++ b/pkg/configv2/types/bacalhau.go
@@ -1,0 +1,65 @@
+package types
+
+// Bacalhau represents the configuration for the Bacalhau system,
+// including client, server, orchestrator, compute service, and telemetry settings.
+type Bacalhau struct {
+	// Repo specifies a path on the filesystem where Bacalhau will persist its state.
+	Repo string `yaml:"Repo,omitempty"`
+	// Name specifies the name the Bacalhau node will advertise on the network.
+	Name string `yaml:"Name,omitempty"`
+	// Client specifies the configuration of the Bacalhau client.
+	Client Client `yaml:"Client,omitempty"`
+	// Server specifies the configuration of the Bacalhau server.
+	Server Server `yaml:"Server,omitempty"`
+	// Orchestrator specifies the configuration of the Bacalhau orchestration service.
+	Orchestrator Orchestrator `yaml:"Orchestrator,omitempty"`
+	// Compute specifies the configuration of the Bacalhau compute service.
+	Compute Compute `yaml:"Compute,omitempty"`
+	// Telemetry specifies the configuration of the Bacalhau node's telemetry system.
+	Telemetry Telemetry `yaml:"Telemetry,omitempty"`
+}
+
+func (b Bacalhau) Validate() error {
+	//TODO implement me
+	return nil
+}
+
+// Server represents the configuration settings for the Bacalhau server.
+type Server struct {
+	// Address specifies the endpoint Bacalhau will serve on.
+	Address string `yaml:"Address,omitempty"`
+	// Port specifies the port Bacalhau will serve on.
+	Port int `yaml:"Port,omitempty"`
+	// TLS specifies the TLS configuration for the server.
+	TLS TLS `yaml:"TLS,omitempty"`
+	// Auth specifies configuration for authorization and authentication.
+	Auth AuthConfig `yaml:"Auth,omitempty"`
+}
+
+// Client represents the configuration settings for the Bacalhau client.
+type Client struct {
+	// Address specifies the endpoint the Bacalhau client will connect to a Bacalhau API on.
+	Address string `yaml:"Address,omitempty"`
+	// Certificate specifies the path of a certificate file (primarily for self-signed server certs) the client will use for API requests.
+	Certificate string `yaml:"Certificate,omitempty"`
+	// Insecure when true instructs the client not to verify the certificate of the server.
+	Insecure bool `yaml:"Insecure,omitempty"`
+}
+
+// WebUI represents the configuration settings for the Bacalhau WebUI.
+type WebUI struct {
+	// Enabled when true enables the WebUI on the Bacalhau node.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Server specifies the configuration of the server for the WebUI.
+	Server Server `yaml:"Server,omitempty"`
+}
+
+// JobDownloaders represents the configuration settings for job downloaders in Bacalhau.
+type JobDownloaders struct {
+	// Timeout specifies the duration after which job downloads will time out.
+	Timeout Duration `yaml:"Timeout,omitempty"`
+	// IPFS specifies the configuration for the IPFS job downloader.
+	IPFS IPFSStorage `yaml:"IPFS,omitempty"`
+	// S3 specifies the configuration for the S3 job downloader.
+	S3 S3Storage `yaml:"S3,omitempty"`
+}

--- a/pkg/configv2/types/compute.go
+++ b/pkg/configv2/types/compute.go
@@ -1,0 +1,53 @@
+package types
+
+// Compute represents the configuration for the compute service on the Bacalhau node.
+// It includes settings for enabling the service, connecting to orchestrators, TLS, heartbeat, store, capacity, and more.
+type Compute struct {
+	// Enabled when set to true will enable the compute service on the Bacalhau node.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Orchestrators specifies a list of orchestrators the compute node will connect to.
+	Orchestrators []string `yaml:"Orchestrators,omitempty"`
+	// TLS specifies the TLS configuration used to connect to orchestrators.
+	TLS TLS `yaml:"TLS,omitempty"`
+	// Labels specifies a map of key value pairs the compute node will advertise to orchestrators.
+	Labels map[string]string `yaml:"Labels,omitempty"`
+	// Heartbeat specifies the compute node's heartbeat configuration.
+	Heartbeat Heartbeat `yaml:"Heartbeat,omitempty"`
+	// Capacity specifies the compute node's capacity configuration.
+	Capacity Capacity `yaml:"Capacity,omitempty"`
+	// Publishers specifies the configuration of publishers the compute node provides.
+	Publishers Publisher `yaml:"Publishers,omitempty"`
+	// Storages specifies the configuration of storages the compute node provides.
+	Storages Storage `yaml:"Storages,omitempty"`
+	// Engines specifies the configuration of engines the compute node provides.
+	Engines Engine `yaml:"Engines,omitempty"`
+	// Policy specifies the configuration of the compute node's job selection policy.
+	Policy SelectionPolicy `yaml:"Policy,omitempty"`
+}
+
+// Heartbeat represents the configuration settings for the compute node's heartbeat messages.
+type Heartbeat struct {
+	// MessageInterval specifies the duration at which the compute node sends heartbeat messages to the orchestrators.
+	MessageInterval Duration `yaml:"MessageInterval,omitempty"`
+	// ResourceInterval specifies the duration at which the compute node sends resource messages to the orchestrators.
+	ResourceInterval Duration `yaml:"ResourceInterval,omitempty"`
+	// InfoInterval specifies the duration at which the compute node sends info messages to the orchestrators.
+	InfoInterval Duration `yaml:"InfoInterval,omitempty"`
+}
+
+// Capacity represents the capacity configuration settings for the compute node.
+type Capacity struct {
+	// Total when specified overrides the auto-detected capacity of the compute node.
+	// When provided, the Allocated capacity will be ignored.
+	Total Resource `yaml:"Total,omitempty"`
+	// Allocated specifies the percentage of the total capacity that can be allocated to jobs on the compute node.
+	Allocated ResourceScaler `yaml:"Allocated,omitempty"`
+}
+
+// SelectionPolicy represents the job selection policy configuration for the compute node.
+type SelectionPolicy struct {
+	// Networked when set to true allows the compute node to accept jobs requiring network access.
+	Networked bool `yaml:"Networked,omitempty"`
+	// Local when set to true instructs the compute node to only accept jobs whose inputs it has locally.
+	Local bool `yaml:"Local,omitempty"`
+}

--- a/pkg/configv2/types/duration.go
+++ b/pkg/configv2/types/duration.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"time"
+)
+
+// Duration is a wrapper type for time.Duration
+// for decoding and encoding from/to YAML, etc.
+type Duration time.Duration
+
+// UnmarshalText implements interface for YAML decoding
+func (dur *Duration) UnmarshalText(text []byte) error {
+	d, err := time.ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+	*dur = Duration(d)
+	return err
+}
+
+func (dur Duration) MarshalText() ([]byte, error) {
+	d := time.Duration(dur)
+	return []byte(d.String()), nil
+}
+
+func (dur Duration) String() string {
+	return time.Duration(dur).String()
+}
+
+/*
+AsTimeDuration returns Duration as a time.Duration type.
+It is only called in the code gen to set viper defaults.
+This method exists for the following reasons:
+ 1. our config file is yaml, and we want to use durations for configuring things, printed in a human-readable format.
+ 2. time.Duration does not, and will not implement MarshalText/UnmarshalText
+    - https://github.com/golang/go/issues/16039
+ 3. viper.GetDuration doesn't return an error, and instead returns `0` if it fails to cast
+    - https://github.com/spf13/viper/blob/master/viper.go#L1048
+    - https://github.com/spf13/cast/blob/master/caste.go#L61
+    viper.GetDuration is unable to cast a types.Duration to a time.Duration (see second link), so it returns 0.
+
+To meet the 3 constraints above we write durations into viper as a time.Duration, but cast them
+to a types.Duration when they are added to our config structure. This allows us to:
+1. Have human-readable times in out config file.
+2. Have type safety on out cli, i.e. config set <duration_key> 10s
+3. Return durations instead of `0` from viper.GetDuration.
+*/
+func (dur Duration) AsTimeDuration() time.Duration {
+	return time.Duration(dur)
+}

--- a/pkg/configv2/types/engine.go
+++ b/pkg/configv2/types/engine.go
@@ -1,0 +1,35 @@
+package types
+
+type Engine struct {
+	// Docker is the configuration for the Docker runtime provider.
+	Docker Docker `yaml:"Docker,omitempty"`
+	// WASM is the configuration for the WASM runtime provider.
+	WASM WASM `yaml:"WASM,omitempty"`
+}
+
+// Docker represents the configuration settings for the Docker runtime provider.
+type Docker struct {
+	// Enabled specifies whether the Docker provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// TODO the docker engine doesn't permit this field to be configured yet.
+	// Endpoint specifies the endpoint URI for the Docker daemon.
+	// Endpoint string `yaml:"Endpoint,omitempty"`
+	// ManifestCache specifies the settings for the Docker manifest cache.
+	ManifestCache DockerManifestCache `yaml:"ManifestCache,omitempty"`
+}
+
+// DockerManifestCache represents the configuration settings for the Docker manifest cache.
+type DockerManifestCache struct {
+	// Size specifies the size of the Docker manifest cache.
+	Size uint64 `yaml:"Size,omitempty"`
+	// TTL specifies the time-to-live duration for cache entries.
+	TTL Duration `yaml:"TTL,omitempty"`
+	// Refresh specifies the refresh interval for cache entries.
+	Refresh Duration `yaml:"Refresh,omitempty"`
+}
+
+// WASM represents the configuration settings for the WASM runtime provider.
+type WASM struct {
+	// Enabled specifies whether the WASM provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+}

--- a/pkg/configv2/types/gc.go
+++ b/pkg/configv2/types/gc.go
@@ -1,0 +1,8 @@
+package types
+
+type TimeGC struct {
+	// Threshold specifies the duration that data must exist before it becomes eligible for garbage collection.
+	Threshold Duration `yaml:"Threshold,omitempty"`
+	// Interval specifies the frequency at which the garbage collection process runs.
+	Interval Duration `yaml:"Interval,omitempty"`
+}

--- a/pkg/configv2/types/orchestrator.go
+++ b/pkg/configv2/types/orchestrator.go
@@ -1,0 +1,71 @@
+package types
+
+// Orchestrator represents the configuration for the orchestration service on the Bacalhau node.
+// It includes settings for enabling the service, network endpoints, TLS configuration, and various subsystems.
+type Orchestrator struct {
+	// Enabled specifies whether the orchestration service is enabled on the Bacalhau node.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Listen specifies the address the orchestration service will listen on for connections from compute nodes.
+	Listen string `yaml:"Listen,omitempty"`
+	// Port specifies the port the orchestration service will listen for connections from compute nodes.
+	Port int `yaml:"Port,omitempty"`
+	// Advertise specifies the endpoint the orchestration service will advertise to the network for connections from compute nodes.
+	Advertise string `yaml:"Advertise,omitempty"`
+	// AuthSecret is a secret string that clients must use to connect. NATS servers
+	// must supply this value, while clients can also supply it as the user part
+	// of their Orchestrator URL.
+	AuthSecret string `yaml:"AuthSecret,omitempty"`
+	// TLS specifies the TLS configuration of the orchestration service.
+	TLS TLS `yaml:"TLS,omitempty"`
+	// Cluster specifies the cluster configuration of the orchestration service.
+	Cluster Cluster `yaml:"Cluster,omitempty"`
+	// NodeManager specifies the node manager configuration of the orchestration service.
+	NodeManager NodeManager `yaml:"NodeManager,omitempty"`
+	// Scheduler specifies the scheduler configuration of the orchestration service.
+	Scheduler Scheduler `yaml:"Scheduler,omitempty"`
+	// Broker specifies the evaluation broker configuration of the orchestration service.
+	Broker EvaluationBroker `yaml:"Broker,omitempty"`
+}
+
+// Cluster represents the configuration settings for the orchestration service NATs cluster.
+type Cluster struct {
+	// Name specifies the name of the cluster the orchestration service will connect to.
+	Name string `yaml:"Name,omitempty"`
+	// Listen specifies the address the orchestration service will listen on for connections from other orchestration services.
+	Listen string `yaml:"Listen,omitempty"`
+	// Port specifies the port the orchestration service will listen on for connections from other orchestration services.
+	Port int `yaml:"Port,omitempty"`
+	// Advertise specifies the endpoint the orchestration service will advertise to the network for connections from other orchestration services.
+	Advertise string `yaml:"Advertise,omitempty"`
+	// Peers specifies the list of peer orchestration services.
+	Peers []string `yaml:"Peers,omitempty"`
+	// TLS specifies the TLS configuration for connections from orchestration services.
+	TLS TLS `yaml:"TLS,omitempty"`
+}
+
+// NodeManager represents the configuration settings for the node manager within the orchestration service.
+type NodeManager struct {
+	// DisconnectTimeout specifies the duration after which nodes will be considered disconnected if no heartbeat message is received.
+	DisconnectTimeout Duration `yaml:"DisconnectTimeout,omitempty"`
+	// AutoApprove specifies whether to automatically approve a node's membership when a connection is established.
+	// When set to false, sets a node's approval status to 'pending' when a connection is established.
+	AutoApprove bool `yaml:"AutoApprove,omitempty"`
+}
+
+// Scheduler represents the configuration settings for the scheduler within the orchestration service.
+type Scheduler struct {
+	// Workers specifies the number of workers the scheduler will run.
+	Workers int `yaml:"Workers,omitempty"`
+	// HousekeepingInterval specifies the interval at which housekeeping tasks are performed.
+	HousekeepingInterval Duration `yaml:"HousekeepingInterval,omitempty"`
+	// HousekeepingTimeout specifies the timeout duration for housekeeping tasks.
+	HousekeepingTimeout Duration `yaml:"HousekeepingTimeout,omitempty"`
+}
+
+// EvaluationBroker represents the configuration settings for the evaluation broker within the orchestration service.
+type EvaluationBroker struct {
+	// VisibilityTimeout specifies the duration after which an unprocessed evaluation is re-queued.
+	VisibilityTimeout Duration `yaml:"VisibilityTimeout,omitempty"`
+	// MaxRetries specifies the maximum number of retries for processing an evaluation.
+	MaxRetries int `yaml:"MaxRetries,omitempty"`
+}

--- a/pkg/configv2/types/publisher.go
+++ b/pkg/configv2/types/publisher.go
@@ -1,0 +1,57 @@
+package types
+
+// Publisher represents the configuration for different publisher providers.
+type Publisher struct {
+	// IPFS is the configuration for the IPFS provider.
+	IPFS IPFSPublisher `yaml:"IPFS,omitempty"`
+	// S3 is the configuration for the S3 provider.
+	S3 S3Publisher `yaml:"S3,omitempty"`
+	// Local is the configuration for the Local provider.
+	Local LocalPublisher `yaml:"Local,omitempty"`
+	// LocalHTTPServer is the configuration for the local http server run by the compute node
+	LocalHTTPServer LocalHTTPServerPublisher
+}
+
+type IPFSPublisher struct {
+	// Enabled specifies whether the IPFS provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Endpoint specifies the endpoint Multiaddress for the IPFS provider.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+}
+
+type S3Publisher struct {
+	// Enabled specifies whether the S3 provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Endpoint specifies the endpoint URL for the S3 provider.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+	// AccessKey specifies the access key for the S3 provider.
+	AccessKey string `yaml:"AccessKey,omitempty"`
+	// SecretKey specifies the secret key for the S3 provider.
+	SecretKey string `yaml:"SecretKey,omitempty"`
+	// PreSignedURLEnabled specifies whether pre-signed URLs are enabled for the S3 provider.
+	PreSignedURLEnabled bool `yaml:"PreSignedURLEnabled,omitempty"`
+	// PreSignedURLExpiration specifies the duration before a pre-signed URL expires.
+	PreSignedURLExpiration Duration `yaml:"PreSignedURLExpiration,omitempty"`
+}
+
+type LocalPublisher struct {
+	// Enabled specifies whether the Local provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Volumes specifies the list of local volumes available for publisher.
+	Volumes []Volume `yaml:"Volumes,omitempty"`
+}
+
+type HTTPPublisher struct {
+	// Enabled specifies whether the HTTP provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Endpoint specifies the endpoint URL for the HTTP provider.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+	// Headers specifies the HTTP headers to be included in requests to the HTTP provider.
+	Headers map[string]string `yaml:"Headers,omitempty"`
+}
+
+type LocalHTTPServerPublisher struct {
+	Enabled bool   `yaml:"Enabled,omitempty"`
+	Host    string `yaml:"Host,omitempty"`
+	Port    int    `yaml:"Port,omitempty"`
+}

--- a/pkg/configv2/types/resource.go
+++ b/pkg/configv2/types/resource.go
@@ -1,0 +1,84 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Resource represents allocated computing resources.
+// The resource values are specified in Kubernetes format.
+type Resource struct {
+	// CPU specifies the amount of CPU allocated, in Kubernetes format (e.g., "100m" for 100 millicores).
+	CPU string `yaml:"CPU,omitempty"`
+	// Memory specifies the amount of memory allocated, in Kubernetes format (e.g., "1Gi" for 1 Gibibyte).
+	Memory string `yaml:"Memory,omitempty"`
+	// Disk specifies the amount of disk space allocated, in Kubernetes format (e.g., "10Gi" for 10 Gibibytes).
+	Disk string `yaml:"Disk,omitempty"`
+	// GPU specifies the amount of GPU resources allocated, in Kubernetes format (e.g., "1" for 1 GPU).
+	GPU string `yaml:"GPU,omitempty"`
+}
+
+func (r *Resource) IsZero() bool {
+	return r.CPU == "" && r.Memory == "" && r.Disk == "" && r.GPU == ""
+}
+
+type ResourceScaler struct {
+	// CPU specifies the amount of CPU allocated as a percentage.
+	CPU Percentage `yaml:"CPU,omitempty"`
+	// Memory specifies the amount of Memory allocated as a percentage.
+	Memory Percentage `yaml:"Memory,omitempty"`
+	// Disk specifies the amount of Disk space allocated as a percentage.
+	Disk Percentage `yaml:"Disk,omitempty"`
+	// GPU specifies the amount of GPU allocated as a percentage.
+	GPU Percentage `yaml:"GPU,omitempty"`
+}
+
+func (r *ResourceScaler) IsZero() bool {
+	return r.CPU == "" && r.Memory == "" && r.Disk == "" && r.GPU == ""
+}
+
+func (r *ResourceScaler) Validate() error {
+	fields := map[string]Percentage{
+		"CPU":    r.CPU,
+		"Memory": r.Memory,
+		"Disk":   r.Disk,
+		"GPU":    r.GPU,
+	}
+
+	for field, value := range fields {
+		if value != "" {
+			if _, err := value.Parse(); err != nil {
+				return fmt.Errorf("invalid %s percentage: %w", field, err)
+			}
+		}
+	}
+	return nil
+}
+
+type Percentage string
+
+func (pv Percentage) Parse() (float64, error) {
+	// if the percentage is empty then it means the user didn't provide a config
+	// value, and we shouldn't scale. Returning 1 will result in no scaling.
+	if pv == "" {
+		return 1, nil
+	}
+	s := strings.TrimSpace(string(pv))
+	s = strings.TrimSuffix(s, "%")
+
+	value, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid percentage format: %w", err)
+	}
+
+	if value != float64(int(value)) {
+		return 0, fmt.Errorf("percentage must be a whole number")
+	}
+
+	if value < 1 || value > 100 {
+		return 0, fmt.Errorf("percentage must be between 1 and 100")
+	}
+
+	return value / 100, nil
+}

--- a/pkg/configv2/types/storage.go
+++ b/pkg/configv2/types/storage.go
@@ -1,0 +1,44 @@
+package types
+
+// Storage represents the configuration for various storage providers.
+// It includes settings for HTTP, IPFS, Local, and S3 providers.
+type Storage struct {
+	// HTTP is the configuration for the HTTP storage provider.
+	HTTP HTTPStorage
+	// IPFS is the configuration for the IPFS storage provider.
+	IPFS IPFSStorage `yaml:"IPFS,omitempty"`
+	// Local is the configuration for the Local storage provider.
+	Local LocalStorage `yaml:"Local,omitempty"`
+	// S3 is the configuration for the S3 storage provider.
+	S3 S3Storage `yaml:"S3,omitempty"`
+}
+
+type HTTPStorage struct {
+	// Enabled specifies whether the HTTP provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+}
+
+type IPFSStorage struct {
+	// Enabled specifies whether the IPFS provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Endpoint specifies the endpoint URL for the IPFS provider.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+}
+
+type S3Storage struct {
+	// Enabled specifies whether the S3 provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Endpoint specifies the endpoint URL for the S3 provider.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+	// AccessKey specifies the access key for the S3 provider.
+	AccessKey string `yaml:"AccessKey,omitempty"`
+	// SecretKey specifies the secret key for the S3 provider.
+	SecretKey string `yaml:"SecretKey,omitempty"`
+}
+
+type LocalStorage struct {
+	// Enabled specifies whether the Local provider is enabled.
+	Enabled bool `yaml:"Enabled,omitempty"`
+	// Volumes specifies the list of local volumes available for storage.
+	Volumes []Volume `yaml:"Volumes,omitempty"`
+}

--- a/pkg/configv2/types/telemetry.go
+++ b/pkg/configv2/types/telemetry.go
@@ -1,0 +1,32 @@
+package types
+
+// Telemetry represents the configuration for telemetry components,
+// including logging, metrics, and tracing.
+type Telemetry struct {
+	// Logging is the configuration for logging settings.
+	Logging Logging `yaml:"Logging,omitempty"`
+	// Metrics is the configuration for OpenTelemetry (OTel) metrics settings.
+	Metrics Metrics `yaml:"Metrics,omitempty"`
+	// Tracing is the configuration for OpenTelemetry (OTel) tracing settings.
+	Tracing Tracing `yaml:"Tracing,omitempty"`
+}
+
+// Logging represents the configuration settings for logging.
+type Logging struct {
+	// Level specifies the logging level (one of: "trace" "debug", "info", "warn", "error", "fatal", "panic").
+	Level string `yaml:"Level,omitempty"`
+	// Format specifies the format of the logs (one of:., "console", "color", or "json").
+	Format string `yaml:"Format,omitempty"`
+}
+
+// Metrics represents the configuration settings for OpenTelemetry (OTel) metrics collection.
+type Metrics struct {
+	// Endpoint specifies the OpenTelemetry (OTel) endpoint URL for metrics collection.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+}
+
+// Tracing represents the configuration settings for OpenTelemetry (OTel) tracing.
+type Tracing struct {
+	// Endpoint specifies the OpenTelemetry (OTel) endpoint URL for tracing data.
+	Endpoint string `yaml:"Endpoint,omitempty"`
+}

--- a/pkg/configv2/types/tls.go
+++ b/pkg/configv2/types/tls.go
@@ -1,0 +1,14 @@
+package types
+
+// TLS represents the configuration settings for TLS (Transport Layer Security).
+// It includes options for automatic certificate management as well as manually specified certificates.
+type TLS struct {
+	// AutoCert specifies a domain name for a certificate to be obtained via ACME (Automated Certificate Management Environment).
+	AutoCert string `yaml:"AutoCert,omitempty"`
+	// AutoCertCachePath specifies the path where the ACME client will cache certificates to avoid rate limits.
+	AutoCertCachePath string `yaml:"AutoCertCachePath,omitempty"`
+	// Certificate specifies the path to a TLS certificate file to be used.
+	Certificate string `yaml:"Certificate,omitempty"`
+	// Key specifies the path to the private key file corresponding to the TLS certificate.
+	Key string `yaml:"Key,omitempty"`
+}

--- a/pkg/configv2/types/volume.go
+++ b/pkg/configv2/types/volume.go
@@ -1,0 +1,13 @@
+package types
+
+// Volume represents a location on disk with specific attributes.
+// It includes a name for reference, the path on the filesystem,
+// and a flag indicating if the volume is writable.
+type Volume struct {
+	// Name is the identifier used to refer to this volume.
+	Name string `yaml:"Name,omitempty"`
+	// Path is the filesystem location of the volume on disk.
+	Path string `yaml:"Path,omitempty"`
+	// Write indicates whether the volume has write permissions.
+	Write bool `yaml:"Write,omitempty"`
+}


### PR DESCRIPTION
This changes introduces:
- a generic config package agnostic to the underlying config type it operates over
- a new config type system to replace the current