### PR TITLE
skip flaky logstream tests

### DIFF
--- a/pkg/test/logstream/losgream_test.go
+++ b/pkg/test/logstream/losgream_test.go
@@ -100,6 +100,7 @@ func (s *LogStreamTestSuite) runLogStreamTest(job *models.Job) {
 
 // TestDockerOutputStream verifies log streaming works for Docker-based jobs
 func (s *LogStreamTestSuite) TestDockerOutputStream() {
+	s.T().Skip("test is flaky due to log stream stability")
 	docker.MustHaveDocker(s.T())
 	job := &models.Job{
 		Type:  models.JobTypeBatch,


### PR DESCRIPTION
Log stream is already unstable and its tests are causing the pipelines to continuously failing. Should be addressed as part of #3870 