### PR TITLE
Disable NCL tests as it is the default protocol

### DIFF
--- a/buildkite/pipelines/bacalhau-golang.yaml
+++ b/buildkite/pipelines/bacalhau-golang.yaml
@@ -54,26 +54,9 @@ steps:
     agents:
       queue: "buildkite-hosted-linux-large"
 
-  - label: ":testengine: Unit Test (NCL Protocol)"
-    command: "./buildkite/scripts/test.sh unit"
-    key: "unit-test-ncl"
-    env:
-      BACALHAU_PREFER_NCL_PROTOCOL: "true"
-    agents:
-      queue: "buildkite-hosted-linux-large"
-
   - label: ":testengine: Integration Test"
     command: "./buildkite/scripts/test.sh integration"
     key: "integration-test"
-    agents:
-      queue: "buildkite-hosted-linux-large"
-
-
-  - label: ":testengine: Integration Test (NCL Protocol)"
-    command: "./buildkite/scripts/test.sh integration"
-    key: "integration-test-ncl"
-    env:
-      BACALHAU_PREFER_NCL_PROTOCOL: "true"
     agents:
       queue: "buildkite-hosted-linux-large"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed NCL protocol-specific unit and integration testing steps from the pipeline, simplifying the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->