### PR TITLE
fix orchestrator showing as disconnected

### DIFF
--- a/cmd/cli/node/columns.go
+++ b/cmd/cli/node/columns.go
@@ -31,11 +31,7 @@ var alwaysColumns = []output.TableColumn[*models.NodeState]{
 	{
 		ColumnConfig: table.ColumnConfig{Name: "status"},
 		Value: func(ni *models.NodeState) string {
-			if ni.Info.ComputeNodeInfo != nil {
-				return ni.Connection.String()
-			}
-
-			return "" // nothing for requester nodes
+			return ni.Connection.String()
 		},
 	},
 }

--- a/pkg/models/node_connection.go
+++ b/pkg/models/node_connection.go
@@ -65,7 +65,7 @@ func stringToConnection(s string) connection {
 }
 
 func (t connection) IsValid() bool {
-	return t >= connection(1) && t <= connection(len(strConnectionArray))
+	return t >= connection(0) && t <= connection(len(strConnectionArray))
 }
 
 type livenessContainer struct {

--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -68,7 +68,7 @@ func NewRequesterNode(
 	messageSerDeRegistry *ncl.MessageSerDeRegistry,
 	fsr *repo.FsRepo,
 ) (*Requester, error) {
-	nodeManager, heartbeatServer, err := createNodeManager(ctx, transportLayer, requesterConfig)
+	nodeManager, heartbeatServer, err := createNodeManager(ctx, nodeID, transportLayer, requesterConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -374,6 +374,7 @@ func createNodeRanker(requesterConfig RequesterConfig, jobStore jobstore.Store) 
 }
 
 func createNodeManager(ctx context.Context,
+	nodeId string,
 	transportLayer *nats_transport.NATSTransport,
 	requesterConfig RequesterConfig) (*manager.NodeManager, *heartbeat.HeartbeatServer, error) {
 	nodeInfoStore, err := createNodeInfoStore(ctx, transportLayer)
@@ -383,6 +384,7 @@ func createNodeManager(ctx context.Context,
 
 	// heartbeat service
 	heartbeatParams := heartbeat.HeartbeatServerParams{
+		NodeID:                nodeId,
 		Client:                transportLayer.Client(),
 		CheckFrequency:        requesterConfig.ControlPlaneSettings.HeartbeatCheckFrequency.AsTimeDuration(),
 		NodeDisconnectedAfter: requesterConfig.ControlPlaneSettings.NodeDisconnectedAfter.AsTimeDuration(),

--- a/webui/components/nodes/list/NodesOverview.tsx
+++ b/webui/components/nodes/list/NodesOverview.tsx
@@ -36,7 +36,9 @@ export function NodesOverview() {
 
       const allNodes = response.data.Nodes ?? []
       setNodes(allNodes)
-      const connected = allNodes.filter(node => getNodeConnectionStatus(node) == "CONNECTED").length
+      const connected = allNodes.filter(
+        (node) => getNodeConnectionStatus(node) == 'CONNECTED'
+      ).length
       setConnectedNodes(connected)
       setNextToken(response.data.NextToken)
     } catch (error) {
@@ -44,7 +46,7 @@ export function NodesOverview() {
       setNodes([])
       setConnectedNodes(0)
     }
-  }, [isInitialized, pageSize, pageIndex, nextToken])
+  }, [isInitialized, pageIndex, nextToken])
 
   useEffect(() => {
     fetchNodes()
@@ -106,7 +108,10 @@ export function NodesOverview() {
             <RefreshCw className="h-4 w-4" />
           </Button>
         </div>
-        <Badge variant="secondary" className="text-sm px-3 py-1 flex items-center gap-2">
+        <Badge
+          variant="outline"
+          className="text-sm px-3 py-1 flex items-center gap-2"
+        >
           <Server className="h-4 w-4" />
           <span>{connectedNodes} Connected</span>
         </Badge>


### PR DESCRIPTION
orchestrator node doesn't heartbeat which results in its state showing as disconnected in the webUI and http APIs. This PR fixes this by having the orchestrator node treats itself as connected regardless of heartbeats or not. We might have to introduce orchestrator level heartbeats in the future when we introduce multiple orchestrators

### Testing done
- Unit tests
- Verified WebUI is showing the right state
- Verified compute nodes are still marked as disconnected when they go down