### PR TITLE
introduce system.GlobalConfig + migrate installation id

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -148,6 +149,6 @@ func injectRootSpan(cmd *cobra.Command, ctx context.Context) context.Context {
 		names = append([]string{root.Name()}, names...)
 	}
 	name := fmt.Sprintf("bacalhau.%s", strings.Join(names, "."))
-	ctx, span := system.NewRootSpan(ctx, system.GetTracer(), name)
+	ctx, span := telemetry.NewRootSpan(ctx, telemetry.GetTracer(), name)
 	return context.WithValue(ctx, spanKey, span)
 }

--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -9,11 +9,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bacalhau-project/bacalhau/cmd/util/auth"
-	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/apimodels"
 	clientv2 "github.com/bacalhau-project/bacalhau/pkg/publicapi/client/v2"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/version"
 )
 
@@ -50,11 +50,12 @@ func GetAPIClientV2(cmd *cobra.Command, cfg types.Bacalhau) (clientv2.API, error
 		if sysmeta.InstanceID != "" {
 			headers[apimodels.HTTPHeaderBacalhauInstanceID] = []string{sysmeta.InstanceID}
 		}
-		if installationID := config.ReadInstallationID(); installationID != "" {
-			headers[apimodels.HTTPHeaderBacalhauInstallationID] = []string{installationID}
-		}
 	} else {
 		log.Debug().Err(err).Msg("failed to load system metadata from repo path")
+	}
+
+	if installationID := system.InstallationID(); installationID != "" {
+		headers[apimodels.HTTPHeaderBacalhauInstallationID] = []string{installationID}
 	}
 
 	opts := []clientv2.OptionFn{

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -63,13 +63,17 @@ func WithNodeType(isRequester, isCompute bool) Option {
 
 func WithInstallationID(id string) Option {
 	return func(c *Config) {
-		c.attributes = append(c.attributes, attribute.String(NodeInstallationIDKey, id))
+		if id != "" {
+			c.attributes = append(c.attributes, attribute.String(NodeInstallationIDKey, id))
+		}
 	}
 }
 
 func WithInstanceID(id string) Option {
 	return func(c *Config) {
-		c.attributes = append(c.attributes, attribute.String(NodeInstanceIDKey, id))
+		if id != "" {
+			c.attributes = append(c.attributes, attribute.String(NodeInstanceIDKey, id))
+		}
 	}
 }
 

--- a/pkg/compute/endpoint.go
+++ b/pkg/compute/endpoint.go
@@ -10,11 +10,11 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/concurrency"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute/capacity"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/logstream"
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 type BaseEndpointParams struct {
@@ -52,7 +52,7 @@ func (s BaseEndpoint) GetNodeID() string {
 }
 
 func (s BaseEndpoint) AskForBid(ctx context.Context, request AskForBidRequest) (AskForBidResponse, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.BaseEndpoint.AskForBid", trace.WithSpanKind(trace.SpanKindInternal))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/compute.BaseEndpoint.AskForBid", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 	log.Ctx(ctx).Debug().Msgf("asked to bid on: %+v", request)
 	jobsReceived.Add(ctx, 1)

--- a/pkg/compute/executor_buffer.go
+++ b/pkg/compute/executor_buffer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/lib/collections"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
 type bufferTask struct {
@@ -116,9 +116,9 @@ func (s *ExecutorBuffer) Run(ctx context.Context, localExecutionState store.Loca
 // doRun triggers the execution by the delegate backend.Executor and frees up the capacity when the execution is done.
 func (s *ExecutorBuffer) doRun(ctx context.Context, task *bufferTask) {
 	job := task.localExecutionState.Execution.Job
-	ctx = system.AddJobIDToBaggage(ctx, job.ID)
-	ctx = system.AddNodeIDToBaggage(ctx, s.ID)
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Run")
+	ctx = telemetry.AddJobIDToBaggage(ctx, job.ID)
+	ctx = telemetry.AddNodeIDToBaggage(ctx, s.ID)
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/compute.ExecutorBuffer.Run")
 	defer span.End()
 
 	innerCtx := ctx
@@ -200,9 +200,9 @@ func (s *ExecutorBuffer) Cancel(_ context.Context, localExecutionState store.Loc
 	execution := localExecutionState.Execution
 	go func() {
 		ctx := logger.ContextWithNodeIDLogger(context.Background(), s.ID)
-		ctx = system.AddJobIDToBaggage(ctx, execution.Job.ID)
-		ctx = system.AddNodeIDToBaggage(ctx, s.ID)
-		ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/compute.ExecutorBuffer.Cancel")
+		ctx = telemetry.AddJobIDToBaggage(ctx, execution.Job.ID)
+		ctx = telemetry.AddNodeIDToBaggage(ctx, s.ID)
+		ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/compute.ExecutorBuffer.Cancel")
 		defer span.End()
 
 		err := s.delegateService.Cancel(ctx, localExecutionState)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -301,28 +300,4 @@ func GenerateNodeID(ctx context.Context, nodeNameProviderType string) (string, e
 	}
 
 	return nodeName, nil
-}
-
-func ReadInstallationID() string {
-	var idFile string
-	switch runtime.GOOS {
-	case "linux", "darwin":
-		configDir := os.Getenv("XDG_CONFIG_HOME")
-		if configDir == "" {
-			configDir = filepath.Join(os.Getenv("HOME"), ".config")
-		}
-		idFile = filepath.Join(configDir, "bacalhau", "installation_id")
-	case "windows":
-		appData := os.Getenv("APPDATA")
-		idFile = filepath.Join(appData, "bacalhau", "installation_id")
-	default:
-		configDir := filepath.Join(os.Getenv("HOME"), ".config")
-		idFile = filepath.Join(configDir, "bacalhau", "installation_id")
-	}
-
-	idBytes, err := os.ReadFile(idFile)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(idBytes))
 }

--- a/pkg/docker/tracing/traced.go
+++ b/pkg/docker/tracing/traced.go
@@ -17,7 +17,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
@@ -203,9 +202,9 @@ func (c TracedClient) Close() error {
 }
 
 func (c TracedClient) span(ctx context.Context, name string) (context.Context, trace.Span) {
-	return system.NewSpan(
+	return telemetry.NewSpan(
 		ctx,
-		system.GetTracer(),
+		telemetry.GetTracer(),
 		fmt.Sprintf("docker.%s", name),
 		trace.WithAttributes(semconv.HostName(c.hostname), semconv.PeerService("docker")),
 		trace.WithSpanKind(trace.SpanKindClient),

--- a/pkg/eventhandler/context_provider.go
+++ b/pkg/eventhandler/context_provider.go
@@ -8,7 +8,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
@@ -37,7 +36,7 @@ func (t *TracerContextProvider) GetContext(ctx context.Context, jobID string) co
 	t.contextMutex.Lock()
 	defer t.contextMutex.Unlock()
 
-	jobCtx, _ := system.Span(ctx, "pkg/eventhandler/JobEventHandler.HandleJobEvent",
+	jobCtx, _ := telemetry.Span(ctx, "pkg/eventhandler/JobEventHandler.HandleJobEvent",
 		oteltrace.WithSpanKind(oteltrace.SpanKindInternal),
 		oteltrace.WithAttributes(
 			attribute.String(telemetry.TracerAttributeNameNodeID, t.nodeID),

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -12,10 +12,9 @@ import (
 	"github.com/tetratelabs/wazero"
 	"go.uber.org/atomic"
 
-	"github.com/bacalhau-project/bacalhau/pkg/models"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
-
 	"github.com/bacalhau-project/bacalhau/pkg/lib/math"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 
 	"github.com/bacalhau-project/bacalhau/pkg/bidstrategy"
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
@@ -66,7 +65,7 @@ const WasmMaxPagesLimit = 1 << (WasmArch / 2)
 
 // Start initiates an execution based on the provided RunCommandRequest.
 func (e *Executor) Start(ctx context.Context, request *executor.RunCommandRequest) error {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.Executor.Start")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.Executor.Start")
 	defer span.End()
 
 	if handler, found := e.handlers.Get(request.ExecutionID); found {

--- a/pkg/executor/wasm/loader.go
+++ b/pkg/executor/wasm/loader.go
@@ -15,7 +15,7 @@ import (
 	"go.ptx.dk/multierrgroup"
 
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
 // ModuleLoader handles the loading of WebAssembly modules from
@@ -46,7 +46,7 @@ func NewModuleLoader(runtime wazero.Runtime, config wazero.ModuleConfig, storage
 
 // Load compiles and returns a module located at the passed path.
 func (loader *ModuleLoader) Load(ctx context.Context, path string) (wazero.CompiledModule, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.ModuleLoader.Load")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.ModuleLoader.Load")
 	span.SetAttributes(attribute.String("Path", path))
 	defer span.End()
 
@@ -66,7 +66,7 @@ func (loader *ModuleLoader) Load(ctx context.Context, path string) (wazero.Compi
 
 // loadModule loads and compiles all of the modules located by the passed storage specs.
 func (loader *ModuleLoader) loadModule(ctx context.Context, m storage.PreparedStorage) (wazero.CompiledModule, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.ModuleLoader.loadModule")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.ModuleLoader.loadModule")
 	defer span.End()
 
 	programPath := m.Volume.Source
@@ -106,7 +106,7 @@ func (loader *ModuleLoader) loadModule(ctx context.Context, m storage.PreparedSt
 // loaded modules, so that the returned module has all of its dependencies fully
 // instantiated and is ready to use.
 func (loader *ModuleLoader) InstantiateRemoteModule(ctx context.Context, m storage.PreparedStorage) (api.Module, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.ModuleLoader.InstantiateRemoteModule")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.ModuleLoader.InstantiateRemoteModule")
 	span.SetAttributes(attribute.String("ModuleName", m.InputSource.Alias))
 	defer span.End()
 
@@ -150,7 +150,7 @@ const unknownModuleErrStr = ("could not find WASM module with name %q. " +
 	"see also: https://docs.bacalhau.org/getting-started/wasm-workload-onboarding")
 
 func (loader *ModuleLoader) loadModuleByName(ctx context.Context, moduleName string) (api.Module, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.ModuleLoader.loadModuleByName")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.ModuleLoader.loadModuleByName")
 	span.SetAttributes(attribute.String("ModuleName", moduleName))
 	defer span.End()
 

--- a/pkg/executor/wasm/trace.go
+++ b/pkg/executor/wasm/trace.go
@@ -3,7 +3,6 @@ package wasm
 import (
 	"context"
 
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 
 	observe "github.com/dylibso/observe-sdk/go"
@@ -59,7 +58,7 @@ func (t tracedRuntime) Instantiate(ctx context.Context, source []byte) (api.Modu
 			return nil, err
 		}
 	}
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.tracedRuntime.Instantiate")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.tracedRuntime.Instantiate")
 	defer span.End()
 	module, err := telemetry.RecordErrorOnSpanTwo[api.Module](span)(t.Runtime.Instantiate(ctx, source))
 	if module != nil {
@@ -78,7 +77,7 @@ func (t tracedRuntime) InstantiateWithConfig(ctx context.Context, source []byte,
 			return nil, err
 		}
 	}
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.tracedRuntime.InstantiateWithConfig")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.tracedRuntime.InstantiateWithConfig")
 	defer span.End()
 	module, err := telemetry.RecordErrorOnSpanTwo[api.Module](span)(t.Runtime.InstantiateWithConfig(ctx, source, config))
 	if module != nil {
@@ -97,7 +96,7 @@ func (t tracedRuntime) CompileModule(ctx context.Context, binary []byte) (wazero
 			return nil, err
 		}
 	}
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.tracedRuntime.CompileModule")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.tracedRuntime.CompileModule")
 	defer span.End()
 	module, err := telemetry.RecordErrorOnSpanTwo[wazero.CompiledModule](span)(t.Runtime.CompileModule(ctx, binary))
 	if module != nil {
@@ -114,7 +113,7 @@ func (t tracedRuntime) InstantiateModule(
 	compiled wazero.CompiledModule,
 	config wazero.ModuleConfig,
 ) (api.Module, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/executor/wasm.tracedRuntime.InstantiateModule")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/executor/wasm.tracedRuntime.InstantiateModule")
 	defer span.End()
 	m := compiled.(tracedCompiledModule)
 	module, err := telemetry.RecordErrorOnSpanTwo[api.Module](span)(t.Runtime.InstantiateModule(ctx, m.CompiledModule, config))
@@ -135,9 +134,9 @@ func (t tracedFunction) Call(ctx context.Context, params ...uint64) ([]uint64, e
 	if t.traceCtx != nil {
 		defer t.traceCtx.Finish()
 	}
-	ctx, span := system.NewSpan(
+	ctx, span := telemetry.NewSpan(
 		ctx,
-		system.GetTracer(),
+		telemetry.GetTracer(),
 		"pkg/executor/wasm.tracedFunction.Call",
 		trace.WithAttributes(semconv.CodeFunction(t.Function.Definition().Name())),
 	)
@@ -155,9 +154,9 @@ func (t tracedFunction) CallWithStack(ctx context.Context, stack []uint64) error
 	if t.traceCtx != nil {
 		defer t.traceCtx.Finish()
 	}
-	ctx, span := system.NewSpan(
+	ctx, span := telemetry.NewSpan(
 		ctx,
-		system.GetTracer(),
+		telemetry.GetTracer(),
 		"pkg/executor/wasm.tracedFunction.CallWithStack",
 		trace.WithAttributes(semconv.CodeFunction(t.Function.Definition().Name())),
 	)

--- a/pkg/nats/pubsub/pubsub.go
+++ b/pkg/nats/pubsub/pubsub.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/pubsub"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
 type PubSubParams struct {
@@ -48,7 +48,7 @@ func NewPubSub[T any](params PubSubParams) (*PubSub[T], error) {
 }
 
 func (p *PubSub[T]) Publish(ctx context.Context, message T) error {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub/nats.publish")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/pubsub/nats.publish")
 	defer span.End()
 
 	payload, err := marshaller.JSONMarshalWithMax(message)

--- a/pkg/orchestrator/transformer/job.go
+++ b/pkg/orchestrator/transformer/job.go
@@ -117,7 +117,9 @@ func RequesterInfo(requesterNodeID string) JobTransformer {
 
 func OrchestratorInstanceID(instanceID string) JobTransformer {
 	f := func(ctx context.Context, job *models.Job) error {
-		job.Meta[models.MetaServerInstanceID] = instanceID
+		if instanceID != "" {
+			job.Meta[models.MetaServerInstanceID] = instanceID
+		}
 		return nil
 	}
 	return JobFn(f)
@@ -125,7 +127,9 @@ func OrchestratorInstanceID(instanceID string) JobTransformer {
 
 func OrchestratorInstallationID(installationID string) JobTransformer {
 	f := func(ctx context.Context, job *models.Job) error {
-		job.Meta[models.MetaServerInstallationID] = installationID
+		if installationID != "" {
+			job.Meta[models.MetaServerInstallationID] = installationID
+		}
 		return nil
 	}
 	return JobFn(f)

--- a/pkg/publisher/tracing/tracing.go
+++ b/pkg/publisher/tracing/tracing.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 	"github.com/bacalhau-project/bacalhau/pkg/util/reflection"
 )
@@ -27,7 +26,7 @@ func Wrap(delegate publisher.Publisher) publisher.Publisher {
 }
 
 func (t *tracingPublisher) IsInstalled(ctx context.Context) (bool, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.IsInstalled", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.IsInstalled", t.name))
 	defer span.End()
 
 	return t.delegate.IsInstalled(ctx)
@@ -42,7 +41,7 @@ func (t *tracingPublisher) PublishResult(
 ) (spec models.SpecConfig, err error) {
 	attributes := execution.Job.MetricAttributes()
 
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.PublishResult", t.name),
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.PublishResult", t.name),
 		trace.WithAttributes(attributes...))
 	defer span.End()
 

--- a/pkg/pubsub/buffering_pubsub.go
+++ b/pkg/pubsub/buffering_pubsub.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/rs/zerolog/log"
 )
 
@@ -58,7 +58,7 @@ func NewBufferingPubSub[T any](params BufferingPubSubParams) *BufferingPubSub[T]
 }
 
 func (p *BufferingPubSub[T]) Publish(ctx context.Context, message T) error {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub.BufferingPubSub.publish")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/pubsub.BufferingPubSub.publish")
 	defer span.End()
 
 	payload, err := marshaller.JSONMarshalWithMax(message)
@@ -155,7 +155,7 @@ func (p *BufferingPubSub[T]) Close(ctx context.Context) (err error) {
 
 // flush the buffer to the delegate pubsub
 func (p *BufferingPubSub[T]) flushBuffer(ctx context.Context, envelope BufferingEnvelope, oldestMessageTime time.Time) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub.BufferingPubSub.flushBuffer")
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/pubsub.BufferingPubSub.flushBuffer")
 	defer span.End()
 
 	log.Ctx(ctx).Trace().Msgf("flushing pubsub buffer after %s with %d messages, %d bytes",
@@ -175,7 +175,7 @@ func (p *BufferingPubSub[T]) antiStarvationTask() {
 		case <-p.antiStarvationTicker.C:
 			if p.currentBuffer.Size() > 0 && time.Since(p.oldestMessageTime) > p.maxBufferAge {
 				func() {
-					ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/pubsub.BufferingPubSub.antiStarvationTask") //nolint:govet
+					ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/pubsub.BufferingPubSub.antiStarvationTask") //nolint:govet
 					defer span.End()
 					p.flushMutex.Lock()
 					defer p.flushMutex.Unlock()

--- a/pkg/repo/migrations/helpers.go
+++ b/pkg/repo/migrations/helpers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/config_legacy"
 	legacy_types "github.com/bacalhau-project/bacalhau/pkg/config_legacy/types"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 const libp2pPrivateKey = "libp2p_private_key"
@@ -139,5 +141,20 @@ func copyFile(srcPath, dstPath string) error {
 		return err
 	}
 
+	return nil
+}
+
+// writeInstallationID writes the installation ID to system wide config path
+func writeInstallationID(cfg system.GlobalConfig, installationID string) error {
+	// Create config dir if it doesn't exist
+	if err := os.MkdirAll(cfg.ConfigDir(), util.OS_USER_RW); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+
+	// Write installation ID to file
+	installationIDFile := filepath.Join(cfg.ConfigDir(), system.InstallationIDFile)
+	if err := os.WriteFile(installationIDFile, []byte(installationID), util.OS_USER_RW); err != nil {
+		return fmt.Errorf("writing installation ID file: %w", err)
+	}
 	return nil
 }

--- a/pkg/repo/migrations/v3_4.go
+++ b/pkg/repo/migrations/v3_4.go
@@ -14,6 +14,7 @@ import (
 	legacy_types "github.com/bacalhau-project/bacalhau/pkg/config_legacy/types"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 // V3Migration updates the repo, replacing repo.version and update.json with system_metadata.yaml.
@@ -33,96 +34,106 @@ import (
 // - Removes ./bacalhau/execution_store.
 // - If a user has configured a custom user key path, the configured value is copied to .bacalhau/user_id.pem.
 // - If a user has configured a custom auth tokens path, the configured value is copied to .bacalhau/tokens.json.
-var V3Migration = repo.NewMigration(
-	repo.Version3,
-	repo.Version4,
-	func(r repo.FsRepo) error {
-		repoPath, err := r.Path()
-		if err != nil {
-			return err
-		}
-		_, fileCfg, err := readConfig(r)
-		if err != nil {
-			return err
-		}
-		// migrate from the repo.version file to the system_metadata.yaml file.
-		{
-			// Initialize the SystemMetadataFile in the staging directory
-			if err := r.WriteVersion(repo.Version4); err != nil {
+var V3Migration = V3MigrationWithConfig(system.DefaultGlobalConfig)
+
+func V3MigrationWithConfig(globalCfg system.GlobalConfig) repo.Migration {
+	return repo.NewMigration(
+		repo.Version3,
+		repo.Version4,
+		func(r repo.FsRepo) error {
+			repoPath, err := r.Path()
+			if err != nil {
 				return err
 			}
-			if err := r.WriteLastUpdateCheck(time.UnixMilli(0)); err != nil {
+			_, fileCfg, err := readConfig(r)
+			if err != nil {
 				return err
 			}
+			// migrate from the repo.version file to the system_metadata.yaml file.
+			{
+				// Initialize the SystemMetadataFile in the staging directory
+				if err := r.WriteVersion(repo.Version4); err != nil {
+					return err
+				}
+				if err := r.WriteLastUpdateCheck(time.UnixMilli(0)); err != nil {
+					return err
+				}
 
-			// ignore this error as the file may not exist
-			_ = os.Remove(filepath.Join(repoPath, "update.json"))
-			// remove the legacy repo version file
-			if err := os.Remove(filepath.Join(repoPath, repo.LegacyVersionFile)); err != nil {
-				return fmt.Errorf("removing legacy repo version file: %w", err)
-			}
-		}
-
-		// migrate to the new repo structure
-		{
-			// if the user provided a non-standard path we will move it to the migrated repo
-			// if the user didn't provide a path, no copy required as the location of the file in the repo
-			// is unchanged.
-			if fileCfg.User.KeyPath != "" {
-				if err := copyFile(fileCfg.User.KeyPath, filepath.Join(repoPath, types.UserKeyFileName)); err != nil {
-					return fmt.Errorf("copying user key file: %w", err)
+				// ignore this error as the file may not exist
+				_ = os.Remove(filepath.Join(repoPath, "update.json"))
+				// remove the legacy repo version file
+				if err := os.Remove(filepath.Join(repoPath, repo.LegacyVersionFile)); err != nil {
+					return fmt.Errorf("removing legacy repo version file: %w", err)
 				}
 			}
 
-			// if the user provided a non-standard path we will move it to the migrated repo
-			// if the user didn't provide a path, no copy required as the location of the file in the repo
-			// is unchanged.
-			if fileCfg.Auth.TokensPath != "" {
-				if err := copyFile(fileCfg.Auth.TokensPath, filepath.Join(repoPath, types.AuthTokensFileName)); err != nil {
-					return fmt.Errorf("copying auth tokens file: %w", err)
+			// migrate to the new repo structure
+			{
+				// if the user provided a non-standard path we will move it to the migrated repo
+				// if the user didn't provide a path, no copy required as the location of the file in the repo
+				// is unchanged.
+				if fileCfg.User.KeyPath != "" {
+					if err := copyFile(fileCfg.User.KeyPath, filepath.Join(repoPath, types.UserKeyFileName)); err != nil {
+						return fmt.Errorf("copying user key file: %w", err)
+					}
+				}
+
+				// if the user provided a non-standard path we will move it to the migrated repo
+				// if the user didn't provide a path, no copy required as the location of the file in the repo
+				// is unchanged.
+				if fileCfg.Auth.TokensPath != "" {
+					if err := copyFile(fileCfg.Auth.TokensPath, filepath.Join(repoPath, types.AuthTokensFileName)); err != nil {
+						return fmt.Errorf("copying auth tokens file: %w", err)
+					}
+				}
+
+				if err := migrateOrchestratorStore(repoPath, fileCfg.Node.Requester.JobStore); err != nil {
+					return err
+				}
+
+				if err := migrateComputeStore(repoPath, fileCfg.Node.Compute.ExecutionStore); err != nil {
+					return err
 				}
 			}
 
-			if err := migrateOrchestratorStore(repoPath, fileCfg.Node.Requester.JobStore); err != nil {
-				return err
+			// iff there is a config file in the repo, try and move it to $XDG_CONFIG_HOME/bacalhau
+			{
+				oldConfigFilePath := filepath.Join(repoPath, config_legacy.FileName)
+				if _, err := os.Stat(oldConfigFilePath); err == nil {
+					// migrate installationID if none is present in the system wide config
+					if fileCfg.User.InstallationID != "" && globalCfg.InstallationID() == "" {
+						if err := writeInstallationID(globalCfg, fileCfg.User.InstallationID); err != nil {
+							return err
+						}
+					}
+					if err := r.WriteNodeName(fileCfg.Node.Name); err != nil {
+						return fmt.Errorf("migrating node name: %w", err)
+					}
+					newConfigType, err := config.MigrateV1(fileCfg)
+					if err != nil {
+						return fmt.Errorf("migrating to new config: %w", err)
+					}
+					// ensure the repo path of the config points to the repo
+					newConfigType.DataDir = repoPath
+
+					// Write the updated config back to the same file
+					newConfigBytes, err := yaml.Marshal(&newConfigType)
+					if err != nil {
+						return fmt.Errorf("marshaling new config: %w", err)
+					}
+					if err := os.WriteFile(oldConfigFilePath, newConfigBytes, util.OS_USER_RWX); err != nil {
+						return fmt.Errorf("writing updated config file: %w", err)
+					}
+				} else if !os.IsNotExist(err) {
+					// if there was an error other than the file not existing, abort.
+					return fmt.Errorf("failed to read config file %s while migrating: %w", oldConfigFilePath, err)
+				}
+
 			}
-
-			if err := migrateComputeStore(repoPath, fileCfg.Node.Compute.ExecutionStore); err != nil {
-				return err
-			}
-		}
-
-		// iff there is a config file in the repo, try and move it to $XDG_CONFIG_HOME/bacalhau
-		{
-			oldConfigFilePath := filepath.Join(repoPath, config_legacy.FileName)
-			if _, err := os.Stat(oldConfigFilePath); err == nil {
-				if err := r.WriteNodeName(fileCfg.Node.Name); err != nil {
-					return fmt.Errorf("migrating node name: %w", err)
-				}
-				newConfigType, err := config.MigrateV1(fileCfg)
-				if err != nil {
-					return fmt.Errorf("migrating to new config: %w", err)
-				}
-				// ensure the repo path of the config points to the repo
-				newConfigType.DataDir = repoPath
-
-				// Write the updated config back to the same file
-				newConfigBytes, err := yaml.Marshal(&newConfigType)
-				if err != nil {
-					return fmt.Errorf("marshaling new config: %w", err)
-				}
-				if err := os.WriteFile(oldConfigFilePath, newConfigBytes, util.OS_USER_RWX); err != nil {
-					return fmt.Errorf("writing updated config file: %w", err)
-				}
-			} else if !os.IsNotExist(err) {
-				// if there was an error other than the file not existing, abort.
-				return fmt.Errorf("failed to read config file %s while migrating: %w", oldConfigFilePath, err)
-			}
-
-		}
-		return nil
-	},
-)
+			return nil
+		},
+	)
+}
 
 func migrateComputeStore(repoPath string, config legacy_types.JobStoreConfig) error {
 	oldComputeDir := filepath.Join(repoPath, "compute_store")

--- a/pkg/repo/migrations/v3_4_test.go
+++ b/pkg/repo/migrations/v3_4_test.go
@@ -15,17 +15,39 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/config_legacy"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
+
+type mockGlobalConfig struct {
+	configDir string
+}
+
+func (m *mockGlobalConfig) InstallationID() string {
+	idFile := filepath.Join(m.ConfigDir(), system.InstallationIDFile)
+	idBytes, err := os.ReadFile(idFile)
+	if err != nil {
+		return ""
+	}
+	return string(idBytes)
+}
+
+func (m *mockGlobalConfig) ConfigDir() string {
+	return m.configDir
+}
 
 type V3MigrationsTestSuite struct {
 	BaseMigrationTestSuite // Embed the base suite
+	mockConfig             *mockGlobalConfig
 	repo                   *repo.FsRepo
 }
 
 func (suite *V3MigrationsTestSuite) SetupTest() {
 	suite.BaseMigrationTestSuite.SetupTest()
+	suite.mockConfig = &mockGlobalConfig{
+		configDir: suite.TempDir,
+	}
 	migrations, err := repo.NewMigrationManager(
-		V3Migration,
+		V3MigrationWithConfig(suite.mockConfig),
 	)
 	suite.Require().NoError(err)
 
@@ -134,6 +156,9 @@ Auth:
 	suite.NoDirExists(filepath.Join(suite.TempDir, "executor_storages"))
 	suite.DirExists(filepath.Join(suite.TempDir, types.ComputeDirName))
 	suite.DirExists(filepath.Join(suite.TempDir, types.ComputeDirName, types.ExecutionDirName))
+
+	// verify we can read the expected installationID
+	suite.Require().Equal(expectedInstallationID, suite.mockConfig.InstallationID())
 
 	sysmeta, err := suite.repo.SystemMetadata()
 	suite.Require().NoError(err)
@@ -298,6 +323,9 @@ Auth:
 	suite.DirExists(filepath.Join(suite.TempDir, types.ComputeDirName))
 	suite.DirExists(filepath.Join(suite.TempDir, types.ComputeDirName, types.ExecutionDirName))
 
+	// verify we can read the expected installationID
+	suite.Require().Equal(expectedInstallationID, suite.mockConfig.InstallationID())
+
 	sysmeta, err := suite.repo.SystemMetadata()
 	suite.Require().NoError(err)
 
@@ -399,6 +427,9 @@ Auth:
 	suite.NoDirExists(filepath.Join(suite.TempDir, "orchestrator", "nats-store"))
 	suite.NoFileExists(filepath.Join(suite.TempDir, "orchestrator", "state_boltdb.db"))
 
+	// verify we can read the expected installationID
+	suite.Require().Equal(expectedInstallationID, suite.mockConfig.InstallationID())
+
 	sysmeta, err := suite.repo.SystemMetadata()
 	suite.Require().NoError(err)
 	// old compute directories were replaced with new ones
@@ -411,6 +442,84 @@ Auth:
 
 	// the node name was migrated from the old config to system_metadata.yaml
 	suite.Require().Equal("n-321fd9bf-3a7c-45f5-9b6b-fb9725ac646d", sysmeta.NodeName)
+}
+
+func (suite *V3MigrationsTestSuite) TestV3MigrationInstallationID() {
+	testCases := []struct {
+		name                   string
+		initialInstallationID  string
+		configInstallationID   string
+		expectedInstallationID string
+		noConfigFile           bool
+	}{
+		{
+			name:                   "No existing global installation ID",
+			initialInstallationID:  "",
+			configInstallationID:   "config-id",
+			expectedInstallationID: "config-id",
+		},
+		{
+			name:                   "Existing global installation ID",
+			initialInstallationID:  "existing-id",
+			configInstallationID:   "config-id",
+			expectedInstallationID: "existing-id",
+		},
+		{
+			name:                   "No config installation ID",
+			initialInstallationID:  "",
+			configInstallationID:   "",
+			expectedInstallationID: "",
+		},
+		{
+			name:                   "No config file",
+			noConfigFile:           true,
+			expectedInstallationID: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			// call setup to reset the suite's temporary directory
+			suite.SetupTest()
+
+			// set mock config installation ID if it's not empty
+			if tc.initialInstallationID != "" {
+				suite.Require().NoError(writeInstallationID(suite.mockConfig, tc.initialInstallationID))
+			}
+
+			// Copy test data to the suite's temporary directory
+			testDataPath := filepath.Join("testdata", "v3_minimal_repo")
+			suite.copyRepo(testDataPath)
+
+			if !tc.noConfigFile {
+				// Create a minimal config file
+				configPath := filepath.Join(suite.TempDir, config.DefaultFileName)
+				_, err := createConfig(configPath, fmt.Sprintf(`
+User:
+    InstallationID: %s
+`, tc.configInstallationID))
+				suite.Require().NoError(err)
+				suite.FileExists(configPath)
+			}
+
+			// verify the repo's current version is 3
+			repoVersion3, err := suite.repo.Version()
+			suite.Require().NoError(err)
+			suite.Equal(repo.Version3, repoVersion3)
+
+			// open the repo to trigger the migration to version 4
+			suite.Require().NoError(err)
+			suite.Require().NoError(suite.repo.Open())
+
+			// verify the repo's new current version is 4
+			repoVersion4, err := suite.repo.Version()
+			suite.Require().NoError(err)
+			suite.Equal(repo.Version4, repoVersion4)
+
+			// verify installation ID is as expected
+			suite.Equal(tc.expectedInstallationID, suite.mockConfig.InstallationID())
+		})
+	}
 }
 
 // createConfig creates a config file with the given content

--- a/pkg/routing/tracing/tracing.go
+++ b/pkg/routing/tracing/tracing.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/routing"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 )
 
@@ -22,7 +21,7 @@ func NewNodeStore(delegate routing.NodeInfoStore) *NodeStore {
 }
 
 func (r *NodeStore) Add(ctx context.Context, state models.NodeState) error {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoStore.Add") //nolint:govet
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/routing.NodeInfoStore.Add") //nolint:govet
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, addNodeDurationMilliseconds)
@@ -38,7 +37,7 @@ func (r *NodeStore) Add(ctx context.Context, state models.NodeState) error {
 }
 
 func (r *NodeStore) Get(ctx context.Context, nodeID string) (models.NodeState, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoStore.Get") //nolint:govet
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/routing.NodeInfoStore.Get") //nolint:govet
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, getNodeDurationMilliseconds)
@@ -54,7 +53,7 @@ func (r *NodeStore) Get(ctx context.Context, nodeID string) (models.NodeState, e
 }
 
 func (r *NodeStore) GetByPrefix(ctx context.Context, prefix string) (models.NodeState, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoStore.GetByPrefix") //nolint:govet
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/routing.NodeInfoStore.GetByPrefix") //nolint:govet
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, getPrefixNodeDurationMilliseconds)
@@ -70,7 +69,7 @@ func (r *NodeStore) GetByPrefix(ctx context.Context, prefix string) (models.Node
 }
 
 func (r *NodeStore) List(ctx context.Context, filters ...routing.NodeStateFilter) ([]models.NodeState, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoStore.List") //nolint:govet
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/routing.NodeInfoStore.List") //nolint:govet
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, listNodesDurationMilliseconds)
@@ -85,7 +84,7 @@ func (r *NodeStore) List(ctx context.Context, filters ...routing.NodeStateFilter
 }
 
 func (r *NodeStore) Delete(ctx context.Context, nodeID string) error {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), "pkg/routing.NodeInfoStore.Delete") //nolint:govet
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/routing.NodeInfoStore.Delete") //nolint:govet
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, deleteNodeDurationMilliseconds)

--- a/pkg/storage/tracing/tracing.go
+++ b/pkg/storage/tracing/tracing.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
-	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 	"github.com/bacalhau-project/bacalhau/pkg/util/reflection"
 )
@@ -26,21 +25,21 @@ func Wrap(delegate storage.Storage) storage.Storage {
 }
 
 func (t *tracingStorage) IsInstalled(ctx context.Context) (bool, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.IsInstalled", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.IsInstalled", t.name))
 	defer span.End()
 
 	return t.delegate.IsInstalled(ctx)
 }
 
 func (t *tracingStorage) HasStorageLocally(ctx context.Context, spec models.InputSource) (bool, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.HasStorageLocally", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.HasStorageLocally", t.name))
 	defer span.End()
 
 	return t.delegate.HasStorageLocally(ctx, spec)
 }
 
 func (t *tracingStorage) GetVolumeSize(ctx context.Context, spec models.InputSource) (uint64, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.GetVolumeSize", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.GetVolumeSize", t.name))
 	defer span.End()
 
 	return t.delegate.GetVolumeSize(ctx, spec)
@@ -50,7 +49,7 @@ func (t *tracingStorage) PrepareStorage(
 	ctx context.Context,
 	storageDirectory string,
 	spec models.InputSource) (storage.StorageVolume, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.PrepareStorage", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.PrepareStorage", t.name))
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, jobStoragePrepareDurationMilliseconds, spec.Source.MetricAttributes()...)
@@ -67,7 +66,7 @@ func (t *tracingStorage) PrepareStorage(
 }
 
 func (t *tracingStorage) CleanupStorage(ctx context.Context, spec models.InputSource, volume storage.StorageVolume) error {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.CleanupStorage", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.CleanupStorage", t.name))
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, jobStorageCleanupDurationMilliseconds, spec.Source.MetricAttributes()...)
@@ -83,7 +82,7 @@ func (t *tracingStorage) CleanupStorage(ctx context.Context, spec models.InputSo
 }
 
 func (t *tracingStorage) Upload(ctx context.Context, path string) (models.SpecConfig, error) {
-	ctx, span := system.NewSpan(ctx, system.GetTracer(), fmt.Sprintf("%s.Upload", t.name))
+	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.Upload", t.name))
 	defer span.End()
 
 	stopwatch := telemetry.Timer(ctx, jobStorageUploadDurationMilliseconds)

--- a/pkg/system/config.go
+++ b/pkg/system/config.go
@@ -1,0 +1,68 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// InstallationIDFile is the name of the file storing the installation ID.
+const InstallationIDFile = "installation_id"
+
+// GlobalConfig defines the interface for accessing global configuration settings.
+// The interface is used to abstract the configuration directory and installation ID
+// and allows for easy testing, such as testing migration logic.
+type GlobalConfig interface {
+	// InstallationID returns the unique identifier for this installation, if available.
+	InstallationID() string
+	// ConfigDir returns the path to the configuration directory.
+	ConfigDir() string
+}
+
+// DefaultGlobalConfig is the default implementation of GlobalConfig.
+var DefaultGlobalConfig GlobalConfig = &realGlobalConfig{}
+
+// realGlobalConfig is the concrete implementation of GlobalConfig.
+type realGlobalConfig struct{}
+
+// ConfigDir returns the path to the Bacalhau configuration directory.
+// It respects the XDG Base Directory Specification on Unix-like systems
+// and uses the appropriate directory on Windows.
+func (r *realGlobalConfig) ConfigDir() string {
+	var baseDir string
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		baseDir = os.Getenv("XDG_CONFIG_HOME")
+		if baseDir == "" {
+			baseDir = filepath.Join(os.Getenv("HOME"), ".config")
+		}
+	case "windows":
+		baseDir = os.Getenv("APPDATA")
+	default:
+		baseDir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+	return filepath.Join(baseDir, "bacalhau")
+}
+
+// InstallationID reads and returns the installation ID from the config file.
+// If the file doesn't exist or can't be read, it returns an empty string.
+func (r *realGlobalConfig) InstallationID() string {
+	idFile := filepath.Join(r.ConfigDir(), InstallationIDFile)
+	idBytes, err := os.ReadFile(idFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Debug().Err(err).Msg("Failed to read installation ID file")
+		}
+		return ""
+	}
+	return strings.TrimSpace(string(idBytes))
+}
+
+// InstallationID is a convenience function that returns the installation ID
+// using the DefaultGlobalConfig.
+func InstallationID() string {
+	return DefaultGlobalConfig.InstallationID()
+}

--- a/pkg/telemetry/tracer_test.go
+++ b/pkg/telemetry/tracer_test.go
@@ -1,12 +1,11 @@
 //go:build unit || !integration
 
-package system
+package telemetry
 
 import (
 	"context"
 	"testing"
 
-	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -16,7 +15,7 @@ import (
 
 func TestTracer(t *testing.T) {
 	t.Cleanup(func() {
-		assert.NoError(t, telemetry.Cleanup())
+		assert.NoError(t, Cleanup())
 	})
 
 	var sr SpanRecorder

--- a/pkg/util/targzip/targzip.go
+++ b/pkg/util/targzip/targzip.go
@@ -11,9 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/pkg/system"
-	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 	"github.com/c2h5oh/datasize"
+
+	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
+	"github.com/bacalhau-project/bacalhau/pkg/util/closer"
 )
 
 const (
@@ -55,7 +56,7 @@ func UncompressedSize(src io.Reader) (datasize.ByteSize, error) {
 //
 //nolint:gocyclo,funlen
 func compress(ctx context.Context, src string, buf io.Writer, max datasize.ByteSize, stripPath bool) error {
-	_, span := system.NewSpan(ctx, system.GetTracer(), "pkg/util/targzip.compress")
+	_, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), "pkg/util/targzip.compress")
 	defer span.End()
 
 	// tar > gzip > buf

--- a/pkg/version/update.go
+++ b/pkg/version/update.go
@@ -13,11 +13,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
-	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	baccrypto "github.com/bacalhau-project/bacalhau/pkg/lib/crypto"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/system"
 )
 
 const (
@@ -60,7 +60,7 @@ func CheckForUpdate(
 		q.Set("serverVersion", currentServerVersion.GitVersion)
 	}
 	q.Set("clientID", clientID)
-	if installationID := config.ReadInstallationID(); installationID != "" {
+	if installationID := system.InstallationID(); installationID != "" {
 		q.Set("InstallationID", installationID)
 	}
 


### PR DESCRIPTION
After another look, we actually do persist the installationID in the `config.yaml` file in v1.4.0. The bug was that if no installationID existed, we kept on generating new ones with each run and not persisting it. So if `config.yaml` has an installation, we should migrate it to `~/.config/bacalhau/installation_id` which is what this PR does.

Few changes were required to achieve _and_ test this:
1. Moved `GetInstallationID()` from `config` to `system` package as the installationID is not really configurable
2. Faced import cycle that forced me to move `system/tracer.go` to `telemetry/tracer.go`, which is what is causing a lot of files to change in the PR
3. Introduced `system.GlobalConfig` interface to allow mocking the `ConfigDir()` and be able to test the migrations properly as we don't want the tests to actually update `~/.config/bacalhau`