### PR TITLE
improve orchestrator node self-registeration

### DIFF
--- a/pkg/models/node_state.go
+++ b/pkg/models/node_state.go
@@ -27,12 +27,12 @@ type ConnectionState struct {
 	LastHeartbeat time.Time `json:"LastHeartbeat"`
 
 	// Message sequencing for reliable delivery
-	LastComputeSeqNum      uint64 `json:"LastComputeSeqNum"`      // Last seq received from compute node
-	LastOrchestratorSeqNum uint64 `json:"LastOrchestratorSeqNum"` // Last seq received from orchestrator
+	LastComputeSeqNum      uint64 `json:"LastComputeSeqNum,omitempty"`      // Last seq received from compute node
+	LastOrchestratorSeqNum uint64 `json:"LastOrchestratorSeqNum,omitempty"` // Last seq received from orchestrator
 
 	// Connection tracking
 	ConnectedSince    time.Time `json:"ConnectedSince"`
-	DisconnectedSince time.Time `json:"DisconnectedSince,omitempty"`
+	DisconnectedSince time.Time `json:"DisconnectedSince"`
 	LastError         string    `json:"LastError,omitempty"`
 }
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -158,6 +158,7 @@ func NewNode(
 			apiServer,
 			transportLayer,
 			metadataStore,
+			nodeInfoProvider,
 		)
 		if err != nil {
 			return nil, err
@@ -194,21 +195,6 @@ func NewNode(
 		DebugInfoProviders: debugInfoProviders,
 		BacalhauConfig:     cfg.BacalhauConfig,
 	})
-
-	// We want to register the current requester node to the node store
-	// TODO (walid): revisit self node registration of requester node
-	if cfg.BacalhauConfig.Orchestrator.Enabled && !cfg.BacalhauConfig.Compute.Enabled {
-		nodeState := models.NodeState{
-			Info:       nodeInfoProvider.GetNodeInfo(ctx),
-			Membership: models.NodeMembership.APPROVED,
-			ConnectionState: models.ConnectionState{
-				Status: models.NodeStates.CONNECTED,
-			},
-		}
-		if err = requesterNode.NodeInfoStore.Put(ctx, nodeState); err != nil {
-			return nil, err
-		}
-	}
 
 	// Start periodic software update checks.
 	version.RunUpdateChecker(

--- a/pkg/orchestrator/nodes/manager.go
+++ b/pkg/orchestrator/nodes/manager.go
@@ -803,7 +803,7 @@ func (n *nodesManager) selfRegister(ctx context.Context) error {
 	state, err := n.store.Get(ctx, nodeInfo.ID())
 	if err != nil {
 		if !bacerrors.IsErrorWithCode(err, bacerrors.NotFoundError) {
-			return bacerrors.New("failed to self-register node: %w", err).
+			return bacerrors.New("failed to self-register node: %v", err).
 				WithComponent(errComponent)
 		}
 		state = models.NodeState{
@@ -826,7 +826,7 @@ func (n *nodesManager) selfRegister(ctx context.Context) error {
 
 	// store the updated state
 	if err = n.store.Put(ctx, state); err != nil {
-		return bacerrors.New("failed to self-register node: %w", err).
+		return bacerrors.New("failed to self-register node: %v", err).
 			WithComponent(errComponent)
 	}
 

--- a/pkg/orchestrator/nodes/manager.go
+++ b/pkg/orchestrator/nodes/manager.go
@@ -46,9 +46,10 @@ const (
 // state persistence with configurable intervals.
 type nodesManager struct {
 	// Core dependencies
-	store      Store              // Persistent storage for node states
-	eventstore watcher.EventStore // Store for events
-	clock      clock.Clock        // Time source (can be mocked for testing)
+	store            Store                   // Persistent storage for node states
+	eventstore       watcher.EventStore      // Event store for sequence number tracking
+	nodeInfoProvider models.NodeInfoProvider // Provides node information for self registration
+	clock            clock.Clock             // Time source (can be mocked for testing)
 
 	// Configuration
 	defaultApprovalState    models.NodeMembershipState // Initial membership state for new nodes
@@ -81,6 +82,9 @@ type ManagerParams struct {
 
 	// Clock is the time source (defaults to real clock if nil)
 	Clock clock.Clock
+
+	// NodeInfoProvider provides node information for self registration
+	NodeInfoProvider models.NodeInfoProvider
 
 	// NodeDisconnectedAfter is how long to wait before marking nodes as disconnected
 	NodeDisconnectedAfter time.Duration
@@ -150,6 +154,7 @@ func NewManager(params ManagerParams) (Manager, error) {
 	if err := errors.Join(
 		validate.NotNil(params.Store, "store required"),
 		validate.NotNil(params.EventStore, "event store required"),
+		validate.NotNil(params.NodeInfoProvider, "node info provider required"),
 	); err != nil {
 		return nil, fmt.Errorf("node manager invalid params: %w", err)
 	}
@@ -157,6 +162,7 @@ func NewManager(params ManagerParams) (Manager, error) {
 	return &nodesManager{
 		store:                   params.Store,
 		eventstore:              params.EventStore,
+		nodeInfoProvider:        params.NodeInfoProvider,
 		clock:                   params.Clock,
 		liveState:               &sync.Map{},
 		defaultApprovalState:    defaultApprovalState,
@@ -188,6 +194,11 @@ func (n *nodesManager) Start(ctx context.Context) error {
 	// Initialize clean state
 	n.liveState = &sync.Map{}
 	n.stopCh = make(chan struct{})
+
+	// self register the node's info in the store
+	if err := n.selfRegister(ctx); err != nil {
+		return err
+	}
 
 	// Start background tasks
 	n.startBackgroundTask("health-check", n.healthCheckLoop)
@@ -313,7 +324,7 @@ func (n *nodesManager) checkNodeHealth() {
 		// Try to update live state only if it hasn't changed since we checked it
 		newConnectionState := node.state.connectionState
 		newConnectionState.Status = models.NodeStates.DISCONNECTED
-		newConnectionState.DisconnectedSince = n.clock.Now()
+		newConnectionState.DisconnectedSince = n.clock.Now().UTC()
 		newConnectionState.LastError = "heartbeat timeout"
 
 		newState := &trackedLiveState{
@@ -331,7 +342,7 @@ func (n *nodesManager) checkNodeHealth() {
 			NodeID:    node.id,
 			Previous:  models.NodeStates.CONNECTED,
 			Current:   models.NodeStates.DISCONNECTED,
-			Timestamp: n.clock.Now(),
+			Timestamp: n.clock.Now().UTC(),
 		})
 	}
 }
@@ -443,8 +454,8 @@ func (n *nodesManager) Handshake(
 		Membership: n.defaultApprovalState,
 		ConnectionState: models.ConnectionState{
 			Status:         models.NodeStates.CONNECTED,
-			ConnectedSince: n.clock.Now(),
-			LastHeartbeat:  n.clock.Now(),
+			ConnectedSince: n.clock.Now().UTC(),
+			LastHeartbeat:  n.clock.Now().UTC(),
 		},
 	}
 
@@ -482,7 +493,7 @@ func (n *nodesManager) Handshake(
 		NodeID:    request.NodeInfo.ID(),
 		Previous:  existingConnectionState,
 		Current:   state.ConnectionState.Status,
-		Timestamp: n.clock.Now(),
+		Timestamp: n.clock.Now().UTC(),
 	})
 
 	log.Info().Msgf("handshake successful with node %s", request.NodeInfo.ID())
@@ -560,7 +571,7 @@ func (n *nodesManager) Heartbeat(
 
 		// updated connection state
 		updated := existing.connectionState
-		updated.LastHeartbeat = n.clock.Now()
+		updated.LastHeartbeat = n.clock.Now().UTC()
 		if request.LastOrchestratorSeqNum > 0 {
 			updated.LastOrchestratorSeqNum = request.LastOrchestratorSeqNum
 		}
@@ -630,7 +641,7 @@ func (n *nodesManager) RejectNode(ctx context.Context, nodeID string) error {
 	// Update persistent state first
 	state.Membership = models.NodeMembership.REJECTED
 	state.ConnectionState.Status = models.NodeStates.DISCONNECTED
-	state.ConnectionState.DisconnectedSince = n.clock.Now()
+	state.ConnectionState.DisconnectedSince = n.clock.Now().UTC()
 	state.ConnectionState.LastError = "node rejected"
 
 	if err = n.store.Put(ctx, state); err != nil {
@@ -644,7 +655,7 @@ func (n *nodesManager) RejectNode(ctx context.Context, nodeID string) error {
 				NodeID:    state.Info.ID(),
 				Previous:  models.NodeStates.CONNECTED,
 				Current:   models.NodeStates.DISCONNECTED,
-				Timestamp: n.clock.Now(),
+				Timestamp: n.clock.Now().UTC(),
 			})
 		}
 	}
@@ -679,7 +690,7 @@ func (n *nodesManager) DeleteNode(ctx context.Context, nodeID string) error {
 				NodeID:    state.Info.ID(),
 				Previous:  models.NodeStates.CONNECTED,
 				Current:   models.NodeStates.DISCONNECTED,
-				Timestamp: n.clock.Now(),
+				Timestamp: n.clock.Now().UTC(),
 			})
 		}
 	}
@@ -782,6 +793,44 @@ func (n *nodesManager) enrichState(state *models.NodeState) {
 	}
 	//nolint:staticcheck
 	state.Connection = state.ConnectionState.Status // for backward compatibility
+}
+
+func (n *nodesManager) selfRegister(ctx context.Context) error {
+	// get latest node info
+	nodeInfo := n.nodeInfoProvider.GetNodeInfo(ctx)
+
+	// get node info from the store if it exists
+	state, err := n.store.Get(ctx, nodeInfo.ID())
+	if err != nil {
+		if !bacerrors.IsErrorWithCode(err, bacerrors.NotFoundError) {
+			return bacerrors.New("failed to self-register node: %w", err).
+				WithComponent(errComponent)
+		}
+		state = models.NodeState{
+			Info:       nodeInfo,
+			Membership: models.NodeMembership.APPROVED,
+			ConnectionState: models.ConnectionState{
+				ConnectedSince: n.clock.Now().UTC(),
+			},
+		}
+	}
+	// update the node info and make as connected
+	state.Info = nodeInfo
+	state.ConnectionState.Status = models.NodeStates.CONNECTED
+	state.ConnectionState.LastHeartbeat = n.clock.Now().UTC()
+
+	// for backward compatibility before connection state was introduced
+	if state.ConnectionState.ConnectedSince.IsZero() {
+		state.ConnectionState.ConnectedSince = n.clock.Now().UTC()
+	}
+
+	// store the updated state
+	if err = n.store.Put(ctx, state); err != nil {
+		return bacerrors.New("failed to self-register node: %w", err).
+			WithComponent(errComponent)
+	}
+
+	return nil
 }
 
 // compile-time check that nodesManager implements the Manager interface

--- a/pkg/orchestrator/nodes/manager_test.go
+++ b/pkg/orchestrator/nodes/manager_test.go
@@ -25,12 +25,14 @@ import (
 
 type NodeManagerTestSuite struct {
 	suite.Suite
-	ctx          context.Context
-	clock        *clock.Mock
-	store        nodes.Store
-	eventStore   watcher.EventStore
-	manager      nodes.Manager
-	disconnected time.Duration
+	ctx              context.Context
+	clock            *clock.Mock
+	store            nodes.Store
+	eventStore       watcher.EventStore
+	manager          nodes.Manager
+	disconnected     time.Duration
+	nodeInfo         models.NodeInfo
+	nodeInfoProvider models.NodeInfoProvider
 }
 
 func TestNodeManagerSuite(t *testing.T) {
@@ -48,10 +50,17 @@ func (s *NodeManagerTestSuite) SetupTest() {
 	})
 
 	s.eventStore, _ = testutils.CreateStringEventStore(s.T())
+	s.nodeInfo = models.NodeInfo{
+		NodeID:   "orchestrator-node",
+		NodeType: models.NodeTypeRequester,
+		Labels:   map[string]string{"test": "true"},
+	}
+	s.nodeInfoProvider = &mockNodeInfoProvider{info: s.nodeInfo}
 
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 		HealthCheckFrequency:  1 * time.Second,
@@ -446,7 +455,7 @@ func (s *NodeManagerTestSuite) TestConcurrentHandshakes() {
 	// Verify all nodes are registered
 	nodes, err := s.manager.List(s.ctx)
 	s.Require().NoError(err)
-	assert.Len(s.T(), nodes, numNodes)
+	assert.Len(s.T(), nodes, numNodes+1) // +1 for the current node
 }
 
 func (s *NodeManagerTestSuite) TestConcurrentHealthCheckAndHeartbeat() {
@@ -540,6 +549,7 @@ func (s *NodeManagerTestSuite) TestConcurrentOperations() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 clock.New(), // Use real clock for this test
 		NodeDisconnectedAfter: s.disconnected,
 		HealthCheckFrequency:  1 * time.Second,
@@ -589,10 +599,14 @@ func (s *NodeManagerTestSuite) TestConcurrentOperations() {
 	// Verify final state of all nodes
 	nodes, err := manager.List(ctx)
 	s.Require().NoError(err)
-	s.Require().Len(nodes, numNodes)
+	s.Require().Len(nodes, numNodes+1) // +1 for the current node
 
 	// Verify each node's state and sequence numbers
 	for _, state := range nodes {
+		// Skip current node
+		if state.Info.ID() == s.nodeInfo.ID() {
+			continue
+		}
 		// Verify connection status
 		s.Assert().Equal(models.NodeStates.CONNECTED, state.ConnectionState.Status)
 
@@ -699,6 +713,7 @@ func (s *NodeManagerTestSuite) TestStartStop() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 		HealthCheckFrequency:  1 * time.Second,
@@ -726,6 +741,7 @@ func (s *NodeManagerTestSuite) TestStartAlreadyStarted() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 	})
@@ -752,6 +768,7 @@ func (s *NodeManagerTestSuite) TestStartContextCancellation() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 		HealthCheckFrequency:  1 * time.Second,
@@ -780,6 +797,7 @@ func (s *NodeManagerTestSuite) TestStopAlreadyStopped() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 	})
@@ -800,6 +818,90 @@ func (s *NodeManagerTestSuite) TestStopAlreadyStopped() {
 	s.Require().False(manager.Running())
 }
 
+func (s *NodeManagerTestSuite) TestSelfRegistration() {
+	tests := []struct {
+		name          string
+		existingState *models.NodeState
+		providerInfo  models.NodeInfo
+		validateState func(*testing.T, models.NodeState)
+	}{
+		{
+			name: "new registration",
+			providerInfo: models.NodeInfo{
+				NodeID:   "node1",
+				NodeType: models.NodeTypeRequester,
+			},
+			validateState: func(t *testing.T, state models.NodeState) {
+				assert.Equal(t, models.NodeMembership.APPROVED, state.Membership)
+				assert.Equal(t, models.NodeStates.CONNECTED, state.ConnectionState.Status)
+				assert.False(t, state.ConnectionState.ConnectedSince.IsZero())
+			},
+		},
+		{
+			name: "preserves existing state",
+			existingState: &models.NodeState{
+				Info: models.NodeInfo{NodeID: "node2", NodeType: models.NodeTypeRequester},
+				ConnectionState: models.ConnectionState{
+					LastOrchestratorSeqNum: 42,
+					LastComputeSeqNum:      24,
+				},
+				Membership: models.NodeMembership.APPROVED,
+			},
+			providerInfo: models.NodeInfo{
+				NodeID:   "node2",
+				NodeType: models.NodeTypeRequester,
+				Labels:   map[string]string{"new": "true"},
+			},
+			validateState: func(t *testing.T, state models.NodeState) {
+				assert.Equal(t, uint64(42), state.ConnectionState.LastOrchestratorSeqNum)
+				assert.Equal(t, uint64(24), state.ConnectionState.LastComputeSeqNum)
+				assert.Equal(t, "true", state.Info.Labels["new"])
+			},
+		},
+		{
+			name: "updates zero connected time",
+			existingState: &models.NodeState{
+				Info: models.NodeInfo{NodeID: "node3", NodeType: models.NodeTypeRequester},
+				ConnectionState: models.ConnectionState{
+					Status: models.NodeStates.DISCONNECTED,
+				},
+			},
+			providerInfo: models.NodeInfo{NodeID: "node3", NodeType: models.NodeTypeRequester},
+			validateState: func(t *testing.T, state models.NodeState) {
+				assert.Equal(t, s.clock.Now().UTC(), state.ConnectionState.ConnectedSince)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			// Setup existing state if needed
+			if tt.existingState != nil {
+				require.NoError(s.T(), s.store.Put(s.ctx, *tt.existingState))
+			}
+
+			// Create and start manager
+			manager, err := nodes.NewManager(nodes.ManagerParams{
+				Store:                 s.store,
+				EventStore:            s.eventStore,
+				Clock:                 s.clock,
+				NodeInfoProvider:      &mockNodeInfoProvider{info: tt.providerInfo},
+				NodeDisconnectedAfter: s.disconnected,
+			})
+			require.NoError(s.T(), err)
+
+			err = manager.Start(s.ctx)
+			require.NoError(s.T(), err)
+			defer manager.Stop(s.ctx)
+
+			// Verify state
+			state, err := manager.Get(s.ctx, tt.providerInfo.ID())
+			require.NoError(s.T(), err)
+			tt.validateState(s.T(), state)
+		})
+	}
+}
+
 // Persistence Tests
 
 func (s *NodeManagerTestSuite) TestPeriodicStatePersistence() {
@@ -808,6 +910,7 @@ func (s *NodeManagerTestSuite) TestPeriodicStatePersistence() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 		PersistInterval:       persistInterval,
@@ -872,6 +975,7 @@ func (s *NodeManagerTestSuite) TestStatePersistenceOnStop() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 		PersistInterval:       time.Hour, // Long interval to ensure persistence happens on stop
@@ -917,6 +1021,7 @@ func (s *NodeManagerTestSuite) TestPersistenceWithContextCancellation() {
 	manager, err := nodes.NewManager(nodes.ManagerParams{
 		Store:                 s.store,
 		EventStore:            s.eventStore,
+		NodeInfoProvider:      s.nodeInfoProvider,
 		Clock:                 s.clock,
 		NodeDisconnectedAfter: s.disconnected,
 		PersistInterval:       100 * time.Millisecond,
@@ -965,4 +1070,12 @@ func (s *NodeManagerTestSuite) TestPersistenceWithContextCancellation() {
 	assert.Equal(s.T(), newResources, state.Info.ComputeNodeInfo.AvailableCapacity)
 	assert.Equal(s.T(), lastOrchestratorSeqNum, state.ConnectionState.LastOrchestratorSeqNum)
 	assert.Equal(s.T(), lastComputeSeqNum, state.ConnectionState.LastComputeSeqNum)
+}
+
+type mockNodeInfoProvider struct {
+	info models.NodeInfo
+}
+
+func (m *mockNodeInfoProvider) GetNodeInfo(context.Context) models.NodeInfo {
+	return m.info
 }

--- a/pkg/transport/bprotocol/orchestrator/heartbeat_test.go
+++ b/pkg/transport/bprotocol/orchestrator/heartbeat_test.go
@@ -63,6 +63,8 @@ func (s *HeartbeatTestSuite) SetupTest() {
 		Store:                 inmemory.NewNodeStore(inmemory.NodeStoreParams{TTL: 1 * time.Hour}),
 		NodeDisconnectedAfter: 5 * time.Second,
 		EventStore:            s.eventStore,
+		NodeInfoProvider: &mockNodeInfoProvider{info: models.NodeInfo{
+			NodeID: "orchestrator-node", NodeType: models.NodeTypeRequester}},
 	})
 	s.Require().NoError(err)
 	s.Require().NoError(s.nodeManager.Start(context.Background()))
@@ -276,4 +278,12 @@ func (s *HeartbeatTestSuite) TestConcurrentHeartbeats() {
 		s.Require().NoError(err)
 		s.Require().Equal(models.NodeStates.CONNECTED, nodeState.ConnectionState.Status)
 	}
+}
+
+type mockNodeInfoProvider struct {
+	info models.NodeInfo
+}
+
+func (m *mockNodeInfoProvider) GetNodeInfo(context.Context) models.NodeInfo {
+	return m.info
 }


### PR DESCRIPTION
Avoid orchestrator node showing as disconnected or with empty connected since dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced node initialization with additional information through a new `nodeInfoProvider` parameter.
	- Introduced self-registration capabilities for the node manager, improving node information management.

- **Bug Fixes**
	- Updated timestamp handling for connection states and heartbeats to use UTC format.

- **Tests**
	- Expanded test suite to include scenarios for node self-registration and improved handling of concurrent operations. 
	- Added mock implementations to facilitate testing of node information management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->