### PR TITLE
fix orchestrator data-plan startSeqNum

### DIFF
--- a/pkg/models/messages/node.go
+++ b/pkg/models/messages/node.go
@@ -15,9 +15,10 @@ type HandshakeRequest struct {
 
 // HandshakeResponse is sent in response to handshake requests
 type HandshakeResponse struct {
-	Accepted          bool   `json:"accepted"`
-	Reason            string `json:"reason,omitempty"`
-	LastComputeSeqNum uint64 `json:"LastComputeSeqNum"` // Last seq received from compute node
+	Accepted                   bool   `json:"accepted"`
+	Reason                     string `json:"reason,omitempty"`
+	LastComputeSeqNum          uint64 `json:"LastComputeSeqNum"`      // Last seq received from compute node
+	StartingOrchestratorSeqNum uint64 `json:"LastOrchestratorSeqNum"` // Seq to start sending to compute node
 }
 
 type HeartbeatRequest struct {

--- a/pkg/orchestrator/nodes/manager.go
+++ b/pkg/orchestrator/nodes/manager.go
@@ -492,9 +492,10 @@ func (n *nodesManager) Handshake(
 		reason = "node reconnected"
 	}
 	return messages.HandshakeResponse{
-		Accepted:          true,
-		Reason:            reason,
-		LastComputeSeqNum: state.ConnectionState.LastComputeSeqNum,
+		Accepted:                   true,
+		Reason:                     reason,
+		LastComputeSeqNum:          state.ConnectionState.LastComputeSeqNum,
+		StartingOrchestratorSeqNum: state.ConnectionState.LastOrchestratorSeqNum,
 	}, nil
 }
 

--- a/pkg/transport/nclprotocol/orchestrator/manager.go
+++ b/pkg/transport/nclprotocol/orchestrator/manager.go
@@ -186,7 +186,7 @@ func (cm *ComputeManager) handleHandshakeRequest(ctx context.Context, msg *envel
 	}
 
 	// Create data plane for accepted node
-	if err = cm.setupDataPlane(ctx, request.NodeInfo, request.LastOrchestratorSeqNum); err != nil {
+	if err = cm.setupDataPlane(ctx, request.NodeInfo, response.StartingOrchestratorSeqNum); err != nil {
 		return nil, fmt.Errorf("setup data plane failed: %w", err)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field, `StartingOrchestratorSeqNum`, in the handshake response to enhance information during node registration.
- **Bug Fixes**
	- Improved assertions in testing to ensure correct handling of sequence numbers for both new and reconnecting nodes during handshakes.
- **Documentation**
	- Updated comments and logging statements for clarity and consistency regarding the handshake process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->