### PR TITLE
End-to-End Testing: Initial setup

### DIFF
--- a/test-integration/Dockerfile
+++ b/test-integration/Dockerfile
@@ -1,0 +1,10 @@
+# Use the docker:dind image as the base image
+FROM docker:dind
+
+# Install curl and bash
+RUN apk update && apk add --no-cache curl bash
+
+# Download and execute the Bash script from the given URL
+RUN curl -sSL https://get.bacalhau.org/install.sh | bash
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/test-integration/Dockerfile-ComputeNode
+++ b/test-integration/Dockerfile-ComputeNode
@@ -1,0 +1,12 @@
+# Use the docker:dind image as the base image
+FROM docker:dind
+
+# Install curl and bash
+RUN apk update && apk add --no-cache curl bash
+
+# Download and execute the Bash script from the given URL
+RUN curl -sSL https://get.bacalhau.org/install.sh | bash
+
+COPY compute_node_runner.sh compute_node_runner.sh
+ENTRYPOINT ["/usr/bin/env"]
+CMD ./compute_node_runner.sh

--- a/test-integration/README.md
+++ b/test-integration/README.md
@@ -1,0 +1,59 @@
+# Running Bacalhau on Docker
+
+## Overview
+
+Since Bacalhau is a distributed system with multiple components, it is critical to have a reliable method for end-to-end testing. Additionally, it's important that these tests closely resemble a real production environment without relying on mocks.
+
+This setup addresses those needs by running Bacalhau inside containers while also supporting Docker workloads within these containers (using Docker-in-Docker, or DinD).
+
+## Architecture
+
+- A Requestor Docker image is built, containing the Bacalhau CLI.
+- A Compute Docker image is built with Bacalhau CLI and is configured to run Docker containers inside it.
+- Docker Compose is used to create three services: the Requestor Node, the Compute Node, and the Client CLI Node.
+- All three services are connected on the same Docker network, allowing them to communicate over the bridged network.
+
+## Setup
+
+### Build the Docker Images
+
+Build the Compute Node image:
+```shell
+docker build -f Dockerfile-ComputeNode -t bacalhau-compute-node-image .
+```
+
+
+Build the Requestor Node image:
+```shell
+docker build -t bacalhau-in-docker .
+```
+
+After running these commands, you should see the two images created:
+```shell
+docker image ls
+```
+
+### Running the setup
+
+Run Docker Compose:
+```shell
+docker-compose up
+```
+
+Access the utility container to use the Bacalhau CLI:
+```shell
+docker exec -it bacalhau-client-node-container /bin/bash
+```
+
+Once inside the container, you can run the following commands to verify the setup:
+```shell
+# You should see two nodes: a Requestor and a Compute Node
+bacalhau --api-host=bacalhau-requester-node --api-port=1234 node list
+```
+
+```shell
+# Run a test workload
+bacalhau --api-host=bacalhau-requester-node --api-port=1234 docker run alpine echo hellooooo
+
+# Describe the job; it should have completed successfully.
+```

--- a/test-integration/compute_node_runner.sh
+++ b/test-integration/compute_node_runner.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Total wait time in seconds
+TOTAL_WAIT_TIME_FOR_DOCKERD=30
+# Time interval between retries in seconds
+RETRY_INTERVAL=3
+# Calculating the maximum number of attempts
+MAX_ATTEMPTS=$((TOTAL_WAIT_TIME_FOR_DOCKERD / RETRY_INTERVAL))
+attempt=1
+
+# Start the first docker daemon
+dockerd-entrypoint.sh &
+
+
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+    echo "Checking if dockerd is available (attempt $attempt of $MAX_ATTEMPTS)..."
+
+    # Try to communicate with Docker daemon
+    if docker info >/dev/null 2>&1; then
+        echo "dockerd is available! Now Starting Bacalhau as a compute node"
+        bacalhau config set "node.network.authsecret" "${NETWORK_AUTH_TOKEN}"
+        bacalhau serve --node-type=compute --orchestrators="nats://${REQUESTER_NODE_LINK}:4222"
+        # Wait for any process to exit
+        wait -n
+
+        # Exit with status of process that exited first
+        exit $?
+    fi
+
+    # Wait before retrying
+    echo "dockerd is not available yet. Retrying in $RETRY_INTERVAL seconds..."
+    sleep "$RETRY_INTERVAL"
+
+    # Increment attempt counter
+    attempt=$((attempt + 1))
+done
+
+echo "dockerd did not become available within $TOTAL_WAIT_TIME_FOR_DOCKERD seconds."
+exit 1

--- a/test-integration/docker-compose.yml
+++ b/test-integration/docker-compose.yml
@@ -1,0 +1,62 @@
+x-common-env-variables: &common-env-variables
+  NETWORK_AUTH_TOKEN: "i_am_very_secret_token"
+  API_SERVER_PORT: "1234"
+
+networks:
+  bacalhau-network:
+    driver: bridge
+
+services:
+  bacalhau-requester-node:
+    image: bacalhau-in-docker
+    container_name: bacalhau-requester-node-container
+    networks:
+      - bacalhau-network
+    environment: *common-env-variables
+    privileged: true
+    command:
+      - /bin/bash
+      - -c
+      - |
+          bacalhau config set "node.network.authsecret" "$${NETWORK_AUTH_TOKEN}" && bacalhau serve --port=$${API_SERVER_PORT} --node-type requester
+    healthcheck:
+      test: ["CMD-SHELL", "nc -zv localhost 1234"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  bacalhau-compute-node:
+    image: bacalhau-compute-node-image
+    container_name: bacalhau-compute-node-container
+    privileged: true
+    networks:
+      - bacalhau-network
+    depends_on:
+      bacalhau-requester-node:
+        condition: service_healthy
+    environment:
+      <<: *common-env-variables
+      REQUESTER_NODE_LINK: 'bacalhau-requester-node'
+    healthcheck:
+      test: ["CMD-SHELL", "nc -zv localhost 1234"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  bacalhau-client-node:
+    image: bacalhau-in-docker
+    container_name: bacalhau-client-node-container
+    networks:
+      - bacalhau-network
+    depends_on:
+      bacalhau-requester-node:
+        condition: service_healthy
+      bacalhau-compute-node:
+        condition: service_healthy
+    environment:
+      <<: *common-env-variables
+      REQUESTER_NODE_HOST: 'bacalhau-requester-node'
+      COMPUTE_NODE_HOST: 'bacalhau-compute-node'
+    command: tail -f /dev/null


### PR DESCRIPTION
Since Bacalhau is a distributed system with multiple components, it is critical to have a reliable method for end-to-end testing. Additionally, it's important that these tests closely resemble a real production environment without relying on mocks.

This initial setup addresses those needs by running Bacalhau inside containers while also supporting Docker workloads within these containers (using Docker-in-Docker, or DinD).

Notes:
1. This is a first step towards allowing end-to-end tests that identically runs on local machines as well ass CI. 
2. This allows to have a real world setup for integration tests 
3. Docker networks will allow all sorts of test scenarios of network failures, latency, and segmentation.
4. In the next step, Minio container will be added to test S3 interactions
5. IPFS could also be included in a seperate container as well.
6. Currently we need to privileged flag in containers to be true, but this can be changed when we use https://github.com/nestybox/sysbox 
7. This setup can be wrapped around a suite of integration tests written in Go. No need to mess around with bash scripts to test. 
8. This allows for easier experimentation for new users of Bacalhau, they can run the whole thing locally in one container (taking advantage of nested containers ability)
9. Allows for easier fuzz testing setup for later on. 
10. This can be adapted to have multiple requester and computer nodes scenarios. No mocking, actual real setup.