### PR TITLE
set logging dest to be stdout, and simplify cmd logging

### DIFF
--- a/cmd/cli/config/list.go
+++ b/cmd/cli/config/list.go
@@ -41,7 +41,7 @@ Each key shown can be used with:
 			if err != nil {
 				return err
 			}
-			log.Info().Msgf("Config loaded from: %s, and with data-dir %s", cfg.Paths(), cfg.Get(types.DataDirKey))
+			log.Debug().Msgf("Config loaded from: %s, and with data-dir %s", cfg.Paths(), cfg.Get(types.DataDirKey))
 			return list(cmd, cfg, o)
 		},
 	}

--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -103,9 +104,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// TODO: a hack to force debug logging for devstack
 			//  until I figure out why flags and env vars are not working
-			if err := logger.ConfigureLogging(string(logger.LogModeDefault), "debug"); err != nil {
-				return fmt.Errorf("failed to configure logging: %w", err)
-			}
+			logger.ConfigureLogging(logger.LogModeDefault, zerolog.DebugLevel)
 			return runDevstack(cmd, ODs)
 		},
 	}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/trace"
@@ -25,6 +24,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
@@ -72,8 +72,18 @@ func NewRootCmd() *cobra.Command {
 			return err
 		}
 
-		// set cmd log mode by default.
-		logger.ConfigureLogging(logger.LogModeCmd, zerolog.InfoLevel)
+		// Configure logging
+		// While we allow users to configure logging via the config file, they are applied
+		// and will override this configuration at a later stage when the config is loaded.
+		// This is needed to ensure any logs before the config is loaded are captured.
+		logLevel := viper.GetString(types.LoggingLevelKey)
+		if logLevel == "" {
+			logLevel = "Info"
+		}
+		if err := logger.ParseAndConfigureLogging(string(logger.LogModeCmd), logLevel); err != nil {
+			return fmt.Errorf("failed to configure logging: %w", err)
+		}
+
 		return nil
 	}
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/trace"
@@ -24,7 +25,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/cliflags"
 	"github.com/bacalhau-project/bacalhau/cmd/util/flags/configflags"
-	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
 	"github.com/bacalhau-project/bacalhau/pkg/telemetry"
@@ -72,22 +72,8 @@ func NewRootCmd() *cobra.Command {
 			return err
 		}
 
-		// Configure logging
-		// While we allow users to configure logging via the config file, they are applied
-		// and will override this configuration at a later stage when the config is loaded.
-		// This is needed to ensure any logs before the config is loaded are captured.
-		logMode := viper.GetString(types.LoggingModeKey)
-		if logMode == "" {
-			logMode = string(logger.LogModeDefault)
-		}
-		logLevel := viper.GetString(types.LoggingLevelKey)
-		if logLevel == "" {
-			logLevel = "Info"
-		}
-		if err := logger.ConfigureLogging(logMode, logLevel); err != nil {
-			return fmt.Errorf("failed to configure logging: %w", err)
-		}
-
+		// set cmd log mode by default.
+		logger.ConfigureLogging(logger.LogModeCmd, zerolog.InfoLevel)
 		return nil
 	}
 

--- a/cmd/cli/serve/serve.go
+++ b/cmd/cli/serve/serve.go
@@ -95,6 +95,10 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("failed to setup config: %w", err)
 			}
 
+			if err = logger.ParseAndConfigureLogging(cfg.Logging.Mode, cfg.Logging.Level); err != nil {
+				return fmt.Errorf("failed to configure logging: %w", err)
+			}
+
 			log.Info().Msgf("Config loaded from: %s, and with data-dir %s",
 				rawCfg.Paths(), rawCfg.Get(types.DataDirKey))
 
@@ -103,7 +107,6 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to reconcile repo: %w", err)
 			}
-
 			return serve(cmd, cfg, fsr)
 		},
 	}

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
-	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
 )
@@ -76,12 +75,6 @@ func SetupConfigType(cmd *cobra.Command) (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// We always apply the configured logging level. Logging mode on the other hand is only applied with serve cmd
-	if err = logger.ParseAndConfigureLoggingLevel(cfg.Get(types.LoggingLevelKey).(string)); err != nil {
-		return nil, fmt.Errorf("failed to configure logging: %w", err)
-	}
-
 	return cfg, nil
 }
 

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
 )
@@ -75,6 +76,12 @@ func SetupConfigType(cmd *cobra.Command) (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// We always apply the configured logging level. Logging mode on the other hand is only applied with serve cmd
+	if err = logger.ParseAndConfigureLoggingLevel(cfg.Get(types.LoggingLevelKey).(string)); err != nil {
+		return nil, fmt.Errorf("failed to configure logging: %w", err)
+	}
+
 	return cfg, nil
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -172,6 +172,7 @@ func defaultLogging() io.Writer {
 
 func defaultLogFormat(w *zerolog.ConsoleWriter) {
 	isTerminal := isatty.IsTerminal(os.Stdout.Fd())
+	w.Out = os.Stdout
 	w.NoColor = !isTerminal
 	w.TimeFormat = "15:04:05.999 |"
 	w.PartsOrder = []string{

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -67,7 +67,8 @@ func init() { //nolint:gochecknoinits
 		strings.HasSuffix(os.Args[0], ".test") ||
 		flag.Lookup("test.v") != nil ||
 		flag.Lookup("test.run") != nil {
-		ConfigureLogging(LogModeDefault, zerolog.DebugLevel)
+		ConfigureLoggingLevel(zerolog.DebugLevel)
+		configureLogging(defaultLogging())
 		return
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -46,7 +46,7 @@ func ParseLogMode(s string) (LogMode, error) {
 			return logMode, nil
 		}
 	}
-	return "", fmt.Errorf("%q is an invalid log-mode (valid modes: %q)", s, lm)
+	return "Error", fmt.Errorf("%q is an invalid log-mode (valid modes: %q)", s, lm)
 }
 
 func ParseLogLevel(s string) (zerolog.Level, error) {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -23,7 +23,8 @@ func TestConfigureLogging(t *testing.T) {
 	})
 
 	var logging strings.Builder
-	configureLogging(zerolog.InfoLevel, zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+	ConfigureLoggingLevel(zerolog.InfoLevel)
+	configureLogging(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
 		defaultLogFormat(w)
 		w.Out = &logging
 		w.NoColor = true

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -23,15 +23,12 @@ func TestConfigureLogging(t *testing.T) {
 	})
 
 	var logging strings.Builder
-	writer := zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+	ConfigureLoggingLevel(zerolog.InfoLevel)
+	configureLogging(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
 		defaultLogFormat(w)
 		w.Out = &logging
 		w.NoColor = true
-	})
-
-	// Configure logging with the test writer
-	ConfigureLogging(LogModeDefault, zerolog.InfoLevel)
-	configureLogging(writer)
+	}))
 
 	subsubpackage.TestLog("testing error logging", "testing message")
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -23,8 +23,7 @@ func TestConfigureLogging(t *testing.T) {
 	})
 
 	var logging strings.Builder
-	ConfigureLoggingLevel(zerolog.InfoLevel)
-	configureLogging(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+	configureLogging(zerolog.InfoLevel, zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
 		defaultLogFormat(w)
 		w.Out = &logging
 		w.NoColor = true

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/repo/migrations"
 
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
@@ -24,6 +25,9 @@ func SetupMigrationManager() (*repo.MigrationManager, error) {
 
 // SetupBacalhauRepo ensures that a bacalhau repo and config exist and are initialized.
 func SetupBacalhauRepo(cfg types.Bacalhau) (*repo.FsRepo, error) {
+	if err := logger.ParseAndConfigureLogging(cfg.Logging.Mode, cfg.Logging.Level); err != nil {
+		return nil, fmt.Errorf("failed to configure logging: %w", err)
+	}
 	migrationManger, err := SetupMigrationManager()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migration manager: %w", err)

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
-	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/repo/migrations"
 
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
@@ -25,9 +24,6 @@ func SetupMigrationManager() (*repo.MigrationManager, error) {
 
 // SetupBacalhauRepo ensures that a bacalhau repo and config exist and are initialized.
 func SetupBacalhauRepo(cfg types.Bacalhau) (*repo.FsRepo, error) {
-	if err := logger.ParseAndConfigureLogging(cfg.Logging.Mode, cfg.Logging.Level); err != nil {
-		return nil, fmt.Errorf("failed to configure logging: %w", err)
-	}
 	migrationManger, err := SetupMigrationManager()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migration manager: %w", err)

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/config"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
-	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/repo/migrations"
 
 	"github.com/bacalhau-project/bacalhau/pkg/repo"
@@ -25,9 +24,6 @@ func SetupMigrationManager() (*repo.MigrationManager, error) {
 
 // SetupBacalhauRepo ensures that a bacalhau repo and config exist and are initialized.
 func SetupBacalhauRepo(cfg types.Bacalhau) (*repo.FsRepo, error) {
-	if err := logger.ConfigureLogging(cfg.Logging.Mode, cfg.Logging.Level); err != nil {
-		return nil, fmt.Errorf("failed to configure logging: %w", err)
-	}
 	migrationManger, err := SetupMigrationManager()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migration manager: %w", err)


### PR DESCRIPTION
This PR creates a simplified logging mode for command line outputs and makes it the default mode, and only apply configurable log mode with `serve` command.

Also sets the logging destination as `stdout` instead of `stderr`