### PR TITLE
Switch to ubuntu 22.04 from ChainGaurd docker image

### DIFF
--- a/docker/bacalhau-image/Dockerfile
+++ b/docker/bacalhau-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Automatically set by Docker to be the --platform flag
 ARG TARGETPLATFORM

--- a/docker/bacalhau-image/Dockerfile
+++ b/docker/bacalhau-image/Dockerfile
@@ -1,5 +1,4 @@
-# syntax=docker/dockerfile:1.4
-FROM cgr.dev/chainguard/nvidia-device-plugin
+FROM ubuntu:22.04
 
 # Automatically set by Docker to be the --platform flag
 ARG TARGETPLATFORM

--- a/test_integration/10_ubuntu_orchestrator_basic_suite_test.go
+++ b/test_integration/10_ubuntu_orchestrator_basic_suite_test.go
@@ -29,7 +29,7 @@ func (s *UbuntuOrchestratorBasicConfigSuite) SetupSuite() {
 	orchestratorStartCommand := fmt.Sprintf("bacalhau serve --config=%s", orchestratorConfigFile)
 	extraRenderingData := map[string]interface{}{
 		"OrchestratorStartCommand": orchestratorStartCommand,
-		"OrchestratorImageName":    fmt.Sprintf("bacalhau-test-ubuntu-compute-%s:%s", s.GlobalRunIdentifier, s.GlobalRunIdentifier),
+		"OrchestratorImageName":    fmt.Sprintf("bacalhau-test-ubuntu-orchestrator-%s:%s", s.GlobalRunIdentifier, s.GlobalRunIdentifier),
 	}
 	s.BaseDockerComposeTestSuite.SetupSuite(rawDockerComposeFilePath, extraRenderingData)
 }

--- a/test_integration/10_ubuntu_orchestrator_basic_suite_test.go
+++ b/test_integration/10_ubuntu_orchestrator_basic_suite_test.go
@@ -1,0 +1,71 @@
+package test_integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+type UbuntuOrchestratorBasicConfigSuite struct {
+	BaseDockerComposeTestSuite
+}
+
+func NewUbuntuOrchestratorBasicConfigSuite() *UbuntuOrchestratorBasicConfigSuite {
+	s := &UbuntuOrchestratorBasicConfigSuite{}
+	s.GlobalRunIdentifier = globalTestExecutionId
+	s.SuiteRunIdentifier = strings.ToLower(strings.Split(uuid.New().String(), "-")[0])
+	return s
+}
+
+func (s *UbuntuOrchestratorBasicConfigSuite) SetupSuite() {
+	rawDockerComposeFilePath := "./common_assets/docker_compose_files/orchestrator-ubuntu-node-with-custom-start-command.yml"
+	s.Context, s.Cancel = context.WithCancel(context.Background())
+
+	orchestratorConfigFile := s.commonAssets("nodes_configs/10_basic_orchestrator_config.yaml")
+	orchestratorStartCommand := fmt.Sprintf("bacalhau serve --config=%s", orchestratorConfigFile)
+	extraRenderingData := map[string]interface{}{
+		"OrchestratorStartCommand": orchestratorStartCommand,
+		"OrchestratorImageName":    fmt.Sprintf("bacalhau-test-ubuntu-compute-%s:%s", s.GlobalRunIdentifier, s.GlobalRunIdentifier),
+	}
+	s.BaseDockerComposeTestSuite.SetupSuite(rawDockerComposeFilePath, extraRenderingData)
+}
+
+func (s *UbuntuOrchestratorBasicConfigSuite) TearDownSuite() {
+	s.T().Log("Tearing down [Test Suite] in UbuntuOrchestratorBasicConfigSuite...")
+	s.BaseDockerComposeTestSuite.TearDownSuite()
+}
+
+func (s *UbuntuOrchestratorBasicConfigSuite) TestNodesCanBeListed() {
+	nodeListOutput, err := s.executeCommandInDefaultJumpbox(
+		[]string{
+			"bacalhau", "node", "list", "--output=json",
+		},
+	)
+	s.Require().NoErrorf(err, "Error listing nodes: %q", err)
+
+	output, err := s.convertStringToDynamicJSON(nodeListOutput)
+	s.Require().NoError(err)
+
+	nodeList, err := output.Query("$")
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(nodeList.Array()))
+
+	nodeInfo, err := output.Query("$[0].Info.NodeType")
+	s.Require().NoError(err)
+	s.Require().Equal("Requester", nodeInfo.String())
+
+	label1Value, err := output.Query("$[0].Info.Labels.label1")
+	s.Require().NoError(err)
+	s.Require().Equal("label1Value", label1Value.String())
+	label2Value, err := output.Query("$[0].Info.Labels.label2")
+	s.Require().NoError(err)
+	s.Require().Equal("label2Value", label2Value.String())
+}
+
+func TestUbuntuOrchestratorBasicConfigSuite(t *testing.T) {
+	suite.Run(t, NewUbuntuOrchestratorBasicConfigSuite())
+}

--- a/test_integration/common_assets/docker_compose_files/orchestrator-ubuntu-node-with-custom-start-command.yml
+++ b/test_integration/common_assets/docker_compose_files/orchestrator-ubuntu-node-with-custom-start-command.yml
@@ -1,0 +1,40 @@
+x-common-env-variables: &common-env-variables
+  NETWORK_AUTH_TOKEN: "i_am_very_secret_token"
+  BACALHAU_API_PORT: "1234"
+  BACALHAU_UPDATECONFIG_INTERVAL: "0"
+  BACALHAU_DISABLEANALYTICS: true
+
+networks:
+  bacalhau-network:
+    driver: bridge
+
+services:
+  bacalhau-orchestrator-node:
+    image: {{ .OrchestratorImageName }}
+    networks:
+      - bacalhau-network
+    environment: *common-env-variables
+    privileged: true
+    command:
+      - /bin/bash
+      - -c
+      - |
+        {{ .OrchestratorStartCommand }}
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -zv localhost 1234" ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      # Need to increase the time since ubuntu container takes a bit longer to start
+      start_period: 20s
+
+  bacalhau-jumpbox-node:
+    image: {{ .JumpboxImageName }}
+    privileged: true
+    command: tail -f /dev/null
+    restart: unless-stopped
+    networks:
+      - bacalhau-network
+    environment:
+      <<: *common-env-variables
+      BACALHAU_API_HOST: 'bacalhau-orchestrator-node'

--- a/test_integration/common_assets/dockerfiles/Dockerfile-UbuntuOrchestratorNode
+++ b/test_integration/common_assets/dockerfiles/Dockerfile-UbuntuOrchestratorNode
@@ -19,6 +19,6 @@ RUN update-ca-certificates
 RUN mkdir -p /bacalhau_integration_tests
 COPY ./ /bacalhau_integration_tests
 
-# Download and execute the Bash script from the given URL
 COPY ./common_assets/bacalhau_bin /usr/local/bin/bacalhau
-RUN chmod +x /usr/local/bin/bacalhau
+RUN chown root:root /usr/local/bin/bacalhau && \
+    chmod 755 /usr/local/bin/bacalhau

--- a/test_integration/common_assets/dockerfiles/Dockerfile-UbuntuOrchestratorNode
+++ b/test_integration/common_assets/dockerfiles/Dockerfile-UbuntuOrchestratorNode
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04
+
+# Set the working directory
+WORKDIR /app
+
+RUN apt update && apt install -y \
+    bash \
+    netcat-traditional \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy a root ca into the image
+COPY ./common_assets/certificates/generated_assets/bacalhau_test_root_ca.crt /usr/local/share/ca-certificates/bacalhau_test_root_ca.crt
+
+# Update CA certificates
+RUN update-ca-certificates
+
+# Copy Tests Assets
+RUN mkdir -p /bacalhau_integration_tests
+COPY ./ /bacalhau_integration_tests
+
+# Download and execute the Bash script from the given URL
+COPY ./common_assets/bacalhau_bin /usr/local/bin/bacalhau
+RUN chmod +x /usr/local/bin/bacalhau

--- a/test_integration/common_assets/nodes_configs/10_basic_orchestrator_config.yaml
+++ b/test_integration/common_assets/nodes_configs/10_basic_orchestrator_config.yaml
@@ -1,0 +1,10 @@
+NameProvider: "uuid"
+API:
+  Port: 1234
+Orchestrator:
+  Enabled: true
+  Auth:
+    Token: "i_am_very_secret_token"
+Labels:
+  label1: label1Value
+  label2: label2Value

--- a/test_integration/utils/test_utils.go
+++ b/test_integration/utils/test_utils.go
@@ -151,11 +151,11 @@ func BuildBaseImages(testIdentifier string) error {
 
 	err = buildDockerImage(
 		"common_assets/dockerfiles/Dockerfile-UbuntuOrchestratorNode",
-		"bacalhau-test-ubuntu-compute-"+testIdentifier,
+		"bacalhau-test-ubuntu-orchestrator-"+testIdentifier,
 		testIdentifier,
 	)
 	if err != nil {
-		return fmt.Errorf("error creating the bacalhau-test-ubuntu-compute image: %v", err)
+		return fmt.Errorf("error creating the bacalhau-test-ubuntu-orchestrator image: %v", err)
 	}
 
 	return nil

--- a/test_integration/utils/test_utils.go
+++ b/test_integration/utils/test_utils.go
@@ -149,6 +149,15 @@ func BuildBaseImages(testIdentifier string) error {
 		return fmt.Errorf("error creating the bacalhau-test-traefik image: %v", err)
 	}
 
+	err = buildDockerImage(
+		"common_assets/dockerfiles/Dockerfile-UbuntuOrchestratorNode",
+		"bacalhau-test-ubuntu-compute-"+testIdentifier,
+		testIdentifier,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating the bacalhau-test-ubuntu-compute image: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
We were using nvidia-device-plugin ChainGuard base image to build our docker images, but they have made the their images not public anymore.

We will switch to Ubuntu 24.04 LTS image.

In this PR, an integration test was added that uses the Ubuntu 24.04 LTS image for the test.

Linear: https://linear.app/expanso/issue/ENG-398/add-ubuntu-2404-as-the-base-image-for-published-docker-images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Docker Compose configuration for orchestrating services, including `bacalhau-orchestrator-node` and `bacalhau-jumpbox-node`.
	- Added a basic orchestrator configuration file with API settings and authentication tokens.
	- New test suite for the Ubuntu orchestrator configuration to validate node listing functionality.
	- Updated Dockerfile for the orchestrator node to ensure proper setup and integration test readiness with Ubuntu 24.04.

- **Chores**
	- Changed the base image of the Dockerfile to Ubuntu 24.04 for improved compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->