### PR TITLE
fix test flakiness by useing busybox instead of ubuntu images 

### DIFF
--- a/cmd/cli/docker/docker_run_test.go
+++ b/cmd/cli/docker/docker_run_test.go
@@ -354,7 +354,8 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 			ctx := context.Background()
 			_, out, err := s.ExecuteTestCobraCommand(
 				"docker", "run",
-				"busybox:latest", "--", "perl", "-e", fmt.Sprintf(`print "=" x %d`, tc.inputLength),
+				"busybox:latest", "--", "sh", "-c",
+				fmt.Sprintf(`yes "=" | tr -d "\n" | head -c %d`, tc.inputLength),
 			)
 			s.Require().NoError(err, "Error submitting job. Name: %s. Expected Length: %s", name, tc.expectedLength)
 

--- a/cmd/cli/docker/docker_run_test.go
+++ b/cmd/cli/docker/docker_run_test.go
@@ -54,7 +54,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmit() {
 	ctx := context.Background()
 	randomUUID := uuid.New()
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
-		"ubuntu",
+		"busybox:latest",
 		"echo",
 		randomUUID.String(),
 	)
@@ -67,7 +67,7 @@ func (s *DockerRunSuite) TestRun_DryRun() {
 	randomUUID := uuid.New()
 	entrypointCommand := fmt.Sprintf("echo %s", randomUUID.String())
 	stdout, _, err := s.Execute("docker", "run",
-		"ubuntu",
+		"busybox:latest",
 		entrypointCommand,
 		"--dry-run",
 	)
@@ -137,7 +137,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
 		"--wait",
-		"ubuntu",
+		"busybox:latest",
 		"--",
 		"echo", "hello from docker submit wait",
 	)
@@ -170,7 +170,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 		flagsArray := []string{"docker", "run"}
 
 		flagsArray = append(flagsArray, urls.inputURL.flag, urls.inputURL.url)
-		flagsArray = append(flagsArray, "ubuntu", "cat", fmt.Sprintf("%s/%s", urls.inputURL.pathInContainer, urls.inputURL.filename))
+		flagsArray = append(flagsArray, "busybox:latest", "cat", fmt.Sprintf("%s/%s", urls.inputURL.pathInContainer, urls.inputURL.filename))
 
 		_, out, err := s.ExecuteTestCobraCommand(flagsArray...)
 		s.Require().NoError(err, "Error submitting job")
@@ -189,7 +189,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 func (s *DockerRunSuite) TestRun_CreatedAt() {
 	ctx := context.Background()
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
-		"ubuntu",
+		"busybox:latest",
 		"echo", "'hello world'",
 	)
 	s.NoError(err, "Error submitting job.")
@@ -208,8 +208,8 @@ func (s *DockerRunSuite) TestRun_EdgeCaseCLI() {
 		fatalErr   bool
 		errString  string
 	}{
-		{submitArgs: []string{"ubuntu", "-xoo -bar -baz"}, fatalErr: true, errString: "unknown shorthand flag"}, // submitting flag will fail if not separated with a --
-		{submitArgs: []string{"ubuntu", "python -xoo -bar -baz"}, fatalErr: false, errString: ""},               // separating with -- should work and allow flags
+		{submitArgs: []string{"busybox:latest", "-xoo -bar -baz"}, fatalErr: true, errString: "unknown shorthand flag"}, // submitting flag will fail if not separated with a --
+		{submitArgs: []string{"busybox:latest", "python -xoo -bar -baz"}, fatalErr: false, errString: ""},               // separating with -- should work and allow flags
 		// {submitString: "-v QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72:/input_images -o results:/output_images dpokidov/imagemagick -- magick mogrify -fx '((g-b)/(r+g+b))>0.02 ? 1 : 0' -resize 256x256 -quality 100 -path /output_images /input_images/*.jpg"},
 	}
 
@@ -263,7 +263,7 @@ func (s *DockerRunSuite) TestRun_SubmitWorkdir() {
 		ctx := context.Background()
 		flagsArray := []string{"docker", "run"}
 		flagsArray = append(flagsArray, "-w", tc.workdir)
-		flagsArray = append(flagsArray, "ubuntu", "pwd")
+		flagsArray = append(flagsArray, "busybox:latest", "pwd")
 
 		_, out, err := s.ExecuteTestCobraCommand(flagsArray...)
 
@@ -302,7 +302,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		"docker", "run",
 		"--wait",
 		"-i", fmt.Sprintf("file://%s,dst=/inputs", s.AllowListedPath),
-		"ubuntu", "echo", "hello",
+		"busybox:latest", "echo", "hello",
 	}
 
 	_, _, submitErr := s.ExecuteTestCobraCommand(allArgs...)
@@ -354,7 +354,7 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 			ctx := context.Background()
 			_, out, err := s.ExecuteTestCobraCommand(
 				"docker", "run",
-				"ubuntu", "--", "perl", "-e", fmt.Sprintf(`print "=" x %d`, tc.inputLength),
+				"busybox:latest", "--", "perl", "-e", fmt.Sprintf(`print "=" x %d`, tc.inputLength),
 			)
 			s.Require().NoError(err, "Error submitting job. Name: %s. Expected Length: %s", name, tc.expectedLength)
 
@@ -400,7 +400,7 @@ func (s *DockerRunSuite) TestRun_MultipleURLs() {
 
 			args = append(args, "docker", "run")
 			args = append(args, tc.inputFlags...)
-			args = append(args, "ubuntu", "--", "ls", "/input")
+			args = append(args, "busybox:latest", "--", "ls", "/input")
 
 			_, out, err := s.ExecuteTestCobraCommand(args...)
 			s.Require().NoError(err, "Error submitting job")
@@ -421,8 +421,8 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 		errStringContains string
 	}{
 		"good-image-good-executable": {
-			imageName:         "ubuntu", // Good image // TODO we consider an untagged image poor practice, fix this
-			executable:        "ls",     // Good executable
+			imageName:         "busybox:latest", // Good image // TODO we consider an untagged image poor practice, fix this
+			executable:        "ls",             // Good executable
 			isValid:           true,
 			errStringContains: "",
 		},
@@ -433,8 +433,8 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 			errStringContains: "image not available",
 		},
 		"good-image-bad-executable": {
-			imageName:         "ubuntu",        // Good image // TODO we consider an untagged image poor practice, fix this
-			executable:        "BADEXECUTABLE", // Bad executable
+			imageName:         "busybox:latest", // Good image // TODO we consider an untagged image poor practice, fix this
+			executable:        "BADEXECUTABLE",  // Bad executable
 			isValid:           false,
 			errStringContains: "executable file not found",
 		},
@@ -497,7 +497,7 @@ func (s *DockerRunSuite) TestRun_InvalidImage() {
 func (s *DockerRunSuite) TestRun_Timeout_DefaultValue() {
 	ctx := context.Background()
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
-		"ubuntu",
+		"busybox:latest",
 		"echo", "'hello world'",
 	)
 	s.NoError(err, "Error submitting job without defining a timeout value")
@@ -516,7 +516,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
 		"--timeout", fmt.Sprintf("%d", int64(expectedTimeout.Seconds())),
 		"--queue-timeout", fmt.Sprintf("%d", int64(expectedQueueTimeout.Seconds())),
-		"ubuntu",
+		"busybox:latest",
 		"echo", "'hello world'",
 	)
 	s.NoError(err, "Error submitting job with a defined a timeout value")
@@ -530,7 +530,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 func (s *DockerRunSuite) TestRun_NoPublisher() {
 	ctx := context.Background()
 
-	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "ubuntu", "echo", "'hello world'")
+	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "busybox:latest", "echo", "'hello world'")
 	s.Require().NoError(err)
 
 	job := testutils.GetJobFromTestOutput(ctx, s.T(), s.ClientV2, out)
@@ -550,7 +550,7 @@ func (s *DockerRunSuite) TestRun_NoPublisher() {
 func (s *DockerRunSuite) TestRun_LocalPublisher() {
 	ctx := context.Background()
 
-	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "-p", "local", "ubuntu", "echo", "'hello world'")
+	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "-p", "local", "busybox:latest", "echo", "'hello world'")
 	s.Require().NoError(err)
 
 	job := testutils.GetJobFromTestOutput(ctx, s.T(), s.ClientV2, out)

--- a/cmd/cli/job/get_test.go
+++ b/cmd/cli/job/get_test.go
@@ -213,9 +213,9 @@ func (s *GetSuite) getDockerRunArgs(extraArgs []string) []string {
 	}
 	args = append(args, extraArgs...)
 	args = append(args,
-		"ubuntu:kinetic",
+		"busybox:latest",
 		"--",
-		"bash", "-c",
+		"sh", "-c",
 		"echo hello > /data/file.txt && echo hello && mkdir /data/apples && echo oranges > /data/apples/file.txt",
 	)
 	return args

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
@@ -45,7 +45,7 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 
 	t.Run("positive response for supported architecture", func(t *testing.T) {
 		response, err := strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
-			Job: jobForDockerImage(t, "ubuntu"),
+			Job: jobForDockerImage(t, "busybox:latest"),
 		})
 
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 		semantic.ManifestCache = cc
 
 		response, err := strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
-			Job: jobForDockerImage(t, "ubuntu:latest"),
+			Job: jobForDockerImage(t, "busybox:latest"),
 		})
 
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 
 		// Second time we expect should be cached
 		response, err = strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
-			Job: jobForDockerImage(t, "ubuntu:latest"),
+			Job: jobForDockerImage(t, "busybox:latest"),
 		})
 
 		require.NoError(t, err)

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -216,8 +216,8 @@ func (s *ExecutorTestSuite) TestDockerResourceLimitsCPU() {
 	// same 0.1 value that 100m means
 	// https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/using-cgroups-v2-to-control-distribution-of-cpu-time-for-applications_managing-monitoring-and-updating-the-kernel#proc_controlling-distribution-of-cpu-time-for-applications-by-adjusting-cpu-bandwidth_using-cgroups-v2-to-control-distribution-of-cpu-time-for-applications
 
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu:20.04").
-		WithEntrypoint("bash", "-c", "cat /sys/fs/cgroup/cpu.max").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37").
+		WithEntrypoint("sh", "-c", "cat /sys/fs/cgroup/cpu.max").
 		Build()
 	s.Require().NoError(err)
 
@@ -261,8 +261,8 @@ func (s *ExecutorTestSuite) TestDockerResourceLimitsMemory() {
 	}
 
 	for _, p := range tests {
-		es, err := dockermodels.NewDockerEngineBuilder("ubuntu:20.04").
-			WithEntrypoint("bash", "-c", "cat /sys/fs/cgroup/memory.max").
+		es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37").
+			WithEntrypoint("sh", "-c", "cat /sys/fs/cgroup/memory.max").
 			Build()
 		s.Require().NoError(err)
 
@@ -386,8 +386,8 @@ func (s *ExecutorTestSuite) TestDockerExecutionCancellation() {
 	errC := make(chan error, 1)
 	executionID := uuid.New().String()
 
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu").
-		WithEntrypoint("bash", "-c", "sleep 30").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "-c", "sleep 30").
 		Build()
 
 	s.Require().NoError(err)
@@ -448,8 +448,8 @@ func (s *ExecutorTestSuite) TestTimesOutCorrectly() {
 	jobCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu").
-		WithEntrypoint("bash", "-c", fmt.Sprintf(`sleep 1 && echo "%s" && sleep 20`, expected)).
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "-c", fmt.Sprintf(`sleep 1 && echo "%s" && sleep 20`, expected)).
 		Build()
 	s.Require().NoError(err)
 	task := mock.Task()
@@ -504,8 +504,8 @@ func (s *ExecutorTestSuite) TestDockerStreamsAlreadyComplete() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu").
-		WithEntrypoint("bash", "cat /sys/fs/cgroup/cpu.max").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "cat /sys/fs/cgroup/cpu.max").
 		Build()
 	s.Require().NoError(err)
 	task := mock.Task()
@@ -531,8 +531,8 @@ func (s *ExecutorTestSuite) TestDockerStreamsAlreadyComplete() {
 func (s *ExecutorTestSuite) TestDockerStreamsSlowTask() {
 	id := "streams-ok"
 
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu").
-		WithEntrypoint("bash", "-c", "echo hello && sleep 20").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "-c", "echo hello && sleep 20").
 		Build()
 	s.Require().NoError(err)
 
@@ -565,7 +565,7 @@ func (s *ExecutorTestSuite) TestDockerStreamsSlowTask() {
 }
 
 func (s *ExecutorTestSuite) TestDockerOOM() {
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
 		WithEntrypoint("tail", "/dev/zero").
 		Build()
 	s.Require().NoError(err)

--- a/pkg/jobstore/boltdb/store_test.go
+++ b/pkg/jobstore/boltdb/store_test.go
@@ -118,7 +118,7 @@ func (s *BoltJobstoreTestSuite) SetupTest() {
 	for _, fixture := range jobFixtures {
 		s.clock.Add(1 * time.Second)
 		job := makeDockerEngineJob(
-			[]string{"bash", "-c", "echo hello"})
+			[]string{"sh", "-c", "echo hello"})
 
 		job.ID = fixture.id
 		job.Type = fixture.jobType
@@ -704,7 +704,7 @@ func (s *BoltJobstoreTestSuite) TestSearchJobs() {
 
 func (s *BoltJobstoreTestSuite) TestDeleteJob() {
 	job := makeDockerEngineJob(
-		[]string{"bash", "-c", "echo hello"})
+		[]string{"sh", "-c", "echo hello"})
 	job.Labels = map[string]string{"tag": "value"}
 	job.ID = "deleteme"
 	job.Namespace = "client1"
@@ -907,7 +907,7 @@ func (s *BoltJobstoreTestSuite) TestShortIDs() {
 	shortString := "9308d0d2"
 
 	job := makeDockerEngineJob(
-		[]string{"bash", "-c", "echo hello"})
+		[]string{"sh", "-c", "echo hello"})
 	job.ID = uuidString
 	job.Namespace = "110"
 
@@ -941,7 +941,7 @@ func (s *BoltJobstoreTestSuite) TestEvents() {
 	)
 
 	job := makeDockerEngineJob(
-		[]string{"bash", "-c", "echo hello"})
+		[]string{"sh", "-c", "echo hello"})
 	job.ID = "10"
 	job.Namespace = "110"
 
@@ -1244,7 +1244,7 @@ func makeDockerEngineJob(entrypointArray []string) *models.Job {
 	j.Task().Engine = &models.SpecConfig{
 		Type: models.EngineDocker,
 		Params: map[string]interface{}{
-			"Image":      "ubuntu:latest",
+			"Image":      "busybox:latest",
 			"Entrypoint": entrypointArray,
 		},
 	}

--- a/pkg/lib/marshaller/utils_test.go
+++ b/pkg/lib/marshaller/utils_test.go
@@ -21,9 +21,9 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "ubuntu:latest",
+          "Image": "busybox:latest",
           "Entrypoint": [
-            "/bin/bash"
+            "/bin/sh"
           ],
           "Parameters": [
             "-c",
@@ -52,9 +52,9 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "ubuntu:latest",
+          "Image": "busybox:latest",
           "Entrypoint": [
-            "/bin/bash"
+            "/bin/sh"
           ],
           "Parameters": [
             "-c",
@@ -84,9 +84,9 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "ubuntu:latest",
+          "Image": "busybox:latest",
           "Entrypoint": [
-            "/bin/bash"
+            "/bin/sh"
           ],
           "Parameters": [
             "-c",
@@ -115,9 +115,9 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "ubuntu:latest",
+          "Image": "busybox:latest",
           "Entrypoint": [
-            "/bin/bash"
+            "/bin/sh"
           ],
           "Parameters": [
             "-c",

--- a/pkg/test/compute/cancel_test.go
+++ b/pkg/test/compute/cancel_test.go
@@ -58,8 +58,8 @@ func (s *CancelSuite) TestCancelDocker() {
 	ctx := context.Background()
 
 	// prepare a docker execution that sleeps for 10 seconds so we can cancel it
-	dockerSpec, err := dockermodels.NewDockerEngineBuilder("ubuntu").
-		WithEntrypoint("bash", "-c", "sleep 10").
+	dockerSpec, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "-c", "sleep 10").
 		Build()
 	s.NoError(err)
 

--- a/pkg/test/devstack/default_publisher_test.go
+++ b/pkg/test/devstack/default_publisher_test.go
@@ -28,8 +28,8 @@ func getTestEngine() *models.SpecConfig {
 	return &models.SpecConfig{
 		Type: models.EngineDocker,
 		Params: dockmodels.EngineSpec{
-			Image: "ubuntu:latest",
-			Entrypoint: []string{"/bin/bash", "-c", `
+			Image: "busybox:latest",
+			Entrypoint: []string{"/bin/sh", "-c", `
                 echo "output to stdout" && \
                 if [ ! -d /outputs ]; then \
                     mkdir -p /outputs; \

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -55,8 +55,8 @@ func executorTestCases(t testing.TB) []*models.Job {
 			Tasks: []*models.Task{
 				{
 					Name: t.Name(),
-					Engine: dockmodels.NewDockerEngineBuilder("ubuntu:latest").
-						WithEntrypoint("bash", "-c", "echo -n 'apples' >&1; echo -n 'oranges' >&2; exit 19;").
+					Engine: dockmodels.NewDockerEngineBuilder("busybox:latest").
+						WithEntrypoint("sh", "-c", "echo -n 'apples' >&1; echo -n 'oranges' >&2; exit 19;").
 						MustBuild(),
 					Publisher: publisher_local.NewSpecConfig(),
 				},

--- a/pkg/test/executor/docker_entrypoint_test.go
+++ b/pkg/test/executor/docker_entrypoint_test.go
@@ -132,8 +132,8 @@ func (suite *DockerEntrypointTestSuite) TearDownSuite() {
 
 func (suite *DockerEntrypointTestSuite) TestTableDriven() {
 	var (
-		overwriteEntrypoint = []string{"/bin/ls"}
-		overwriteCmd        = []string{"media"}
+		overwriteEntrypoint = []string{"ls"}
+		overwriteCmd        = []string{"var"}
 	)
 
 	testCases := []struct {
@@ -150,20 +150,20 @@ func (suite *DockerEntrypointTestSuite) TestTableDriven() {
 		{
 			name:           "TrueTrue - Override both entrypoint and cmd",
 			imageSuffix:    "true-true",
-			expectedStdout: "cdrom\nfloppy\nusb\n",
+			expectedStdout: "spool\nwww\n",
 			entrypoint:     overwriteEntrypoint,
 			parameters:     overwriteCmd,
 		},
 		{
 			name:           "TrueTrue - Override only cmd",
 			imageSuffix:    "true-true",
-			expectedStdout: "media\n",
+			expectedStdout: "var\n",
 			parameters:     overwriteCmd,
 		},
 		{
 			name:           "TrueTrue - Override only entrypoint",
 			imageSuffix:    "true-true",
-			expectedStdout: "bin\ndev\netc\nhome\nlib\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar\n",
+			expectedStdout: "bin\ndev\netc\nhome\nlib\nlib64\nproc\nroot\nsys\ntmp\nusr\nvar\n",
 			entrypoint:     overwriteEntrypoint,
 		},
 		{
@@ -175,20 +175,20 @@ func (suite *DockerEntrypointTestSuite) TestTableDriven() {
 		{
 			name:           "TrueFalse - Override only cmd",
 			imageSuffix:    "true-false",
-			expectedStdout: "media\n",
+			expectedStdout: "var\n",
 			parameters:     overwriteCmd,
 		},
 		{
 			name:           "TrueFalse - Override both entrypoint and cmd",
 			imageSuffix:    "true-false",
-			expectedStdout: "cdrom\nfloppy\nusb\n",
+			expectedStdout: "spool\nwww\n",
 			entrypoint:     overwriteEntrypoint,
 			parameters:     overwriteCmd,
 		},
 		{
 			name:           "TrueFalse - Override only entrypoint",
 			imageSuffix:    "true-false",
-			expectedStdout: "bin\ndev\netc\nhome\nlib\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar\n",
+			expectedStdout: "bin\ndev\netc\nhome\nlib\nlib64\nproc\nroot\nsys\ntmp\nusr\nvar\n",
 			entrypoint:     overwriteEntrypoint,
 		},
 		{
@@ -207,13 +207,13 @@ func (suite *DockerEntrypointTestSuite) TestTableDriven() {
 		{
 			name:           "FalseTrue - Override only entrypoint",
 			imageSuffix:    "false-true",
-			expectedStdout: "bin\ndev\netc\nhome\nlib\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar\n",
+			expectedStdout: "bin\ndev\netc\nhome\nlib\nlib64\nproc\nroot\nsys\ntmp\nusr\nvar\n",
 			entrypoint:     overwriteEntrypoint,
 		},
 		{
 			name:           "FalseTrue - Override both entrypoint and cmd",
 			imageSuffix:    "false-true",
-			expectedStdout: "cdrom\nfloppy\nusb\n",
+			expectedStdout: "spool\nwww\n",
 			entrypoint:     overwriteEntrypoint,
 			parameters:     overwriteCmd,
 		},
@@ -233,13 +233,13 @@ func (suite *DockerEntrypointTestSuite) TestTableDriven() {
 		{
 			name:           "FalseFalse - Override only entrypoint",
 			imageSuffix:    "false-false",
-			expectedStdout: "bin\ndev\netc\nhome\nlib\nmedia\nmnt\nopt\nproc\nroot\nrun\nsbin\nsrv\nsys\ntmp\nusr\nvar\n",
+			expectedStdout: "bin\ndev\netc\nhome\nlib\nlib64\nproc\nroot\nsys\ntmp\nusr\nvar\n",
 			entrypoint:     overwriteEntrypoint,
 		},
 		{
 			name:           "FalseFalse - Override both entrypoint and cmd",
 			imageSuffix:    "false-false",
-			expectedStdout: "cdrom\nfloppy\nusb\n",
+			expectedStdout: "spool\nwww\n",
 			entrypoint:     overwriteEntrypoint,
 			parameters:     overwriteCmd,
 		},
@@ -287,7 +287,7 @@ func createTestScenario(t testing.TB, expectedStderr, expectedStdout, image stri
 		SubmitChecker: scenario.SubmitJobSuccess(),
 	}
 	if expectError == true {
-		testScenario.SubmitChecker = scenario.SubmitJobErrorContains(`"media": executable file not found in $PATH`)
+		testScenario.SubmitChecker = scenario.SubmitJobErrorContains(`"var": executable file not found in $PATH`)
 		testScenario.ResultsChecker = scenario.ManyChecks()
 	}
 	return testScenario

--- a/pkg/test/executor/docker_entrypoint_test.go
+++ b/pkg/test/executor/docker_entrypoint_test.go
@@ -301,7 +301,7 @@ type dockerfilePermutation struct {
 func createDockerfile(d dockerfilePermutation) string {
 	ep := "\nENTRYPOINT [\"/bin/echo\"]"
 	cmd := "\nCMD [\"echo\", \"This is from CMD\"]"
-	baseDockerFile := "FROM alpine:latest"
+	baseDockerFile := "FROM busybox:latest"
 	if d.entrypoint == true {
 		baseDockerFile += ep
 	}

--- a/pkg/test/logstream/stream_address_test.go
+++ b/pkg/test/logstream/stream_address_test.go
@@ -20,8 +20,8 @@ func (s *LogStreamTestSuite) TestStreamAddress() {
 	docker.MustHaveDocker(s.T())
 	node := s.stack.Nodes[0]
 
-	es, err := dockermodels.NewDockerEngineBuilder("bash").
-		WithEntrypoint("bash", "-c", "for i in {1..100}; do echo \"logstreamoutput\"; sleep 1; done").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "-c", "for i in {1..100}; do echo \"logstreamoutput\"; sleep 1; done").
 		Build()
 	s.Require().NoError(err)
 	task := mock.Task()

--- a/pkg/test/logstream/stream_docker_test.go
+++ b/pkg/test/logstream/stream_docker_test.go
@@ -28,8 +28,8 @@ func (s *LogStreamTestSuite) TestDockerOutputStream() {
 	success := make(chan bool, 1)
 	fail := make(chan bool, 1)
 
-	es, err := dockermodels.NewDockerEngineBuilder("ubuntu:latest").
-		WithEntrypoint("bash", "-c", "for i in {1..100}; do echo \"logstreamoutput\"; sleep 1; done").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+		WithEntrypoint("sh", "-c", "for i in {1..100}; do echo \"logstreamoutput\"; sleep 1; done").
 		Build()
 	s.Require().NoError(err)
 	task := mock.Task()

--- a/pkg/test/logstream/stream_docker_test.go
+++ b/pkg/test/logstream/stream_docker_test.go
@@ -4,7 +4,6 @@ package logstream_test
 
 import (
 	"context"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -22,7 +21,7 @@ func (s *LogStreamTestSuite) TestDockerOutputStream() {
 
 	node := s.stack.Nodes[0]
 
-	ctx, cancelFunc := context.WithTimeout(s.ctx, time.Duration(10)*time.Second)
+	ctx, cancelFunc := context.WithCancel(s.ctx)
 	defer cancelFunc()
 
 	success := make(chan bool, 1)
@@ -69,8 +68,6 @@ func (s *LogStreamTestSuite) TestDockerOutputStream() {
 	}()
 
 	go func() {
-		// TODO(forrest): [correctness] we need to wait a little for the container to become active.
-		time.Sleep(time.Second * 3)
 		ch, err := waitForOutputStream(ctx, execution.ID, true, true, exec)
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), ch)

--- a/pkg/test/scenario/test_scenarios.go
+++ b/pkg/test/scenario/test_scenarios.go
@@ -24,7 +24,7 @@ const helloWorld = "hello world"
 const simpleMountPath = "/data/file.txt"
 const simpleOutputPath = "/output_data/output_file.txt"
 const catProgram = "cat " + simpleMountPath + " > " + simpleOutputPath
-const defaultDockerImage = "ubuntu:latest"
+const defaultDockerImage = "busybox:latest"
 
 const AllowedListedLocalPathsSuffix = string(os.PathSeparator) + "*"
 
@@ -94,7 +94,7 @@ func CatFileToVolume(t testing.TB) Scenario {
 				{
 					Name: t.Name(),
 					Engine: dockmodels.NewDockerEngineBuilder(defaultDockerImage).
-						WithEntrypoint("bash", simpleMountPath).MustBuild(),
+						WithEntrypoint("sh", simpleMountPath).MustBuild(),
 				},
 			},
 		},

--- a/testdata/jobs/docker-hello.yaml
+++ b/testdata/jobs/docker-hello.yaml
@@ -6,9 +6,9 @@ tasks:
     engine:
       type: docker
       params:
-        Image: ubuntu:latest
+        Image: busybox:latest
         Entrypoint:
-          - /bin/bash
+          - /bin/sh
         Parameters:
           - -c
           - echo Hello Bacalhau!

--- a/testdata/jobs/docker-output.yaml
+++ b/testdata/jobs/docker-output.yaml
@@ -7,9 +7,9 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: ubuntu:latest
+        Image: busybox:latest
         Entrypoint:
-          - /bin/bash
+          - /bin/sh
         Parameters:
           - -c
           - echo 15 > /output_custom/output.txt

--- a/testdata/jobs/docker-s3.yaml
+++ b/testdata/jobs/docker-s3.yaml
@@ -7,9 +7,9 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: ubuntu:latest
+        Image: busybox:latest
         Entrypoint:
-          - /bin/bash
+          - /bin/sh
         Parameters:
           - -c
           - ls /input_custom

--- a/testdata/jobs/docker.yaml
+++ b/testdata/jobs/docker.yaml
@@ -7,9 +7,9 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: ubuntu:latest
+        Image: busybox:latest
         Entrypoint:
-          - /bin/bash
+          - /bin/sh
         Parameters:
           - -c
           - echo 15


### PR DESCRIPTION
Flakiness seems related to buildkite taking too long to pull images uses in tests, where we mainly use ubuntu. 

Udit mentioned that there are certain times of the day where buildkite tests were failing more than others, and this might explain why. During peek hours, buildkite network bandwidth might become limited and takes longer to fetch resources

This PR  changes from ubuntu to busybox for most tests, but it is werid that buildkite is pulling images multiple times instead of reusing them