### PR TITLE
fix: remove warning flag causing noise

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,9 +144,9 @@ func New(opts ...Option) (*Config, error) {
 		for _, flag := range flags {
 			// only if the flag has been set do we want to bind to it, this allows multiple flags
 			// to bind to the same config key.
-			log.Warn().Msgf("Binding flag %+v to config key %q", flag, name)
 			if flag == nil {
 				log.Error().Msgf("flag %q is nil", name)
+				continue
 			}
 			if flag.Changed {
 				switch name {


### PR DESCRIPTION
This change was introduced in #4580. @wdbaruni was this intentional, or for debugging?