### PR TITLE
Add persisted sequence tracking and checkpoint support

### DIFF
--- a/pkg/compute/store/boltdb/constants.go
+++ b/pkg/compute/store/boltdb/constants.go
@@ -37,4 +37,7 @@ const (
 	// Event-related buckets
 	eventsBucket      = currentSchemaVersion + "_events"
 	checkpointsBucket = currentSchemaVersion + "_checkpoints"
+
+	// Sequence tracking checkpoints
+	sequenceTrackingBucket = currentSchemaVersion + "_sequence_tracking"
 )

--- a/pkg/compute/store/boltdb/store.go
+++ b/pkg/compute/store/boltdb/store.go
@@ -91,7 +91,12 @@ func NewStore(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	err = database.Update(func(tx *bolt.Tx) error {
-		buckets := []string{executionsBucket, executionEventsBucket, idxExecutionsByJobBucket, idxExecutionsByStateBucket}
+		buckets := []string{
+			executionsBucket,
+			executionEventsBucket,
+			idxExecutionsByJobBucket,
+			idxExecutionsByStateBucket,
+			sequenceTrackingBucket}
 		for _, b := range buckets {
 			_, err = tx.CreateBucketIfNotExists(strToBytes(b))
 			if err != nil {
@@ -518,6 +523,46 @@ func (s *Store) GetExecutionCount(ctx context.Context, state models.ExecutionSta
 	})
 
 	return count, err
+}
+
+func (s *Store) Checkpoint(ctx context.Context, name string, sequenceNumber uint64) error {
+	return s.database.Update(func(tx *bolt.Tx) error {
+		b := bucket(tx, sequenceTrackingBucket)
+		if b == nil {
+			return fmt.Errorf("sequence tracking bucket not found")
+		}
+
+		// Store sequence number as bytes
+		err := b.Put(strToBytes(name), uint64ToBytes(sequenceNumber))
+		if err != nil {
+			return fmt.Errorf("store sequence number: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (s *Store) GetCheckpoint(ctx context.Context, name string) (uint64, error) {
+	var seq uint64
+	err := s.database.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(strToBytes(sequenceTrackingBucket))
+		if b == nil {
+			return nil // Return 0 if bucket doesn't exist yet
+		}
+
+		data := b.Get(strToBytes(name))
+		if data == nil {
+			return nil // Return 0 if sequence doesn't exist
+		}
+
+		seq = bytesToUint64(data)
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("get sequence tracking value: %w", err)
+	}
+
+	return seq, nil
 }
 
 // compile-time check that we implement the interface ExecutionStore

--- a/pkg/compute/store/boltdb/store.go
+++ b/pkg/compute/store/boltdb/store.go
@@ -526,6 +526,10 @@ func (s *Store) GetExecutionCount(ctx context.Context, state models.ExecutionSta
 }
 
 func (s *Store) Checkpoint(ctx context.Context, name string, sequenceNumber uint64) error {
+	if name == "" {
+		return fmt.Errorf("checkpoint name cannot be empty")
+	}
+
 	return s.database.Update(func(tx *bolt.Tx) error {
 		b := bucket(tx, sequenceTrackingBucket)
 		if b == nil {

--- a/pkg/compute/store/boltdb/store.go
+++ b/pkg/compute/store/boltdb/store.go
@@ -527,9 +527,8 @@ func (s *Store) GetExecutionCount(ctx context.Context, state models.ExecutionSta
 
 func (s *Store) Checkpoint(ctx context.Context, name string, sequenceNumber uint64) error {
 	if name == "" {
-		return fmt.Errorf("checkpoint name cannot be empty")
+		return store.NewErrCheckpointNameBlank()
 	}
-
 	return s.database.Update(func(tx *bolt.Tx) error {
 		b := bucket(tx, sequenceTrackingBucket)
 		if b == nil {
@@ -547,6 +546,9 @@ func (s *Store) Checkpoint(ctx context.Context, name string, sequenceNumber uint
 }
 
 func (s *Store) GetCheckpoint(ctx context.Context, name string) (uint64, error) {
+	if name == "" {
+		return 0, store.NewErrCheckpointNameBlank()
+	}
 	var seq uint64
 	err := s.database.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(strToBytes(sequenceTrackingBucket))

--- a/pkg/compute/store/boltdb/utils.go
+++ b/pkg/compute/store/boltdb/utils.go
@@ -25,6 +25,11 @@ func uint64ToBytes(i uint64) []byte {
 	return buf
 }
 
+// bytesToUint64 converts a byte slice to an uint64
+func bytesToUint64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
 // Helper function to safely access buckets and nested buckets
 func bucket(tx *bolt.Tx, bucketNames ...string) *bolt.Bucket {
 	var b *bolt.Bucket

--- a/pkg/compute/store/errors.go
+++ b/pkg/compute/store/errors.go
@@ -116,3 +116,14 @@ func (e ErrExecutionAlreadyTerminal) Error() string {
 	return fmt.Sprintf("execution %s is in terminal state %s and cannot transition to %s",
 		e.ExecutionID, e.Actual.String(), e.NewState.String())
 }
+
+// ErrCheckpointNameBlank is returned when attempting to checkpoint with an empty name
+type ErrCheckpointNameBlank struct{}
+
+func NewErrCheckpointNameBlank() ErrCheckpointNameBlank {
+	return ErrCheckpointNameBlank{}
+}
+
+func (e ErrCheckpointNameBlank) Error() string {
+	return "checkpoint name cannot be blank"
+}

--- a/pkg/compute/store/test/store_suite.go
+++ b/pkg/compute/store/test/store_suite.go
@@ -251,6 +251,16 @@ func (s *StoreSuite) TestCheckpointWithClosedStore() {
 	s.Error(err)
 }
 
+func (s *StoreSuite) TestGetCheckpointBlankName() {
+	_, err := s.executionStore.GetCheckpoint(s.ctx, "")
+	s.ErrorAs(err, &store.ErrCheckpointNameBlank{})
+}
+
+func (s *StoreSuite) TestCheckpointBlankName() {
+	err := s.executionStore.Checkpoint(s.ctx, "", 42)
+	s.ErrorAs(err, &store.ErrCheckpointNameBlank{})
+}
+
 func (s *StoreSuite) verifyWatcherExecutionEvent(event watcher.Event,
 	expectedOperation watcher.Operation,
 	execution *models.Execution,

--- a/pkg/compute/store/test/store_suite.go
+++ b/pkg/compute/store/test/store_suite.go
@@ -1,5 +1,6 @@
 //go:build unit || !integration
 
+//nolint:all // Test suite file
 package test
 
 import (
@@ -171,6 +172,83 @@ func (s *StoreSuite) TestDeleteExecutionDoesntExist() {
 func (s *StoreSuite) TestGetExecutionEventsDoesntExist() {
 	_, err := s.executionStore.GetExecutionEvents(s.ctx, uuid.NewString())
 	s.ErrorAs(err, &store.ErrExecutionEventsNotFound{})
+}
+
+func (s *StoreSuite) TestGetCheckpointReturnsZeroForNonExistent() {
+	seq, err := s.executionStore.GetCheckpoint(s.ctx, "test-checkpoint")
+	s.Require().NoError(err)
+	s.Equal(uint64(0), seq)
+}
+
+func (s *StoreSuite) TestCheckpointStoresAndRetrieves() {
+	checkpointName := "test-checkpoint"
+	expectedSeq := uint64(42)
+
+	// Store checkpoint
+	err := s.executionStore.Checkpoint(s.ctx, checkpointName, expectedSeq)
+	s.Require().NoError(err)
+
+	// Retrieve checkpoint
+	seq, err := s.executionStore.GetCheckpoint(s.ctx, checkpointName)
+	s.Require().NoError(err)
+	s.Equal(expectedSeq, seq)
+}
+
+func (s *StoreSuite) TestMultipleCheckpointsCoexist() {
+	checkpoints := map[string]uint64{
+		"checkpoint-1": 42,
+		"checkpoint-2": 100,
+		"checkpoint-3": 999,
+	}
+
+	// Store multiple checkpoints
+	for name, seq := range checkpoints {
+		err := s.executionStore.Checkpoint(s.ctx, name, seq)
+		s.Require().NoError(err)
+	}
+
+	// Verify each checkpoint
+	for name, expectedSeq := range checkpoints {
+		seq, err := s.executionStore.GetCheckpoint(s.ctx, name)
+		s.Require().NoError(err)
+		s.Equal(expectedSeq, seq)
+	}
+}
+
+func (s *StoreSuite) TestCheckpointCanBeUpdated() {
+	checkpointName := "update-test"
+	initialSeq := uint64(42)
+	updatedSeq := uint64(100)
+
+	// Store initial checkpoint
+	err := s.executionStore.Checkpoint(s.ctx, checkpointName, initialSeq)
+	s.Require().NoError(err)
+
+	// Verify initial value
+	seq, err := s.executionStore.GetCheckpoint(s.ctx, checkpointName)
+	s.Require().NoError(err)
+	s.Equal(initialSeq, seq)
+
+	// Update checkpoint
+	err = s.executionStore.Checkpoint(s.ctx, checkpointName, updatedSeq)
+	s.Require().NoError(err)
+
+	// Verify updated value
+	seq, err = s.executionStore.GetCheckpoint(s.ctx, checkpointName)
+	s.Require().NoError(err)
+	s.Equal(updatedSeq, seq)
+}
+
+func (s *StoreSuite) TestCheckpointWithClosedStore() {
+	s.Require().NoError(s.executionStore.Close(s.ctx))
+
+	// Try to set checkpoint after closing
+	err := s.executionStore.Checkpoint(s.ctx, "test-checkpoint", 42)
+	s.Error(err)
+
+	// Try to get checkpoint after closing
+	_, err = s.executionStore.GetCheckpoint(s.ctx, "test-checkpoint")
+	s.Error(err)
 }
 
 func (s *StoreSuite) verifyWatcherExecutionEvent(event watcher.Event,

--- a/pkg/compute/store/types.go
+++ b/pkg/compute/store/types.go
@@ -34,6 +34,10 @@ type ExecutionStore interface {
 	GetExecutionCount(ctx context.Context, state models.ExecutionStateType) (uint64, error)
 	// GetEventStore returns the event store for the execution store
 	GetEventStore() watcher.EventStore
+	// Checkpoint saves the last sequence number processed
+	Checkpoint(ctx context.Context, name string, sequenceNumber uint64) error
+	// GetCheckpoint returns the last sequence number processed
+	GetCheckpoint(ctx context.Context, name string) (uint64, error)
 	// Close provides the opportunity for the underlying store to cleanup
 	// any resources as the compute node is shutting down
 	Close(ctx context.Context) error

--- a/pkg/test/compute/setup_test.go
+++ b/pkg/test/compute/setup_test.go
@@ -50,7 +50,7 @@ type ComputeSuite struct {
 }
 
 func (s *ComputeSuite) SetupTest() {
-	s.T().Skip("ENG-402 Unskip compute test suite")
+	s.T().Skip("ENG-402 Un-skip compute test suite")
 	s.setupConfig()
 	s.setupNode()
 }


### PR DESCRIPTION
This PR introduces persistent sequence tracking functionality in our execution store, distinct from our local event watcher checkpoints. This new tracking mechanism will help compute nodes maintain message continuity with orchestrators across restarts.

When a compute node reconnects to an orchestrator, it needs to know which message sequence number to resume from to avoid missing messages during downtime. This sequence tracking will allow compute nodes to persist the last sequence number _received_ from the orchestrator and request message replay from that point during reconnection.

Key changes:
- Added new bucket `sequence_tracking` to store remote sequence numbers
- Added `Checkpoint()` and `GetCheckpoint()` methods to store interface
- Added test coverage for sequence tracking
- All changes maintain backward compatibility with existing schema

Note: This is separate from our local event watcher checkpoints - this tracking is specifically for maintaining message ordering and continuity between compute nodes and orchestrators during reconnection scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for sequence tracking in the database.
	- Added methods to store and retrieve sequence numbers.
	- Enhanced utility with a new function for byte conversion.
	- Introduced a new error type for blank checkpoint names.

- **Bug Fixes**
	- Updated the skip message in the test suite for grammatical accuracy.

- **Tests**
	- Added comprehensive tests for checkpoint management, including storage, retrieval, updating, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->