### PR TITLE
speed up tests by using tagged images instead of latest

### DIFF
--- a/cmd/cli/docker/docker_run_test.go
+++ b/cmd/cli/docker/docker_run_test.go
@@ -54,7 +54,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmit() {
 	ctx := context.Background()
 	randomUUID := uuid.New()
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
-		"busybox:latest",
+		"busybox:1.37.0",
 		"echo",
 		randomUUID.String(),
 	)
@@ -67,7 +67,7 @@ func (s *DockerRunSuite) TestRun_DryRun() {
 	randomUUID := uuid.New()
 	entrypointCommand := fmt.Sprintf("echo %s", randomUUID.String())
 	stdout, _, err := s.Execute("docker", "run",
-		"busybox:latest",
+		"busybox:1.37.0",
 		entrypointCommand,
 		"--dry-run",
 	)
@@ -137,7 +137,7 @@ func (s *DockerRunSuite) TestRun_GenericSubmitWait() {
 
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
 		"--wait",
-		"busybox:latest",
+		"busybox:1.37.0",
 		"--",
 		"echo", "hello from docker submit wait",
 	)
@@ -170,7 +170,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 		flagsArray := []string{"docker", "run"}
 
 		flagsArray = append(flagsArray, urls.inputURL.flag, urls.inputURL.url)
-		flagsArray = append(flagsArray, "busybox:latest", "cat", fmt.Sprintf("%s/%s", urls.inputURL.pathInContainer, urls.inputURL.filename))
+		flagsArray = append(flagsArray, "busybox:1.37.0", "cat", fmt.Sprintf("%s/%s", urls.inputURL.pathInContainer, urls.inputURL.filename))
 
 		_, out, err := s.ExecuteTestCobraCommand(flagsArray...)
 		s.Require().NoError(err, "Error submitting job")
@@ -189,7 +189,7 @@ func (s *DockerRunSuite) TestRun_SubmitUrlInputs() {
 func (s *DockerRunSuite) TestRun_CreatedAt() {
 	ctx := context.Background()
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
-		"busybox:latest",
+		"busybox:1.37.0",
 		"echo", "'hello world'",
 	)
 	s.NoError(err, "Error submitting job.")
@@ -208,8 +208,8 @@ func (s *DockerRunSuite) TestRun_EdgeCaseCLI() {
 		fatalErr   bool
 		errString  string
 	}{
-		{submitArgs: []string{"busybox:latest", "-xoo -bar -baz"}, fatalErr: true, errString: "unknown shorthand flag"}, // submitting flag will fail if not separated with a --
-		{submitArgs: []string{"busybox:latest", "python -xoo -bar -baz"}, fatalErr: false, errString: ""},               // separating with -- should work and allow flags
+		{submitArgs: []string{"busybox:1.37.0", "-xoo -bar -baz"}, fatalErr: true, errString: "unknown shorthand flag"}, // submitting flag will fail if not separated with a --
+		{submitArgs: []string{"busybox:1.37.0", "python -xoo -bar -baz"}, fatalErr: false, errString: ""},               // separating with -- should work and allow flags
 		// {submitString: "-v QmeZRGhe4PmjctYVSVHuEiA9oSXnqmYa4kQubSHgWbjv72:/input_images -o results:/output_images dpokidov/imagemagick -- magick mogrify -fx '((g-b)/(r+g+b))>0.02 ? 1 : 0' -resize 256x256 -quality 100 -path /output_images /input_images/*.jpg"},
 	}
 
@@ -263,7 +263,7 @@ func (s *DockerRunSuite) TestRun_SubmitWorkdir() {
 		ctx := context.Background()
 		flagsArray := []string{"docker", "run"}
 		flagsArray = append(flagsArray, "-w", tc.workdir)
-		flagsArray = append(flagsArray, "busybox:latest", "pwd")
+		flagsArray = append(flagsArray, "busybox:1.37.0", "pwd")
 
 		_, out, err := s.ExecuteTestCobraCommand(flagsArray...)
 
@@ -302,7 +302,7 @@ func (s *DockerRunSuite) TestRun_ExplodeVideos() {
 		"docker", "run",
 		"--wait",
 		"-i", fmt.Sprintf("file://%s,dst=/inputs", s.AllowListedPath),
-		"busybox:latest", "echo", "hello",
+		"busybox:1.37.0", "echo", "hello",
 	}
 
 	_, _, submitErr := s.ExecuteTestCobraCommand(allArgs...)
@@ -354,7 +354,7 @@ func (s *DockerRunSuite) TestTruncateReturn() {
 			ctx := context.Background()
 			_, out, err := s.ExecuteTestCobraCommand(
 				"docker", "run",
-				"busybox:latest", "--", "sh", "-c",
+				"busybox:1.37.0", "--", "sh", "-c",
 				fmt.Sprintf(`yes "=" | tr -d "\n" | head -c %d`, tc.inputLength),
 			)
 			s.Require().NoError(err, "Error submitting job. Name: %s. Expected Length: %s", name, tc.expectedLength)
@@ -401,7 +401,7 @@ func (s *DockerRunSuite) TestRun_MultipleURLs() {
 
 			args = append(args, "docker", "run")
 			args = append(args, tc.inputFlags...)
-			args = append(args, "busybox:latest", "--", "ls", "/input")
+			args = append(args, "busybox:1.37.0", "--", "ls", "/input")
 
 			_, out, err := s.ExecuteTestCobraCommand(args...)
 			s.Require().NoError(err, "Error submitting job")
@@ -422,7 +422,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 		errStringContains string
 	}{
 		"good-image-good-executable": {
-			imageName:         "busybox:latest", // Good image // TODO we consider an untagged image poor practice, fix this
+			imageName:         "busybox:1.37.0", // Good image
 			executable:        "ls",             // Good executable
 			isValid:           true,
 			errStringContains: "",
@@ -434,7 +434,7 @@ func (s *DockerRunSuite) TestRun_BadExecutables() {
 			errStringContains: "image not available",
 		},
 		"good-image-bad-executable": {
-			imageName:         "busybox:latest", // Good image // TODO we consider an untagged image poor practice, fix this
+			imageName:         "busybox:1.37.0", // Good image
 			executable:        "BADEXECUTABLE",  // Bad executable
 			isValid:           false,
 			errStringContains: "executable file not found",
@@ -498,7 +498,7 @@ func (s *DockerRunSuite) TestRun_InvalidImage() {
 func (s *DockerRunSuite) TestRun_Timeout_DefaultValue() {
 	ctx := context.Background()
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
-		"busybox:latest",
+		"busybox:1.37.0",
 		"echo", "'hello world'",
 	)
 	s.NoError(err, "Error submitting job without defining a timeout value")
@@ -517,7 +517,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 	_, out, err := s.ExecuteTestCobraCommand("docker", "run",
 		"--timeout", fmt.Sprintf("%d", int64(expectedTimeout.Seconds())),
 		"--queue-timeout", fmt.Sprintf("%d", int64(expectedQueueTimeout.Seconds())),
-		"busybox:latest",
+		"busybox:1.37.0",
 		"echo", "'hello world'",
 	)
 	s.NoError(err, "Error submitting job with a defined a timeout value")
@@ -531,7 +531,7 @@ func (s *DockerRunSuite) TestRun_Timeout_DefinedValue() {
 func (s *DockerRunSuite) TestRun_NoPublisher() {
 	ctx := context.Background()
 
-	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "busybox:latest", "echo", "'hello world'")
+	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "busybox:1.37.0", "echo", "'hello world'")
 	s.Require().NoError(err)
 
 	job := testutils.GetJobFromTestOutput(ctx, s.T(), s.ClientV2, out)
@@ -551,7 +551,7 @@ func (s *DockerRunSuite) TestRun_NoPublisher() {
 func (s *DockerRunSuite) TestRun_LocalPublisher() {
 	ctx := context.Background()
 
-	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "-p", "local", "busybox:latest", "echo", "'hello world'")
+	_, out, err := s.ExecuteTestCobraCommand("docker", "run", "-p", "local", "busybox:1.37.0", "echo", "'hello world'")
 	s.Require().NoError(err)
 
 	job := testutils.GetJobFromTestOutput(ctx, s.T(), s.ClientV2, out)

--- a/cmd/cli/job/get_test.go
+++ b/cmd/cli/job/get_test.go
@@ -213,7 +213,7 @@ func (s *GetSuite) getDockerRunArgs(extraArgs []string) []string {
 	}
 	args = append(args, extraArgs...)
 	args = append(args,
-		"busybox:latest",
+		"busybox:1.37.0",
 		"--",
 		"sh", "-c",
 		"echo hello > /data/file.txt && echo hello && mkdir /data/apples && echo oranges > /data/apples/file.txt",

--- a/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
+++ b/pkg/executor/docker/bidstrategy/semantic/image_platform_test.go
@@ -45,7 +45,7 @@ func TestBidsBasedOnImagePlatform(t *testing.T) {
 
 	t.Run("positive response for supported architecture", func(t *testing.T) {
 		response, err := strategy.ShouldBid(context.Background(), bidstrategy.BidStrategyRequest{
-			Job: jobForDockerImage(t, "busybox:latest"),
+			Job: jobForDockerImage(t, "busybox:1.37.0"),
 		})
 
 		require.NoError(t, err)

--- a/pkg/executor/docker/executor_test.go
+++ b/pkg/executor/docker/executor_test.go
@@ -386,7 +386,7 @@ func (s *ExecutorTestSuite) TestDockerExecutionCancellation() {
 	errC := make(chan error, 1)
 	executionID := uuid.New().String()
 
-	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37.0").
 		WithEntrypoint("sh", "-c", "sleep 30").
 		Build()
 
@@ -448,7 +448,7 @@ func (s *ExecutorTestSuite) TestTimesOutCorrectly() {
 	jobCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37.0").
 		WithEntrypoint("sh", "-c", fmt.Sprintf(`sleep 1 && echo "%s" && sleep 20`, expected)).
 		Build()
 	s.Require().NoError(err)
@@ -504,7 +504,7 @@ func (s *ExecutorTestSuite) TestDockerStreamsAlreadyComplete() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37.0").
 		WithEntrypoint("sh", "cat /sys/fs/cgroup/cpu.max").
 		Build()
 	s.Require().NoError(err)
@@ -531,7 +531,7 @@ func (s *ExecutorTestSuite) TestDockerStreamsAlreadyComplete() {
 func (s *ExecutorTestSuite) TestDockerStreamsSlowTask() {
 	id := "streams-ok"
 
-	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37.0").
 		WithEntrypoint("sh", "-c", "echo hello && sleep 20").
 		Build()
 	s.Require().NoError(err)
@@ -565,7 +565,7 @@ func (s *ExecutorTestSuite) TestDockerStreamsSlowTask() {
 }
 
 func (s *ExecutorTestSuite) TestDockerOOM() {
-	es, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+	es, err := dockermodels.NewDockerEngineBuilder("busybox:1.37.0").
 		WithEntrypoint("tail", "/dev/zero").
 		Build()
 	s.Require().NoError(err)

--- a/pkg/jobstore/boltdb/store_test.go
+++ b/pkg/jobstore/boltdb/store_test.go
@@ -1274,7 +1274,7 @@ func makeDockerEngineJob(entrypointArray []string) *models.Job {
 	j.Task().Engine = &models.SpecConfig{
 		Type: models.EngineDocker,
 		Params: map[string]interface{}{
-			"Image":      "busybox:latest",
+			"Image":      "busybox:1.37.0",
 			"Entrypoint": entrypointArray,
 		},
 	}

--- a/pkg/lib/marshaller/utils_test.go
+++ b/pkg/lib/marshaller/utils_test.go
@@ -21,7 +21,7 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "busybox:latest",
+          "Image": "busybox:1.37.0",
           "Entrypoint": [
             "/bin/sh"
           ],
@@ -52,7 +52,7 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "busybox:latest",
+          "Image": "busybox:1.37.0",
           "Entrypoint": [
             "/bin/sh"
           ],
@@ -84,7 +84,7 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "busybox:latest",
+          "Image": "busybox:1.37.0",
           "Entrypoint": [
             "/bin/sh"
           ],
@@ -115,7 +115,7 @@ func TestUnmarshalJob(t *testing.T) {
       "Engine": {
         "Type": "docker",
         "Params": {
-          "Image": "busybox:latest",
+          "Image": "busybox:1.37.0",
           "Entrypoint": [
             "/bin/sh"
           ],

--- a/pkg/test/compute/cancel_test.go
+++ b/pkg/test/compute/cancel_test.go
@@ -59,7 +59,7 @@ func (s *CancelSuite) TestCancelDocker() {
 	ctx := context.Background()
 
 	// prepare a docker execution that sleeps for 10 seconds so we can cancel it
-	dockerSpec, err := dockermodels.NewDockerEngineBuilder("busybox:latest").
+	dockerSpec, err := dockermodels.NewDockerEngineBuilder("busybox:1.37.0").
 		WithEntrypoint("sh", "-c", "sleep 10").
 		Build()
 	s.NoError(err)

--- a/pkg/test/devstack/default_publisher_test.go
+++ b/pkg/test/devstack/default_publisher_test.go
@@ -28,7 +28,7 @@ func getTestEngine() *models.SpecConfig {
 	return &models.SpecConfig{
 		Type: models.EngineDocker,
 		Params: dockmodels.EngineSpec{
-			Image: "busybox:latest",
+			Image: "busybox:1.37.0",
 			Entrypoint: []string{"/bin/sh", "-c", `
                 echo "output to stdout" && \
                 if [ ! -d /outputs ]; then \

--- a/pkg/test/devstack/errorlogs_test.go
+++ b/pkg/test/devstack/errorlogs_test.go
@@ -55,7 +55,7 @@ func executorTestCases(t testing.TB) []*models.Job {
 			Tasks: []*models.Task{
 				{
 					Name: t.Name(),
-					Engine: dockmodels.NewDockerEngineBuilder("busybox:latest").
+					Engine: dockmodels.NewDockerEngineBuilder("busybox:1.37.0").
 						WithEntrypoint("sh", "-c", "echo -n 'apples' >&1; echo -n 'oranges' >&2; exit 19;").
 						MustBuild(),
 					Publisher: publisher_local.NewSpecConfig(),

--- a/pkg/test/devstack/stop_test.go
+++ b/pkg/test/devstack/stop_test.go
@@ -152,7 +152,7 @@ func (s *StopSuite) submitJob(sleepTime int) (string, error) {
 		Tasks: []*models.Task{
 			{
 				Name: "main",
-				Engine: dockmodels.NewDockerEngineBuilder("busybox:latest").
+				Engine: dockmodels.NewDockerEngineBuilder("busybox:1.37.0").
 					WithEntrypoint("sh", "-c", fmt.Sprintf("sleep %d", sleepTime)).
 					MustBuild(),
 			},

--- a/pkg/test/executor/docker_entrypoint_test.go
+++ b/pkg/test/executor/docker_entrypoint_test.go
@@ -301,7 +301,7 @@ type dockerfilePermutation struct {
 func createDockerfile(d dockerfilePermutation) string {
 	ep := "\nENTRYPOINT [\"/bin/echo\"]"
 	cmd := "\nCMD [\"echo\", \"This is from CMD\"]"
-	baseDockerFile := "FROM busybox:latest"
+	baseDockerFile := "FROM busybox:1.37.0"
 	if d.entrypoint == true {
 		baseDockerFile += ep
 	}

--- a/pkg/test/logstream/losgream_test.go
+++ b/pkg/test/logstream/losgream_test.go
@@ -110,7 +110,7 @@ func (s *LogStreamTestSuite) TestDockerOutputStream() {
 				Engine: &models.SpecConfig{
 					Type: models.EngineDocker,
 					Params: dockermodels.EngineSpec{
-						Image:      "busybox:latest",
+						Image:      "busybox:1.37.0",
 						Entrypoint: []string{"sh", "-c", "for i in {1..100}; do echo \"logstreamoutput\"; sleep .1; done"},
 					}.ToMap(),
 				},

--- a/pkg/test/scenario/test_scenarios.go
+++ b/pkg/test/scenario/test_scenarios.go
@@ -24,7 +24,7 @@ const helloWorld = "hello world"
 const simpleMountPath = "/data/file.txt"
 const simpleOutputPath = "/output_data/output_file.txt"
 const catProgram = "cat " + simpleMountPath + " > " + simpleOutputPath
-const defaultDockerImage = "busybox:latest"
+const defaultDockerImage = "busybox:1.37.0"
 
 const AllowedListedLocalPathsSuffix = string(os.PathSeparator) + "*"
 

--- a/test_integration/common_assets/job_specs/hello_world.yml
+++ b/test_integration/common_assets/job_specs/hello_world.yml
@@ -6,7 +6,7 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: busybox:latest
+        Image: busybox:1.37.0
         Entrypoint:
           - /bin/sh
         Parameters:

--- a/test_integration/common_assets/job_specs/unsupported_engine_type.yml
+++ b/test_integration/common_assets/job_specs/unsupported_engine_type.yml
@@ -6,7 +6,7 @@ Tasks:
     Engine:
       Type: vroomvroom
       Params:
-        Image: busybox:latest
+        Image: busybox:1.37.0
         Entrypoint:
           - /bin/sh
         Parameters:

--- a/testdata/jobs/docker-hello.yaml
+++ b/testdata/jobs/docker-hello.yaml
@@ -6,7 +6,7 @@ tasks:
     engine:
       type: docker
       params:
-        Image: busybox:latest
+        Image: busybox:1.37.0
         Entrypoint:
           - /bin/sh
         Parameters:

--- a/testdata/jobs/docker-output.yaml
+++ b/testdata/jobs/docker-output.yaml
@@ -7,7 +7,7 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: busybox:latest
+        Image: busybox:1.37.0
         Entrypoint:
           - /bin/sh
         Parameters:

--- a/testdata/jobs/docker-s3.yaml
+++ b/testdata/jobs/docker-s3.yaml
@@ -7,7 +7,7 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: busybox:latest
+        Image: busybox:1.37.0
         Entrypoint:
           - /bin/sh
         Parameters:

--- a/testdata/jobs/docker.yaml
+++ b/testdata/jobs/docker.yaml
@@ -7,7 +7,7 @@ Tasks:
     Engine:
       Type: docker
       Params:
-        Image: busybox:latest
+        Image: busybox:1.37.0
         Entrypoint:
           - /bin/sh
         Parameters:


### PR DESCRIPTION
The orchestrator always tries to translate images with `latest` tag to their sha by communicating with the docker registry. While it does maintain a cache of translated images, the tests are spinning a new orchestrator node with fresh cache for almost each test case, which slows things down.

This PR uses explicit image version in the tests to avoid communicating with the registry for each test