### PR TITLE
fix: don't panic in client due to nil body

### DIFF
--- a/pkg/publicapi/client/v2/client.go
+++ b/pkg/publicapi/client/v2/client.go
@@ -98,10 +98,10 @@ func (c *httpClient) write(ctx context.Context, verb, endpoint string, in apimod
 	}
 
 	_, resp, err := c.doRequest(ctx, verb, endpoint, r) //nolint:bodyclose // this is being closed
-	defer resp.Body.Close()
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return apimodels.ErrInvalidToken


### PR DESCRIPTION
- introduced by #4366, we need to close the body only if there isn't an error, else the body is nil and panics. Mentioned here https://github.com/bacalhau-project/bacalhau/pull/4401#discussion_r1755344006