### PR TITLE
use dataDir/config.yaml as the default config path

### DIFF
--- a/cmd/cli/config/set.go
+++ b/cmd/cli/config/set.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
-	util2 "github.com/bacalhau-project/bacalhau/pkg/storage/util"
 )
 
 func newSetCmd() *cobra.Command {
@@ -42,14 +41,6 @@ func newSetCmd() *cobra.Command {
 					return fmt.Errorf("failed to setup data dir: %w", err)
 				}
 				configPath = filepath.Join(bacalhauConfig.DataDir, config.DefaultFileName)
-
-				// create the config file if it doesn't exist
-				// we only do this for the default config file path
-				if _, err := os.Stat(configPath); os.IsNotExist(err) {
-					if err := os.WriteFile(configPath, []byte{}, util2.OS_USER_RWX); err != nil {
-						return fmt.Errorf("failed to create default config file %s: %w", configPath, err)
-					}
-				}
 			}
 
 			return setConfig(configPath, args[0], args[1:]...)

--- a/cmd/cli/config/set.go
+++ b/cmd/cli/config/set.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util"
+	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
@@ -26,40 +27,58 @@ func newSetCmd() *cobra.Command {
 		PostRunE:     hook.ClientPostRunHooks,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// initialize a new or open an existing repo. We need to ensure a repo
-			// exists before we can create or modify a config file in it.
-			_, err := util.SetupRepoConfig(cmd)
+			// Get the value of the --config flag
+			configFlag, err := cmd.Flags().GetString("config")
 			if err != nil {
-				return fmt.Errorf("failed to setup repo: %w", err)
+				return fmt.Errorf("failed to get config flag: %w", err)
 			}
-			return setConfig(cmd.PersistentFlags().Lookup("config").Value.String(), args[0], args[1:]...)
+
+			// If --config flag is set, use it to set the Viper key
+			if configFlag != "" {
+				viper.Set(cliflags.RootCommandConfigFiles, []string{configFlag})
+			}
+
+			var configPath string
+			// load configs to get the config file path
+			rawConfig, err := util.SetupConfigType(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to setup config: %w", err)
+			}
+
+			configPath = rawConfig.ConfigFileUsed()
+			if configPath == "" {
+				// we fall back to the default config file path $BACALHAU_DIR/config.yaml
+				// this requires initializing a new or opening an existing data-dir
+				bacalhauConfig, err := util.DecodeBacalhauConfig(rawConfig)
+				if err != nil {
+					return fmt.Errorf("failed to decode bacalhau config: %w", err)
+				}
+				_, err = util.SetupRepo(bacalhauConfig)
+				if err != nil {
+					return fmt.Errorf("failed to setup repo: %w", err)
+				}
+				configPath = filepath.Join(bacalhauConfig.DataDir, config.DefaultFileName)
+
+				// create the config file if it doesn't exist
+				if _, err := os.Stat(configPath); os.IsNotExist(err) {
+					if err := os.WriteFile(configPath, []byte{}, util2.OS_USER_RWX); err != nil {
+						return fmt.Errorf("failed to create default config file %s: %w", configPath, err)
+					}
+				}
+			}
+
+			return setConfig(configPath, args[0], args[1:]...)
 		},
-		// provide auto completion for arguments to the `set` command
+		// Provide auto completion for arguments to the `set` command
 		ValidArgsFunction: setAutoComplete,
 	}
 
-	bacalhauCfgDir := "bacalhau"
-	bacalhauCfgFile := config.DefaultFileName
-
-	usrCfgDir, err := os.UserConfigDir()
-	if err != nil {
-		log.Warn().Err(err).Msg("Failed to find user-specific configuration directory. Using current directory to write config.")
-	} else {
-		bacalhauCfgDir = filepath.Join(usrCfgDir, bacalhauCfgDir)
-		if err := os.MkdirAll(bacalhauCfgDir, util2.OS_USER_RWX); err != nil {
-			// This means we failed to create a directory either in the current directory, or the user config dir
-			// indicating a some-what serious misconfiguration of the system. We panic here to provide as much
-			// detail as possible.
-			log.Panic().Err(err).Msgf("Failed to create bacalhau configuration directory: %s", bacalhauCfgDir)
-		}
-		bacalhauCfgFile = filepath.Join(bacalhauCfgDir, bacalhauCfgFile)
-	}
-
-	setCmd.PersistentFlags().String("config", bacalhauCfgFile, "Path to the config file")
+	setCmd.PersistentFlags().String("config", "", "Path to the config file (default is $BACALHAU_DIR/config.yaml)")
 	return setCmd
 }
 
 func setConfig(cfgFilePath, key string, value ...string) error {
+	log.Info().Msgf("Writing config to %s", cfgFilePath)
 	v := viper.New()
 	v.SetConfigFile(cfgFilePath)
 	if err := v.ReadInConfig(); err != nil {

--- a/cmd/cli/config/set.go
+++ b/cmd/cli/config/set.go
@@ -49,7 +49,7 @@ func newSetCmd() *cobra.Command {
 			if configPath == "" {
 				// we fall back to the default config file path $BACALHAU_DIR/config.yaml
 				// this requires initializing a new or opening an existing data-dir
-				bacalhauConfig, err := util.DecodeBacalhauConfig(rawConfig)
+				bacalhauConfig, err := util.UnmarshalBacalhauConfig(rawConfig)
 				if err != nil {
 					return fmt.Errorf("failed to decode bacalhau config: %w", err)
 				}

--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"strings"
 
@@ -390,10 +389,6 @@ func buildEnvVariables(
 	var envvars strings.Builder
 	envvars.WriteString(fmt.Sprintf("export %s=%s\n", config.KeyAsEnvVar(types.APIHostKey), getAPIURL(cfg.API)))
 	envvars.WriteString(fmt.Sprintf("export %s=%d\n", config.KeyAsEnvVar(types.APIPortKey), cfg.API.Port))
-	if cfg.Orchestrator.Enabled {
-		envvars.WriteString(fmt.Sprintf("export %s=%s\n",
-			config.KeyAsEnvVar(types.ComputeOrchestratorsKey), getPublicNATSOrchestratorURL(cfg.Orchestrator)))
-	}
 	return envvars.String()
 }
 
@@ -403,17 +398,4 @@ func getAPIURL(cfg types.API) string {
 	} else {
 		return cfg.Host
 	}
-}
-
-func getPublicNATSOrchestratorURL(cfg types.Orchestrator) *url.URL {
-	orchestrator := &url.URL{
-		Scheme: "nats",
-		Host:   cfg.Advertise,
-	}
-
-	if cfg.Advertise == "" {
-		orchestrator.Host = fmt.Sprintf("127.0.0.1:%d", cfg.Port)
-	}
-
-	return orchestrator
 }

--- a/cmd/util/flags/cliflags/config.go
+++ b/cmd/util/flags/cliflags/config.go
@@ -27,23 +27,24 @@ func ConfigAutoComplete(cmd *cobra.Command, args []string, toComplete string) ([
 	return completions, cobra.ShellCompDirectiveNoSpace
 }
 
-func NewConfigFlag() *ConfigFlag {
-	viper.Set(RootCommandConfigValues, new(map[string]any))
-	viper.Set(RootCommandConfigFiles, make([]string, 0))
-	return &ConfigFlag{}
-}
-
 const RootCommandConfigFiles = "Root.Command.Config.Files"
 const RootCommandConfigValues = "Root.Command.Config.Values"
 const RootCommandConfigFlags = "Root.Command.Config.Flags"
 
-type Something struct {
-	ConfigFiles  []string
-	ConfigParams map[string]any
+type ConfigFlag struct {
+	Value       string
+	isWriteMode bool
 }
 
-type ConfigFlag struct {
-	Value string
+func NewConfigFlag() *ConfigFlag {
+	viper.Set(RootCommandConfigValues, new(map[string]any))
+	viper.Set(RootCommandConfigFiles, make([]string, 0))
+	return &ConfigFlag{isWriteMode: false}
+}
+
+func NewWriteConfigFlag() *ConfigFlag {
+	viper.Set(RootCommandConfigFiles, "")
+	return &ConfigFlag{isWriteMode: true}
 }
 
 func (cf *ConfigFlag) String() string {
@@ -51,6 +52,12 @@ func (cf *ConfigFlag) String() string {
 }
 
 func (cf *ConfigFlag) Set(value string) error {
+	if cf.isWriteMode {
+		// Check if a config file is already set in Viper
+		if viper.GetString(RootCommandConfigFiles) != "" {
+			return fmt.Errorf("single config file can be set")
+		}
+	}
 	cf.Value = value
 	return cf.Parse()
 }
@@ -60,34 +67,70 @@ func (cf *ConfigFlag) Type() string {
 }
 
 func (cf *ConfigFlag) Parse() error {
+	if cf.isWriteMode {
+		return cf.parseWriteMode()
+	}
+	return cf.parseReadMode()
+}
+
+func (cf *ConfigFlag) parseWriteMode() error {
+	if !cf.isConfigFile() {
+		return fmt.Errorf("config file must end with '.yaml' or '.yml'")
+	}
+
+	if err := validateFile(cf.Value); err != nil {
+		return err
+	}
+
+	viper.Set(RootCommandConfigFiles, cf.Value)
+	return nil
+}
+
+func (cf *ConfigFlag) parseReadMode() error {
 	if strings.Contains(cf.Value, "=") {
 		// Handle key-value pair
-		tokens := strings.SplitN(cf.Value, "=", 2)
-		if len(tokens) == 2 {
-			cfgKey := tokens[0]
-			cfgValue := tokens[1]
-			return setIfValid(viper.GetViper(), cfgKey, cfgValue)
-		} else {
-			return fmt.Errorf("config flag value %s is invalid", cf.Value)
-		}
-	} else if strings.HasSuffix(cf.Value, ".yaml") || strings.HasSuffix(cf.Value, ".yml") {
+		return cf.parseKeyValue()
+	} else if cf.isConfigFile() {
 		// Handle YAML file
-		configFiles := viper.GetStringSlice(RootCommandConfigFiles)
-		configFiles = append(configFiles, cf.Value)
-		if stat, err := os.Stat(cf.Value); err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("the specified configuration file %q doesn't exist", cf.Value)
-			}
-			return fmt.Errorf("the specified configuration file %q cannot be read: %w", cf.Value, err)
-		} else if stat.IsDir() {
-			return fmt.Errorf("the specified configuration file %q is a directory, must be a file", cf.Value)
-		} else if stat.Size() == 0 {
-			log.Warn().Msgf("the specified configuration file is empty and ineffectual")
-		}
-		viper.Set(RootCommandConfigFiles, configFiles)
+		return cf.addConfigFile()
 	} else {
 		// Handle dot separated path with boolean value
 		return setIfValid(viper.GetViper(), cf.Value, true)
+	}
+}
+
+func (cf *ConfigFlag) parseKeyValue() error {
+	tokens := strings.SplitN(cf.Value, "=", 2)
+	if len(tokens) != 2 {
+		return fmt.Errorf("config flag value %s is invalid", cf.Value)
+	}
+	return setIfValid(viper.GetViper(), tokens[0], tokens[1])
+}
+
+func (cf *ConfigFlag) addConfigFile() error {
+	if err := validateFile(cf.Value); err != nil {
+		return err
+	}
+
+	configFiles := viper.GetStringSlice(RootCommandConfigFiles)
+	configFiles = append(configFiles, cf.Value)
+	viper.Set(RootCommandConfigFiles, configFiles)
+	return nil
+}
+
+func validateFile(filePath string) error {
+	stat, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("the specified configuration file %q doesn't exist", filePath)
+		}
+		return fmt.Errorf("the specified configuration file %q cannot be read: %w", filePath, err)
+	}
+	if stat.IsDir() {
+		return fmt.Errorf("the specified configuration file %q is a directory, must be a file", filePath)
+	}
+	if stat.Size() == 0 {
+		log.Warn().Msgf("the specified configuration file is empty and ineffectual")
 	}
 	return nil
 }
@@ -109,4 +152,8 @@ func setIfValid(v *viper.Viper, key string, value any) error {
 	configMap[key] = parsed
 	v.Set(RootCommandConfigValues, configMap)
 	return nil
+}
+
+func (cf *ConfigFlag) isConfigFile() bool {
+	return strings.HasSuffix(cf.Value, ".yaml") || strings.HasSuffix(cf.Value, ".yml")
 }

--- a/cmd/util/flags/cliflags/config_test.go
+++ b/cmd/util/flags/cliflags/config_test.go
@@ -30,13 +30,17 @@ func createTempConfig(content string) (string, error) {
 	return tmpfile.Name(), nil
 }
 
-// setupTestCommand sets up a cobra command for testing
-func setupTestCommand() *cobra.Command {
+// setupTestCommand to accept a boolean for write mode
+func setupTestCommand(writeMode bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "test",
 		Run: func(cmd *cobra.Command, args []string) {},
 	}
-	cmd.PersistentFlags().VarP(NewConfigFlag(), "config", "c", "config file(s) or dot separated path(s) to config values")
+	if writeMode {
+		cmd.PersistentFlags().VarP(NewWriteConfigFlag(), "config", "c", "config file for writing")
+	} else {
+		cmd.PersistentFlags().VarP(NewConfigFlag(), "config", "c", "config file(s) or dot separated path(s) to config values")
+	}
 	return cmd
 }
 
@@ -79,7 +83,7 @@ API:
 		require.NoError(t, err)
 		defer os.Remove(configFile)
 
-		cmd := setupTestCommand()
+		cmd := setupTestCommand(false)
 		cmd.SetArgs([]string{"-c", configFile})
 		err = cmd.Execute()
 		require.NoError(t, err)
@@ -117,7 +121,7 @@ API:
 		require.NoError(t, err)
 		defer os.Remove(overrideConfig)
 
-		cmd := setupTestCommand()
+		cmd := setupTestCommand(false)
 		cmd.SetArgs([]string{"-c", baseConfig, "-c", overrideConfig})
 		err = cmd.Execute()
 		require.NoError(t, err)
@@ -146,7 +150,7 @@ API:
 		require.NoError(t, err)
 		defer os.Remove(configFile)
 
-		cmd := setupTestCommand()
+		cmd := setupTestCommand(false)
 		cmd.SetArgs([]string{"-c", configFile, "-c", "DataDir=override", "-c", "API.Host=2.2.2.2"})
 		err = cmd.Execute()
 		require.NoError(t, err)
@@ -164,7 +168,7 @@ API:
 	// Test case 4: Dot notation without value (boolean true)
 	t.Run("DotNotationWithoutValue", func(t *testing.T) {
 		viper.Reset()
-		cmd := setupTestCommand()
+		cmd := setupTestCommand(false)
 		cmd.SetArgs([]string{"-c", "WebUI.Enabled"})
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -177,7 +181,7 @@ API:
 	// Test case 5: Multiple dot notation values
 	t.Run("MultipleDotNotationValues", func(t *testing.T) {
 		viper.Reset()
-		cmd := setupTestCommand()
+		cmd := setupTestCommand(false)
 		cmd.SetArgs([]string{
 			"-c", "WebUI.Enabled=true",
 			"-c", "WebUI.Listen=0.0.0.0:9090",
@@ -214,7 +218,7 @@ API:
 		require.NoError(t, err)
 		defer os.Remove(configFile)
 
-		cmd := setupTestCommand()
+		cmd := setupTestCommand(false)
 		cmd.SetArgs([]string{
 			"-c", configFile,
 			"-c", "WebUI.Enabled=true",
@@ -237,4 +241,68 @@ API:
 		assert.Equal(t, "192.168.1.5", config.API.Host)
 	})
 
+	// New test case: Write mode with single config file
+	t.Run("WriteModeWithSingleConfigFile", func(t *testing.T) {
+		viper.Reset()
+		configFile, err := createTempConfig("")
+		require.NoError(t, err)
+		defer os.Remove(configFile)
+
+		cmd := setupTestCommand(true)
+		cmd.SetArgs([]string{"-c", configFile})
+		err = cmd.Execute()
+		require.NoError(t, err)
+
+		assert.Equal(t, configFile, viper.GetString(RootCommandConfigFiles))
+	})
+
+	// New test case: Write mode with multiple config files (should fail)
+	t.Run("WriteModeWithMultipleConfigFiles", func(t *testing.T) {
+		viper.Reset()
+		configFile1, err := createTempConfig("")
+		require.NoError(t, err)
+		defer os.Remove(configFile1)
+
+		configFile2, err := createTempConfig("")
+		require.NoError(t, err)
+		defer os.Remove(configFile2)
+
+		cmd := setupTestCommand(true)
+		cmd.SetArgs([]string{"-c", configFile1, "-c", configFile2})
+		err = cmd.Execute()
+		assert.Error(t, err) // Expect an error when trying to use multiple config files in write mode
+	})
+
+	// New test case: Write mode with key/value pairs or non-files (should fail)
+	t.Run("WriteModeWithKeyValueOrNonFiles", func(t *testing.T) {
+		viper.Reset()
+
+		// Test with key/value pair
+		cmd := setupTestCommand(true)
+		cmd.SetArgs([]string{"-c", "DataDir=testdir"})
+		err := cmd.Execute()
+		assert.Error(t, err, "Write mode should fail with key/value pair")
+
+		// Test with non-file argument
+		cmd = setupTestCommand(true)
+		cmd.SetArgs([]string{"-c", "not_a_file"})
+		err = cmd.Execute()
+		assert.Error(t, err, "Write mode should fail with non-file argument")
+
+		// Test with multiple key/value pairs
+		cmd = setupTestCommand(true)
+		cmd.SetArgs([]string{"-c", "DataDir=testdir", "-c", "API.Host=localhost"})
+		err = cmd.Execute()
+		assert.Error(t, err, "Write mode should fail with multiple key/value pairs")
+
+		// Test with mix of file and key/value pair
+		configFile, err := createTempConfig("")
+		require.NoError(t, err)
+		defer os.Remove(configFile)
+
+		cmd = setupTestCommand(true)
+		cmd.SetArgs([]string{"-c", configFile, "-c", "DataDir=testdir"})
+		err = cmd.Execute()
+		assert.Error(t, err, "Write mode should fail with mix of file and key/value pair")
+	})
 }

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -83,10 +83,10 @@ func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
 	if err != nil {
 		return types.Bacalhau{}, err
 	}
-	return DecodeBacalhauConfig(cfg)
+	return UnmarshalBacalhauConfig(cfg)
 }
 
-func DecodeBacalhauConfig(cfg *config.Config) (types.Bacalhau, error) {
+func UnmarshalBacalhauConfig(cfg *config.Config) (types.Bacalhau, error) {
 	var out types.Bacalhau
 	if err := cfg.Unmarshal(&out); err != nil {
 		return types.Bacalhau{}, err

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -86,6 +86,18 @@ func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
 	return UnmarshalBacalhauConfig(cfg)
 }
 
+func SetupConfigs(cmd *cobra.Command) (types.Bacalhau, *config.Config, error) {
+	cfg, err := SetupConfigType(cmd)
+	if err != nil {
+		return types.Bacalhau{}, nil, err
+	}
+	bacalhauCfg, err := UnmarshalBacalhauConfig(cfg)
+	if err != nil {
+		return types.Bacalhau{}, nil, err
+	}
+	return bacalhauCfg, cfg, nil
+}
+
 func UnmarshalBacalhauConfig(cfg *config.Config) (types.Bacalhau, error) {
 	var out types.Bacalhau
 	if err := cfg.Unmarshal(&out); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -188,6 +189,26 @@ func New(opts ...Option) (*Config, error) {
 		c.base.Set(name, value)
 	}
 
+	// if no config file was provided, we look for a config.yaml under the resolved data directory,
+	// and if it exists, we create and return a new config with the resolved path.
+	// we attempt this last to ensure the data-dir is resolved correctly from all config sources.
+	if len(c.paths) == 0 {
+		configFile := filepath.Join(c.base.GetString(types.DataDirKey), DefaultFileName)
+		if _, err := os.Stat(configFile); err == nil {
+			opts = append(opts, WithPaths(configFile))
+			return New(opts...)
+		}
+	}
+
+	// log the resolved config paths
+	absoluteConfigPaths := make([]string, len(c.paths))
+	for i, path := range c.paths {
+		absoluteConfigPaths[i], err = filepath.Abs(path)
+		if err != nil {
+			absoluteConfigPaths[i] = path
+		}
+	}
+	log.Info().Msgf("Config loaded from: %s, and with data-dir %s", absoluteConfigPaths, c.base.Get(types.DataDirKey))
 	return c, nil
 }
 
@@ -218,7 +239,6 @@ func getNodeType(input string) (requester, compute bool, err error) {
 // from the read config file.
 // Load returns an error if the file cannot be read.
 func (c *Config) Load(path string) error {
-	log.Info().Msgf("loading config file: %q", path)
 	c.base.SetConfigFile(path)
 	if err := c.base.ReadInConfig(); err != nil {
 		return err
@@ -229,7 +249,6 @@ func (c *Config) Load(path string) error {
 // Merge merges a new configuration file specified by `path` with the existing config.
 // Merge returns an error if the file cannot be read
 func (c *Config) Merge(path string) error {
-	log.Info().Msgf("merging config file: %q", path)
 	c.base.SetConfigFile(path)
 	if err := c.base.MergeInConfig(); err != nil {
 		return err

--- a/pkg/repo/migrations/v3_4.go
+++ b/pkg/repo/migrations/v3_4.go
@@ -113,28 +113,14 @@ var V3Migration = repo.NewMigration(
 				}
 				// ensure the repo path of the config points to the repo
 				newConfigType.DataDir = repoPath
-				userConfigDir, err := os.UserConfigDir()
-				if err == nil {
-					newConfigDir := filepath.Join(userConfigDir, "bacalhau")
-					if err := os.MkdirAll(newConfigDir, util.OS_USER_RWX); err != nil {
-						return err
-					}
-					newConfigFilePath := filepath.Join(newConfigDir, config_legacy.FileName)
-					if err := os.Rename(oldConfigFilePath, newConfigFilePath); err != nil {
-						return err
-					}
-					newConfigBytes, err := yaml.Marshal(&newConfigType)
-					if err != nil {
-						return err
-					}
-					newConfigFile, err := os.OpenFile(newConfigFilePath, os.O_RDWR|os.O_TRUNC, util.OS_USER_RWX)
-					if err != nil {
-						return err
-					}
-					defer newConfigFile.Close()
-					if _, err := newConfigFile.Write(newConfigBytes); err != nil {
-						return err
-					}
+
+				// Write the updated config back to the same file
+				newConfigBytes, err := yaml.Marshal(&newConfigType)
+				if err != nil {
+					return fmt.Errorf("marshaling new config: %w", err)
+				}
+				if err := os.WriteFile(oldConfigFilePath, newConfigBytes, util.OS_USER_RWX); err != nil {
+					return fmt.Errorf("writing updated config file: %w", err)
 				}
 			} else if !os.IsNotExist(err) {
 				// if there was an error other than the file not existing, abort.

--- a/pkg/repo/migrations/v3_4_test.go
+++ b/pkg/repo/migrations/v3_4_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -42,16 +41,6 @@ func TestV3MigrationsTestSuite(t *testing.T) {
 
 // repo resulting from `bacalhau serve --node-type=compute,requester`
 func (suite *V3MigrationsTestSuite) TestV3MigrationWithFullRepo() {
-	switch runtime.GOOS {
-	case "windows":
-		suite.T().Setenv("AppData", suite.TempDir)
-	case "darwin", "ios":
-		suite.T().Setenv("HOME", suite.TempDir)
-	case "plan9":
-		suite.T().Setenv("home", suite.TempDir)
-	default: // Unix
-		suite.T().Setenv("XDG_CONFIG_HOME", suite.TempDir)
-	}
 	// Copy test data to the suite's temporary directory
 	testDataPath := filepath.Join("testdata", "v3_full_repo")
 	suite.copyRepo(testDataPath)
@@ -116,11 +105,9 @@ Auth:
 	suite.Require().NoError(err)
 	suite.Equal(repo.Version4, repoVersion4)
 
-	// verify the config file has been moved to XDG_CONFIG_HOME/bacalhau/config.yaml
-	// and that it contains the values from the the original config that have been migrated
-	newConfigPath := filepath.Join(suite.TempDir, "bacalhau", config_legacy.FileName)
-	suite.FileExists(newConfigPath)
-	c, err := config.New(config.WithPaths(newConfigPath))
+	// verify the config file remains in the repo directory
+	suite.FileExists(configPath)
+	c, err := config.New(config.WithPaths(configPath))
 	suite.Require().NoError(err)
 	var bacCfg types.Bacalhau
 	suite.Require().NoError(c.Unmarshal(&bacCfg))
@@ -131,11 +118,11 @@ Auth:
 	suite.FileExists(filepath.Join(suite.TempDir, types.OrchestratorDirName, types.JobStoreFileName))
 	suite.FileExists(filepath.Join(suite.TempDir, types.ComputeDirName, types.ExecutionStoreFileName))
 
-	// verify old file were removed
+	// verify old files were removed
 	suite.NoFileExists(filepath.Join(suite.TempDir, "repo.version"))
 	suite.NoFileExists(filepath.Join(suite.TempDir, "update.json"))
 
-	// verify the new files exists
+	// verify the new files exist
 	suite.FileExists(filepath.Join(suite.TempDir, "system_metadata.yaml"))
 
 	suite.NoDirExists(filepath.Join(suite.TempDir, "orchestrator_store"))
@@ -166,16 +153,6 @@ Auth:
 
 // repo resulting from `bacalhau version`
 func (suite *V3MigrationsTestSuite) TestV3MigrationWithMinimalRepo() {
-	switch runtime.GOOS {
-	case "windows":
-		suite.T().Setenv("AppData", suite.TempDir)
-	case "darwin", "ios":
-		suite.T().Setenv("HOME", suite.TempDir)
-	case "plan9":
-		suite.T().Setenv("home", suite.TempDir)
-	default: // Unix
-		suite.T().Setenv("XDG_CONFIG_HOME", suite.TempDir)
-	}
 	// Copy test data to the suite's temporary directory
 	testDataPath := filepath.Join("testdata", "v3_minimal_repo")
 	suite.copyRepo(testDataPath)
@@ -208,8 +185,8 @@ func (suite *V3MigrationsTestSuite) TestV3MigrationWithMinimalRepo() {
 	suite.Equal(repo.Version4, repoVersion4)
 
 	// verify the config file hasn't been created
-	newConfigPath := filepath.Join(suite.TempDir, "bacalhau", config_legacy.FileName)
-	suite.NoFileExists(newConfigPath)
+	configPath := filepath.Join(suite.TempDir, config_legacy.FileName)
+	suite.NoFileExists(configPath)
 
 	suite.NoFileExists(filepath.Join(suite.TempDir, types.OrchestratorDirName, types.JobStoreFileName))
 	suite.NoFileExists(filepath.Join(suite.TempDir, types.ComputeDirName, types.ExecutionStoreFileName))
@@ -241,16 +218,6 @@ func (suite *V3MigrationsTestSuite) TestV3MigrationWithMinimalRepo() {
 
 // repo resulting from `bacalhau serve --node-type=requester`
 func (suite *V3MigrationsTestSuite) TestV3MigrationWithOrchestratorRepo() {
-	switch runtime.GOOS {
-	case "windows":
-		suite.T().Setenv("AppData", suite.TempDir)
-	case "darwin", "ios":
-		suite.T().Setenv("HOME", suite.TempDir)
-	case "plan9":
-		suite.T().Setenv("home", suite.TempDir)
-	default: // Unix
-		suite.T().Setenv("XDG_CONFIG_HOME", suite.TempDir)
-	}
 	// Copy test data to the suite's temporary directory
 	testDataPath := filepath.Join("testdata", "v3_orchestrator_repo")
 	suite.copyRepo(testDataPath)
@@ -314,11 +281,9 @@ Auth:
 	suite.Require().NoError(err)
 	suite.Equal(repo.Version4, repoVersion4)
 
-	// verify the config file has been moved to XDG_CONFIG_HOME/bacalhau/config.yaml
-	// and that it contains the values from the the original config that have been migrated
-	newConfigPath := filepath.Join(suite.TempDir, "bacalhau", config_legacy.FileName)
-	suite.FileExists(newConfigPath)
-	c, err := config.New(config.WithPaths(newConfigPath))
+	// verify the config file remains in the repo directory and contains the migrated values
+	suite.FileExists(configPath)
+	c, err := config.New(config.WithPaths(configPath))
 	suite.Require().NoError(err)
 	var bacCfg types.Bacalhau
 	suite.Require().NoError(c.Unmarshal(&bacCfg))
@@ -364,16 +329,6 @@ Auth:
 
 // repo resulting from `bacalhau serve --node-type=compute --orchestrators=bootstrap.production.bacalhau.org`
 func (suite *V3MigrationsTestSuite) TestV3MigrationWithComputeRepo() {
-	switch runtime.GOOS {
-	case "windows":
-		suite.T().Setenv("AppData", suite.TempDir)
-	case "darwin", "ios":
-		suite.T().Setenv("HOME", suite.TempDir)
-	case "plan9":
-		suite.T().Setenv("home", suite.TempDir)
-	default: // Unix
-		suite.T().Setenv("XDG_CONFIG_HOME", suite.TempDir)
-	}
 	// Copy test data to the suite's temporary directory
 	testDataPath := filepath.Join("testdata", "v3_compute_repo")
 	suite.copyRepo(testDataPath)
@@ -438,11 +393,9 @@ Auth:
 	suite.Require().NoError(err)
 	suite.Equal(repo.Version4, repoVersion4)
 
-	// verify the config file has been moved to XDG_CONFIG_HOME/bacalhau/config.yaml
-	// and that it contains the values from the the original config that have been migrated
-	newConfigPath := filepath.Join(suite.TempDir, "bacalhau", config_legacy.FileName)
-	suite.FileExists(newConfigPath)
-	c, err := config.New(config.WithPaths(newConfigPath))
+	// verify the config file remains in the repo directory and contains the migrated values
+	suite.FileExists(configPath)
+	c, err := config.New(config.WithPaths(configPath))
 	suite.Require().NoError(err)
 	var bacCfg types.Bacalhau
 	suite.Require().NoError(c.Unmarshal(&bacCfg))


### PR DESCRIPTION
A recent change in behaviour has caused some confusion where the default config path changed from `repo/config.yaml` to `~/.config/bacalhau/config.yaml`. This PR reverts this change and continue using a `config.yaml` under the repo/dataDir if present and if no explicit config file was provided by the user through `--config` flag.

The assumption that many users have is deleting the data directory (e.g. `~/.bacalhau`), or pointing to a fresh directory using `$BACALHAU_DIR` env variable or `--data-dir` flag, is reseting the state and configuration of the node or client. However, this wasn't the case as the default config path was outside the data directory. 

### Before this PR
This is an example where issues could happen:
```
# user changes the api port 
# here the user didn't provide a --config file, so configurations 
# were written to a user global `~/.config/bacalhau/config.yaml` 
# and not local to the data dir
bacalhau config set api.port 2233

# user starts a node and expects 2233
# this works as the user didn't specify --config and the default path was picked
bacalhau serve --compute --orchestrator

# user decides to start another node, or just stop the previous one and start fresh again
export BACALHAU_DIR=$(mktemp -d -t bacalhau_dir)
bacalhau serve --compute --orchestrator

# here the user expects the node to start with default api.port of 1234
# but the default configuration was read again
```

### After this PR
```
# user changes the api port 
# the configs are now written to the data dir `$BACALHAU_DIR/config.yaml`
bacalhau config set api.port 2233

# user starts a node and expects 2233
# this works as the user didn't specify --config and the data dir path was picked
bacalhau serve --compute --orchestrator

# user decides to start another node, or just stop the previous one and start fresh again
export BACALHAU_DIR=$(mktemp -d -t bacalhau_dir)
bacalhau serve --compute --orchestrator

# here the node starts with fresh config as the data dir has empty configuratoin
```

### Different Combinations
with the upcoming v1.5.0 release, users are able to define explicit configuration files using `--config` flag, as well as the existing `--data-dir` flag to define where bacalhau stores its state. These are also configurable using env variables.

The default `data-dir` if none is specified is `~/.bacalhau`, and the default config path is `$(dataDir)/config.yaml`. Lets explore what that means in action

#### Setting config
```
# will use ~/.bacalhau/config.yaml
bacalhau config set api.port 2233

# will use hello.yaml
bacalhau config set --config hello.yaml api.port 2233

# will use customDir/config.yaml
bacalhau config set --data-dir customDir api.port 2233

# will use hello.yaml
bacalhau config set --config hello.yaml --data-dir customDir api.port 2233
```

#### Applying config
`bacalhau serve` has the same flags as `bacalhau config set`, and the same logic and precedence applies
```
# will use ~/.bacalhau/config.yaml
bacalhau serve --orchestrator --compute

# will use hello.yaml
bacalhau serve --orchestrator --compute --config hello.yaml

# will use customDir/config.yaml
bacalhau serve --orchestrator --compute --data-dir customDir 

# will use hello.yaml instead of customDir/config.yaml
bacalhau serve --orchestrator --compute --config hello.yaml --data-dir customDir 
```



