### PR TITLE
login docker hub access in buildkite

### DIFF
--- a/buildkite/scripts/build_tarball.sh
+++ b/buildkite/scripts/build_tarball.sh
@@ -9,6 +9,8 @@ echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
 echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
 export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
 export BACALHAU_RELEASE_TOKEN=$(buildkite-agent secret get BACALHAU_RELEASE_TOKEN)
+export DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME)
+export DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD)
 
 # Prevent rebuilding web ui, we should have already attached it
 find webui -exec touch -c '{}' +

--- a/buildkite/scripts/build_tarball.sh
+++ b/buildkite/scripts/build_tarball.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Source docker authentication
+source "$(dirname "$0")/docker-auth.sh"
+docker_auth
+
 export PRIVATE_PEM_B64=$(buildkite-agent secret get PRIVATE_PEM_B64)
 export PUBLIC_PEM_B64=$(buildkite-agent secret get PUBLIC_PEM_B64)
 export PRIVATE_KEY_PASSPHRASE_B64=$(buildkite-agent secret get PRIVATE_KEY_PASSPHRASE_B64)
@@ -9,8 +13,6 @@ echo "$PRIVATE_PEM_B64" | base64 --decode > /tmp/private.pem
 echo "$PUBLIC_PEM_B64" | base64 --decode > /tmp/public.pem
 export PRIVATE_KEY_PASSPHRASE="$(echo $PRIVATE_KEY_PASSPHRASE_B64 | base64 --decode)"
 export BACALHAU_RELEASE_TOKEN=$(buildkite-agent secret get BACALHAU_RELEASE_TOKEN)
-export DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME)
-export DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD)
 
 # Prevent rebuilding web ui, we should have already attached it
 find webui -exec touch -c '{}' +

--- a/buildkite/scripts/build_webui.sh
+++ b/buildkite/scripts/build_webui.sh
@@ -2,4 +2,6 @@
 
 set -euo pipefail
 
+export DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME)
+export DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD)
 make build-webui

--- a/buildkite/scripts/build_webui.sh
+++ b/buildkite/scripts/build_webui.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
-export DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME)
-export DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD)
+# Source docker authentication
+source "$(dirname "$0")/docker-auth.sh"
+docker_auth
+
 make build-webui

--- a/buildkite/scripts/docker-auth.sh
+++ b/buildkite/scripts/docker-auth.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Function for docker authentication - can be sourced by other scripts
+docker_auth() {
+    echo "🔑 Starting Docker Hub authentication..."
+
+    # Function for error handling and logging
+    log_error() {
+        echo "❌ ERROR: $1" >&2
+        exit 1
+    }
+
+    log_info() {
+        echo "ℹ️ INFO: $1"
+    }
+
+    # Try to get secrets from buildkite-agent
+    if ! DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME 2>/dev/null); then
+        log_error "Failed to retrieve DOCKER_USERNAME from buildkite-agent secrets"
+    fi
+
+    if ! DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD 2>/dev/null); then
+        log_error "Failed to retrieve DOCKER_PASSWORD from buildkite-agent secrets"
+    fi
+
+    # Validate credentials are not empty
+    if [ -z "${DOCKER_USERNAME}" ]; then
+        log_error "DOCKER_USERNAME is empty or not set"
+    fi
+
+    if [ -z "${DOCKER_PASSWORD}" ]; then
+        log_error "DOCKER_PASSWORD is empty or not set"
+    fi
+
+    # Create docker config directory if it doesn't exist
+    mkdir -p ~/.docker || log_error "Failed to create ~/.docker directory"
+
+    # Create or update docker config.json with authentication
+    if ! auth_string=$(echo -n "${DOCKER_USERNAME}:${DOCKER_PASSWORD}" | base64); then
+        log_error "Failed to generate auth string"
+    fi
+
+    cat > ~/.docker/config.json << EOF || log_error "Failed to write Docker config file"
+{
+    "auths": {
+        "https://index.docker.io/v1/": {
+            "auth": "${auth_string}"
+        }
+    }
+}
+EOF
+
+    # Verify authentication
+    if ! echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin > /dev/null 2>&1; then
+        log_error "Docker login failed"
+    fi
+
+    log_info "Docker authentication successful"
+}
+
+# Only run if script is executed directly (not sourced)
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]; then
+    docker_auth
+fi

--- a/buildkite/scripts/lint.sh
+++ b/buildkite/scripts/lint.sh
@@ -3,6 +3,10 @@
 set -euo pipefail
 set -x
 
+# Source docker authentication
+source "$(dirname "$0")/docker-auth.sh"
+docker_auth
+
 # NB(forrest/udit): this step needs to be done before linting as without it the code doesn't compile since webuid/build DNE.
 make build-webui
 

--- a/buildkite/scripts/test.sh
+++ b/buildkite/scripts/test.sh
@@ -12,6 +12,8 @@ set_environment_variables() {
     export AWS_SECRET_ACCESS_KEY=$(buildkite-agent secret get AWS_SECRET_ACCESS_KEY)
     export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent secret get TESTSUITE_TOKEN)
     export AWS_REGION=eu-west-1
+    export DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME)
+    export DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD)
 }
 
 # Function to initialize IPFS

--- a/buildkite/scripts/test.sh
+++ b/buildkite/scripts/test.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Source docker authentication
+source "$(dirname "$0")/docker-auth.sh"
+docker_auth
+
 # Function to set environment variables
 set_environment_variables() {
     export LOG_LEVEL=DEBUG
@@ -12,8 +16,6 @@ set_environment_variables() {
     export AWS_SECRET_ACCESS_KEY=$(buildkite-agent secret get AWS_SECRET_ACCESS_KEY)
     export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent secret get TESTSUITE_TOKEN)
     export AWS_REGION=eu-west-1
-    export DOCKER_USERNAME=$(buildkite-agent secret get DOCKER_USERNAME)
-    export DOCKER_PASSWORD=$(buildkite-agent secret get DOCKER_PASSWORD)
 }
 
 # Function to initialize IPFS


### PR DESCRIPTION
login when accessing docker hub in buildkite to avoid rate limiting of unauthenticated access by docker. Without this we are getting these errors sometimes in buildkite:

```

Warning: you are not logged into registry-1.docker.io, you may experience rate-limitting when pulling images
--
  | +all \| apply build +base: earthfile2llb for +base: Earthfile:2:0 apply FROM node:20.8.1: resolve image config for node:20.8.1: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/20.8.1: 429 Too Many Requests
  | +all \| in		github.com/bacalhau-project/bacalhau/webui:HEAD+base
  |  
  | Help: The remote registry responded with a rate limit error. This is usually because you are not logged in.
  | You can login using the command:
  | docker login <server>


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a Docker authentication process to enhance security during build and test processes.
  
- **Bug Fixes**
	- Improved environment setup for scripts to ensure consistent access to Docker credentials across build, web UI, and testing scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->