### PR TITLE
reduce logging noise

### DIFF
--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -216,7 +216,7 @@ func serve(cmd *cobra.Command, cfg types.Bacalhau, fsRepo *repo.FsRepo) error {
 		}
 	}
 	// Create node
-	log.Info().Msg("starting bacalhau...")
+	log.Info().Msg("Starting bacalhau...")
 	standardNode, err := node.NewNode(ctx, cfg, nodeConfig, fsRepo)
 	if err != nil {
 		return fmt.Errorf("error creating node: %w", err)
@@ -300,8 +300,6 @@ func serve(cmd *cobra.Command, cfg types.Bacalhau, fsRepo *repo.FsRepo) error {
 	if err != nil {
 		return err
 	}
-	cmd.Println()
-	cmd.Println()
 	cmd.Printf("A copy of these variables have been written to: %s\n", riPath)
 	defer os.Remove(riPath)
 

--- a/pkg/eventhandler/chained_handlers.go
+++ b/pkg/eventhandler/chained_handlers.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 // An event handler implementation that chains multiple event handlers, and accepts a context provider
@@ -48,18 +46,7 @@ func (r *ChainedJobEventHandler) HandleJobEvent(ctx context.Context, event model
 
 func logEvent(ctx context.Context, event models.JobEvent, startTime time.Time) func(*error) {
 	return func(handlerError *error) {
-		var logMsg *zerolog.Event
-
-		// TODO: #829 Is checking environment every event the most efficient way
-		// to do this? Could we just shunt logs to different places?
-		switch system.GetEnvironment() {
-		case system.EnvironmentDev, system.EnvironmentTest:
-			logMsg = log.Ctx(ctx).Trace()
-		default:
-			logMsg = log.Ctx(ctx).Info()
-		}
-
-		logMsg = logMsg.
+		logMsg := log.Ctx(ctx).Debug().
 			Str("EventName", event.EventName.String()).
 			Str("JobID", event.JobID).
 			Str("NodeID", event.SourceNodeID).

--- a/pkg/lib/watcher/handlers/logging.go
+++ b/pkg/lib/watcher/handlers/logging.go
@@ -22,7 +22,7 @@ func NewLoggingHandler(
 }
 
 func (p *LoggingHandler) HandleEvent(ctx context.Context, event watcher.Event) error {
-	p.logger.Info().Ctx(ctx).
+	p.logger.Debug().Ctx(ctx).
 		Str("event_type", event.ObjectType).
 		Dur("event_age", time.Since(event.Timestamp)).
 		Msgf("Processing event: %+v", event)

--- a/pkg/lib/watcher/registry.go
+++ b/pkg/lib/watcher/registry.go
@@ -70,7 +70,7 @@ func (r *registry) GetWatcher(watcherID string) (Watcher, error) {
 
 // Stop gracefully shuts down the registry and all its watchers
 func (r *registry) Stop(ctx context.Context) error {
-	log.Ctx(ctx).Info().Msg("Shutting down registry")
+	log.Ctx(ctx).Debug().Msg("Shutting down registry")
 
 	done := make(chan struct{})
 
@@ -91,7 +91,7 @@ func (r *registry) Stop(ctx context.Context) error {
 
 	select {
 	case <-done:
-		log.Ctx(ctx).Info().Msg("registry shutdown complete")
+		log.Ctx(ctx).Debug().Msg("registry shutdown complete")
 		return nil
 	case <-ctx.Done():
 		log.Ctx(ctx).Warn().Msg("registry shutdown timed out")

--- a/pkg/lib/watcher/watcher.go
+++ b/pkg/lib/watcher/watcher.go
@@ -55,7 +55,7 @@ func newWatcher(ctx context.Context, id string, handler EventHandler, store Even
 	checkpoint, err := store.GetCheckpoint(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrCheckpointNotFound) {
-			log.Ctx(ctx).Info().Str("watcher_id", id).
+			log.Ctx(ctx).Debug().Str("watcher_id", id).
 				Msgf("No checkpoint found, starting from %s", options.initialEventIterator)
 		} else {
 			return nil, NewWatcherError(id, err)
@@ -64,7 +64,7 @@ func newWatcher(ctx context.Context, id string, handler EventHandler, store Even
 		w.nextEventIterator = AfterSequenceNumberIterator(checkpoint)
 	}
 
-	log.Ctx(ctx).Info().Str("watcher_id", id).Str("starting_at", w.nextEventIterator.String()).
+	log.Ctx(ctx).Debug().Str("watcher_id", id).Str("starting_at", w.nextEventIterator.String()).
 		Msg("starting watcher")
 
 	return w, nil

--- a/pkg/nats/logger.go
+++ b/pkg/nats/logger.go
@@ -20,7 +20,9 @@ func NewZeroLogger(logger zerolog.Logger, serverID string) ZeroLogger {
 }
 
 func (l ZeroLogger) Noticef(format string, v ...interface{}) {
-	l.logWithLevel(zerolog.InfoLevel, format, v)
+	// As we are mainly interested in error and warn logs from nats,
+	// we se debug level as nats notice/info logs are noisy.
+	l.logWithLevel(zerolog.DebugLevel, format, v)
 }
 
 func (l ZeroLogger) Warnf(format string, v ...interface{}) {

--- a/pkg/nats/pubsub/pubsub.go
+++ b/pkg/nats/pubsub/pubsub.go
@@ -6,11 +6,12 @@ import (
 	"reflect"
 	realsync "sync"
 
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/pubsub"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/nats-io/nats.go"
-	"github.com/rs/zerolog/log"
 )
 
 type PubSubParams struct {
@@ -109,7 +110,7 @@ func (p *PubSub[T]) Close(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	log.Ctx(ctx).Info().Msgf("done closing nats pubsub for subject %s", p.subscriptionSubject)
+	log.Ctx(ctx).Debug().Msgf("done closing nats pubsub for subject %s", p.subscriptionSubject)
 	return nil
 }
 

--- a/pkg/nats/server.go
+++ b/pkg/nats/server.go
@@ -46,7 +46,7 @@ func NewServerManager(ctx context.Context, params ServerManagerParams) (*ServerM
 	if !ns.ReadyForConnections(params.ConnectionTimeout) {
 		return nil, fmt.Errorf("could not start nats server on time")
 	}
-	log.Ctx(ctx).Info().Msgf("NATS server %s listening on %s", ns.ID(), ns.ClientURL())
+	log.Ctx(ctx).Debug().Msgf("NATS server %s listening on %s", ns.ID(), ns.ClientURL())
 	return &ServerManager{
 		Server: ns,
 	}, err

--- a/pkg/node/heartbeat/server.go
+++ b/pkg/node/heartbeat/server.go
@@ -81,7 +81,7 @@ func (h *HeartbeatServer) Start(ctx context.Context) error {
 			if err := h.legacySubscriber.Close(ctx); err != nil {
 				log.Ctx(ctx).Error().Err(err).Msg("Error during heartbeat server shutdown")
 			} else {
-				log.Ctx(ctx).Info().Msg("Heartbeat server shutdown")
+				log.Ctx(ctx).Debug().Msg("Heartbeat server shutdown")
 			}
 		}()
 
@@ -101,7 +101,7 @@ func (h *HeartbeatServer) Start(ctx context.Context) error {
 
 	// Wait for the ticker to be created before returning
 	<-tickerStartCh
-	log.Ctx(ctx).Info().Msg("Heartbeat server started")
+	log.Ctx(ctx).Debug().Msg("Heartbeat server started")
 
 	return nil
 }

--- a/pkg/node/manager/node_manager.go
+++ b/pkg/node/manager/node_manager.go
@@ -44,7 +44,7 @@ type NodeManagerParams struct {
 // NewNodeManager constructs a new node manager and returns a pointer
 // to the structure.
 func NewNodeManager(params NodeManagerParams) *NodeManager {
-	log.Info().Msgf("Nodes joining the cluster will be assigned approval state: %s",
+	log.Debug().Msgf("Nodes joining the cluster will be assigned approval state: %s",
 		params.DefaultApprovalState.String())
 	return &NodeManager{
 		resourceMap:          concurrency.NewStripedMap[trackedResources](resourceMapLockCount),
@@ -63,7 +63,7 @@ func (n *NodeManager) Start(ctx context.Context) error {
 		}
 	}
 
-	log.Ctx(ctx).Info().Msg("Node manager started")
+	log.Ctx(ctx).Debug().Msg("Node manager started")
 
 	return nil
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -346,10 +346,6 @@ func prepareConfig(config *NodeConfig, bacalhauConfig types.Bacalhau) error {
 	if err != nil {
 		return err
 	}
-	// TODO: #830 Same as #829 in pkg/eventhandler/chained_handlers.go
-	if system.GetEnvironment() == system.EnvironmentTest || system.GetEnvironment() == system.EnvironmentDev {
-		config.APIServerConfig.LogLevel = "trace"
-	}
 
 	err = config.Validate()
 	if err != nil {

--- a/pkg/publicapi/config.go
+++ b/pkg/publicapi/config.go
@@ -59,7 +59,7 @@ var defaultConfig = Config{
 	MaxBytesToReadInBody:  "10MB",
 	ThrottleLimit:         1000,
 	Protocol:              "http",
-	LogLevel:              "info",
+	LogLevel:              "debug",
 }
 
 // DefaultConfig returns the default configuration for the public API server.

--- a/pkg/publicapi/middleware/version.go
+++ b/pkg/publicapi/middleware/version.go
@@ -42,7 +42,7 @@ func VersionNotifyLogger(logger *zerolog.Logger, serverVersion semver.Version) e
 
 			defer func() {
 				if notif.Message != "" {
-					logger.WithLevel(zerolog.WarnLevel).
+					logger.WithLevel(zerolog.TraceLevel).
 						Str("ClientID", notif.ClientID).
 						Str("RequestID", notif.RequestID).
 						Str("ClientVersion", notif.ClientVersion).

--- a/pkg/publicapi/middleware/version.go
+++ b/pkg/publicapi/middleware/version.go
@@ -42,7 +42,7 @@ func VersionNotifyLogger(logger *zerolog.Logger, serverVersion semver.Version) e
 
 			defer func() {
 				if notif.Message != "" {
-					logger.WithLevel(zerolog.TraceLevel).
+					logger.WithLevel(zerolog.DebugLevel).
 						Str("ClientID", notif.ClientID).
 						Str("RequestID", notif.RequestID).
 						Str("ClientVersion", notif.ClientVersion).

--- a/pkg/publicapi/server.go
+++ b/pkg/publicapi/server.go
@@ -90,13 +90,13 @@ func NewAPIServer(params ServerParams) (*Server, error) {
 	server.Router.Binder = NewNormalizeBinder()
 	server.Router.Validator = NewCustomValidator()
 
-	// set middleware
-	logLevel, err := zerolog.ParseLevel(params.Config.LogLevel)
-	if logLevel == zerolog.DebugLevel {
+	if zerolog.GlobalLevel() <= zerolog.DebugLevel {
 		// enable debug mode to get clearer error messages
 		server.Router.Debug = true
 	}
 
+	// set middleware
+	logLevel, err := zerolog.ParseLevel(params.Config.LogLevel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/publisher/local/server.go
+++ b/pkg/publisher/local/server.go
@@ -49,12 +49,12 @@ func (s *LocalPublisherServer) Run(ctx context.Context) {
 		}
 	}(server, errChan)
 
-	log.Ctx(ctx).Info().Msgf("Running local publishing server on %s", server.Addr)
+	log.Ctx(ctx).Debug().Msgf("Running local publishing server on %s", server.Addr)
 
 	// Wait for cancellation or an error during ListenAndServe
 	select {
 	case <-ctx.Done(): // context cancelled
-		log.Ctx(ctx).Info().Msg("Shutting down local publishing server")
+		log.Ctx(ctx).Debug().Msg("Shutting down local publishing server")
 	case err := <-errChan:
 		log.Ctx(ctx).Error().Err(err).Msg("error running local publishing server")
 	}


### PR DESCRIPTION
### Before
```
❯ bacalhau-1.5.0 serve --orchestrator --compute --data-dir v1.5.0/data-dir
17:49:24.837 | WRN cmd/cli/serve/serve.go:146 > --name flag with value  ignored. Name n-a4e0671b-2679-4bc0-86b7-160ac093d2dc already exists
17:49:24.879 | INF cmd/cli/serve/serve.go:218 > starting bacalhau...
17:49:24.891 | INF pkg/nats/logger.go:47 > Starting nats-server [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.891 | INF pkg/nats/logger.go:47 >   Version:  2.10.11 [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.891 | INF pkg/nats/logger.go:47 >   Git:      [not set] [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.891 | INF pkg/nats/logger.go:47 >   Name:     n-a4e0671b-2679-4bc0-86b7-160ac093d2dc [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.891 | INF pkg/nats/logger.go:47 >   Node:     KQ4D6Bsn [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.891 | INF pkg/nats/logger.go:47 >   ID:       NCEPXW5MIPEZJFEYIWHZ6UVM3UKTG3SAYEP5RZ3U33RZSZ4A6HBYAEMM [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.893 | INF pkg/nats/logger.go:47 > Starting JetStream [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.893 | INF pkg/nats/logger.go:47 > ---------------- JETSTREAM ---------------- [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.893 | INF pkg/nats/logger.go:47 >   Max Memory:      48.00 GB [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.893 | INF pkg/nats/logger.go:47 >   Max Storage:     49.95 GB [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.893 | INF pkg/nats/logger.go:47 >   Store Directory: "v1.5.0/data-dir/orchestrator/nats-store/jetstream" [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.893 | INF pkg/nats/logger.go:47 > ------------------------------------------- [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.894 | INF pkg/nats/logger.go:47 >   Starting restore for stream '$G > KV_node_v1' [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.896 | WRN pkg/nats/logger.go:47 > Filestore [KV_node_v1] Stream state encountered internal inconsistency on recover [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.897 | INF pkg/nats/logger.go:47 >   Restored 1 messages for stream '$G > KV_node_v1' in 2ms [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.897 | INF pkg/nats/logger.go:47 > Listening for client connections on 0.0.0.0:4222 [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.897 | INF pkg/nats/logger.go:47 > Server is ready [Server:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc]
17:49:24.916 | INF pkg/nats/server.go:49 > NATS server NCEPXW5MIPEZJFEYIWHZ6UVM3UKTG3SAYEP5RZ3U33RZSZ4A6HBYAEMM listening on nats://0.0.0.0:4222 [NodeID:n-a4e0671b]
17:49:24.921 | INF pkg/node/manager/node_manager.go:47 > Nodes joining the cluster will be assigned approval state: APPROVED
17:49:24.921 | INF pkg/node/heartbeat/server.go:59 > Heartbeat server started [NodeID:n-a4e0671b]
17:49:24.922 | INF pkg/node/manager/node_manager.go:66 > Node manager started [NodeID:n-a4e0671b]
17:49:24.925 | INF pkg/publisher/local/server.go:52 > Running local publishing server on 0.0.0.0:6001 [NodeID:n-a4e0671b]
17:49:24.925 | INF pkg/lib/watcher/watcher.go:59 > No checkpoint found, starting from latest [NodeID:n-a4e0671b] [watcher_id:compute-logger]
17:49:24.926 | INF pkg/lib/watcher/watcher.go:68 > starting watcher [NodeID:n-a4e0671b] [starting_at:latest] [watcher_id:compute-logger]
17:49:25.632 | INF cmd/cli/serve/serve.go:271 > bacalhau node running [address:0.0.0.0:1234] [capacity:"{CPU: 8.399999999999999, Memory: 48 GB, Disk: 50 GB, GPU: 0}"] [compute_enabled:true] [engines:["docker","wasm"]] [name:n-a4e0671b-2679-4bc0-86b7-160ac093d2dc] [orchestrator_address:0.0.0.0:4222] [orchestrator_enabled:true] [orchestrators:["nats://127.0.0.1:4222"]] [publishers:["local","noop"]] [storages:["urldownload","inline"]] [webui_enabled:false]

To connect to this node from the local client, run the following commands in your shell:
export BACALHAU_API_HOST=127.0.0.1
export BACALHAU_API_PORT=1234
export BACALHAU_COMPUTE_ORCHESTRATORS=nats://127.0.0.1:4222



A copy of these variables have been written to: v1.5.0/data-dir/bacalhau.run
```

### After:
```
bacalhau serve --compute --orchestrator
11:26:25.633 | INF ProtocolLabs/workspace/bacalhau/pkg/config/config.go:211 > Config loaded from: [], and with data-dir /Users/walid/.bacalhau
11:26:25.667 | INF ProtocolLabs/workspace/bacalhau/cmd/cli/serve/serve.go:219 > Starting bacalhau...
11:26:25.77 | INF ProtocolLabs/workspace/bacalhau/cmd/cli/serve/serve.go:292 > bacalhau node running [address:0.0.0.0:1234] [capacity:"{CPU: 5.6, Memory: 12 GB, Disk: 30 GB, GPU: 0}"] [compute_enabled:true] [engines:["docker","wasm"]] [name:n-a98c6a60-4c08-49d2-b17d-90daa49abc5f] [orchestrator_address:0.0.0.0:4222] [orchestrator_enabled:true] [orchestrators:["nats://127.0.0.1:4222"]] [publishers:["local","noop","s3"]] [storages:["urldownload","inline","s3"]] [webui_enabled:false]

To connect to this node from the local client, run the following commands in your shell:
export BACALHAU_API_HOST=127.0.0.1
export BACALHAU_API_PORT=1234

A copy of these variables have been written to: /Users/walid/.bacalhau/bacalhau.run
```
Closes #4438 