### PR TITLE
better error for db in use

### DIFF
--- a/pkg/compute/store/boltdb/store.go
+++ b/pkg/compute/store/boltdb/store.go
@@ -12,6 +12,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/bacalhau-project/bacalhau/pkg/compute/store"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/boltdblib"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/watcher"
 	boltdb_watcher "github.com/bacalhau-project/bacalhau/pkg/lib/watcher/boltdb"
@@ -81,11 +82,8 @@ type Store struct {
 func NewStore(ctx context.Context, dbPath string) (*Store, error) {
 	log.Ctx(ctx).Debug().Msgf("creating new bbolt database at %s", dbPath)
 
-	database, err := bolt.Open(dbPath, defaultDatabasePermissions, &bolt.Options{Timeout: 2 * time.Second})
+	database, err := boltdblib.Open(dbPath)
 	if err != nil {
-		if errors.Is(err, bolt.ErrTimeout) {
-			return nil, fmt.Errorf("timed out while opening database, file %q might be in use", dbPath)
-		}
 		return nil, err
 	}
 

--- a/pkg/jobstore/boltdb/database.go
+++ b/pkg/jobstore/boltdb/database.go
@@ -5,26 +5,14 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strings"
-	"time"
 
-	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
 
 const (
-	DefaultDatabasePermissions   = 0600
 	DefaultBucketSearchSliceSize = 16
 	BucketPathDelimiter          = "/"
 )
-
-func GetDatabase(path string) (*bolt.DB, error) {
-	database, err := bolt.Open(path, DefaultDatabasePermissions, &bolt.Options{Timeout: 2 * time.Second})
-	if err != nil {
-		//nolint:lll
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to open database at %s - often caused because a bacalhau process is already running.", path))
-	}
-	return database, nil
-}
 
 // GetBucketsByPrefix will search through the provided bucket to find other buckets with
 // a name that starts with the partialname that is provided.

--- a/pkg/jobstore/boltdb/database_test.go
+++ b/pkg/jobstore/boltdb/database_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/boltdblib"
 )
 
 type DatabaseTestSuite struct {
@@ -38,7 +40,7 @@ func (s *DatabaseTestSuite) TearDownTest() {
 }
 
 func (s *DatabaseTestSuite) TestGetDatabaseBad() {
-	_, err := GetDatabase("")
+	_, err := boltdblib.Open("")
 	s.Error(err)
 }
 

--- a/pkg/jobstore/boltdb/store.go
+++ b/pkg/jobstore/boltdb/store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/analytics"
 	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
 	"github.com/bacalhau-project/bacalhau/pkg/jobstore"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/boltdblib"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/marshaller"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/math"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -82,7 +83,7 @@ func WithClock(clock clock.Clock) Option {
 //	ExecutionsIndex  = execution-id -> Job id
 //	EvaluationsIndex = evaluation-id -> Job id
 func NewBoltJobStore(dbPath string, options ...Option) (*BoltJobStore, error) {
-	db, err := GetDatabase(dbPath)
+	db, err := boltdblib.Open(dbPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/boltdblib/db.go
+++ b/pkg/lib/boltdblib/db.go
@@ -1,0 +1,35 @@
+package boltdblib
+
+import (
+	"errors"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+)
+
+const component = "BoltDB"
+const defaultDatabasePermissions = 0600
+
+func Open(path string) (*bolt.DB, error) {
+	database, err := bolt.Open(path, defaultDatabasePermissions, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		if errors.Is(err, bolt.ErrTimeout) {
+			return nil, newBoltDBInUseError(path)
+		}
+		return nil, bacerrors.Wrap(err, "failed to open database at %s", path)
+	}
+	return database, nil
+}
+
+func newBoltDBInUseError(path string) bacerrors.Error {
+	return bacerrors.New("db is in use: %s", path).
+		WithHint(`most likely another bacalhau is running and using the same data directory. To resolve, either:
+1. Ensure that no other bacalhau process is running
+2. Select a different data directory using the '--data-dir <new_path>' or '-c %s=<new_path>' flag with your serve command
+`, types.DataDirKey).
+		WithCode(bacerrors.ConfigurationError).
+		WithComponent(component)
+}

--- a/pkg/lib/boltdblib/errors.go
+++ b/pkg/lib/boltdblib/errors.go
@@ -1,0 +1,1 @@
+package boltdblib


### PR DESCRIPTION

### Without Fix:
```
Walid-MacBook-5: ~
→ bacalhau serve --orchestrator --api-port 2234
15:48:24.451 | INF ProtocolLabs/workspace/bacalhau/cmd/cli/serve/serve.go:102 > Config loaded from: [], and with data-dir /Users/walid/.bacalhau

Error: failed to configure requester node: failed to create job store: failed to open database at /Users/walid/.bacalhau/orchestrator/state_boltdb.db - often caused because a bacalhau process is already running.: timeout
```

### With Fix:
```
Walid-MacBook-5: ~
→ bacalhau serve --orchestrator --api-port 2234
15:47:16.556 | INF ProtocolLabs/workspace/bacalhau/cmd/cli/serve/serve.go:102 > Config loaded from: [], and with data-dir /Users/walid/.bacalhau

Error: db is in use: /Users/walid/.bacalhau/orchestrator/state_boltdb.db
Hint:  most likely another bacalhau is running and using the same data directory. To resolve, either:
1. Ensure that no other bacalhau process is running
2. Select a different data directory using the '--data-dir <new_path>' or '-c datadir=<new_path>' flag with your serve command
```