### PR TITLE
fix: list command shows values and current config

### DIFF
--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -45,7 +45,7 @@ func SetupRepo(cfg types.Bacalhau) (*repo.FsRepo, error) {
 	return r, nil
 }
 
-func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
+func SetupConfigType(cmd *cobra.Command) (*config.Config, error) {
 	var opts []config.Option
 	v := viper.GetViper()
 	// check if the user specified config files via the --config flag
@@ -59,7 +59,7 @@ func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
 			if _, err := os.Stat(path); err != nil {
 				// if the file exists and could not be read, return an error
 				if !os.IsNotExist(err) {
-					return types.Bacalhau{}, fmt.Errorf("loading config file at %q: %w", path, err)
+					return nil, fmt.Errorf("loading config file at %q: %w", path, err)
 				}
 			} else {
 				// the file exists, use it.
@@ -74,7 +74,7 @@ func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
 
 	configFlags, err := getConfigFlags(v, cmd)
 	if err != nil {
-		return types.Bacalhau{}, err
+		return nil, err
 	}
 	if len(configFlags) > 0 {
 		opts = append(opts, config.WithFlags(configFlags))
@@ -92,9 +92,16 @@ func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
 
 	cfg, err := config.New(opts...)
 	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
+	cfg, err := SetupConfigType(cmd)
+	if err != nil {
 		return types.Bacalhau{}, err
 	}
-
 	var out types.Bacalhau
 	if err := cfg.Unmarshal(&out); err != nil {
 		return types.Bacalhau{}, err

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -69,6 +69,7 @@ func SetupConfigType(cmd *cobra.Command) (*config.Config, error) {
 	}
 	// if a config file is present, apply it to the config
 	if len(configFiles) > 0 {
+		cmd.Printf("Config file(s) found at path(s): %s\n", configFiles)
 		opts = append(opts, config.WithPaths(configFiles...))
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,7 @@ func getNodeType(input string) (requester, compute bool, err error) {
 // from the read config file.
 // Load returns an error if the file cannot be read.
 func (c *Config) Load(path string) error {
-	log.Debug().Msgf("loading config file: %q", path)
+	log.Info().Msgf("loading config file: %q", path)
 	c.base.SetConfigFile(path)
 	if err := c.base.ReadInConfig(); err != nil {
 		return err
@@ -229,7 +229,7 @@ func (c *Config) Load(path string) error {
 // Merge merges a new configuration file specified by `path` with the existing config.
 // Merge returns an error if the file cannot be read
 func (c *Config) Merge(path string) error {
-	log.Debug().Msgf("merging config file: %q", path)
+	log.Info().Msgf("merging config file: %q", path)
 	c.base.SetConfigFile(path)
 	if err := c.base.MergeInConfig(); err != nil {
 		return err
@@ -239,6 +239,10 @@ func (c *Config) Merge(path string) error {
 
 func (c *Config) Get(key string) any {
 	return c.base.Get(key)
+}
+
+func (c *Config) ConfigFileUsed() string {
+	return c.base.ConfigFileUsed()
 }
 
 // Unmarshal returns the current configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -237,6 +237,10 @@ func (c *Config) Merge(path string) error {
 	return nil
 }
 
+func (c *Config) Get(key string) any {
+	return c.base.Get(key)
+}
+
 // Unmarshal returns the current configuration.
 // Unmarshal returns an error if the configuration cannot be unmarshalled.
 func (c *Config) Unmarshal(out interface{}) error {


### PR DESCRIPTION
Modifies `config list` as follows:
```shell
bacalhau config list 
 KEY                                               VALUE                        DESCRIPTION                                                                      
 api.auth.accesspolicypath                                                      AccessPolicyPath is the path to a file or directory that will be loaded as the   
                                                                                policy to apply to all inbound API requests. If unspecified, a policy that       
                                                                                permits access to all API endpoints to both authenticated and unauthenticated    
                                                                                users (the default as of v1.2.0) will be used.                                   
 api.auth.methods                                  map[ClientKey:{challenge }]  Methods maps "method names" to authenticator implementations. A method name is a 
                                                                                human-readable string chosen by the person configuring the system that is shown  
                                                                                to users to help them pick the authentication method they want to use. There can 
                                                                                be multiple usages of the same Authenticator *type* but with different configs   
                                                                                and parameters, each identified with a unique method name. For example, if an    
                                                                                implementation wants to allow users to log in with Github or Bitbucket, they     
                                                                                might both use an authenticator implementation of type "oidc", and each would    
                                                                                appear once on this provider with key / method name "github" and "bitbucket". By 
                                                                                default, only a single authentication method that accepts authentication via     
                                                                                client keys will be enabled.                                                     
 api.host                                          0.0.0.0                      Host specifies the hostname or IP address on which the API server listens or the 
                                                                                client connects.                                                                 
 api.port                                          1234                         Port specifies the port number on which the API server listens or the client     
                                                                                connects.                                                                        
 api.tls.autocert                                                               AutoCert specifies the domain for automatic certificate generation.              
 api.tls.autocertcachepath                                                      AutoCertCachePath specifies the directory to cache auto-generated certificates.  
 api.tls.cafile                                                                 CAFile specifies the path to the Certificate Authority file.                     
 api.tls.certfile                                                               CertFile specifies the path to the TLS certificate file.                         
 api.tls.insecure                                  false                        Insecure allows insecure TLS connections (e.g., self-signed certificates).       
 api.tls.keyfile                                                                KeyFile specifies the path to the TLS private key file.                          
 api.tls.selfsigned                                false                        SelfSigned indicates whether to use a self-signed certificate.                   
 api.tls.usetls                                    false                        UseTLS indicates whether to use TLS for client connections.                      
 compute.allocatedcapacity.cpu                     70%                          CPU specifies the default amount of CPU allocated to a task. It uses Kubernetes  
                                                                                resource string format (e.g., "100m" for 0.1 CPU cores). This value is used when 
                                                                                the task hasn't explicitly set its CPU requirement.                              
..............
```
or for the actual config structure:
```
bacalhau config list --output=yaml
API:
    Host: 0.0.0.0
    Port: 1234
    Auth:
        Methods:
            ClientKey:
                Type: challenge
NameProvider: puuid
DataDir: /home/frrist/.bacalhau
Orchestrator:
    Host: 0.0.0.0
    Port: 4222
    NodeManager:
        DisconnectTimeout: 1m0s
    Scheduler:
        WorkerCount: 32
        HousekeepingInterval: 30s
        HousekeepingTimeout: 2m0s
    EvaluationBroker:
        VisibilityTimeout: 1m0s
        MaxRetryCount: 10
Compute:
    Orchestrators:
        - nats://127.0.0.1:4222
    Heartbeat:
        InfoUpdateInterval: 1m0s
        ResourceUpdateInterval: 30s
        Interval: 15s
    AllocatedCapacity:
        CPU: 70%
        Memory: 70%
        Disk: 70%
        GPU: 100%
    AllowListedLocalPaths: []
WebUI:
    Enabled: true
    Listen: 0.0.0.0:8438
InputSources:
    ReadTimeout: 5m0s
    MaxRetryCount: 3
Engines:
    Types:
        Docker:
            ManifestCache:
                Size: 1000
                TTL: 1h0m0s
                Refresh: 1h0m0s
JobDefaults:
    Batch:
        Task:
            Resources:
                CPU: 500m
                Memory: 1Gb
            Publisher:
                Config:
                    Type: local
    Ops:
        Task:
            Resources:
                CPU: 500m
                Memory: 1Gb
            Publisher:
                Config:
                    Type: local
    Daemon:
        Task:
            Resources:
                CPU: 500m
                Memory: 1Gb
    Service:
        Task:
            Resources:
                CPU: 500m
                Memory: 1Gb
Logging:
    Level: info
    Mode: default
UpdateConfig:
    Interval: 24h0m0s
```