### PR TITLE
better exchange of starting seqNum during handshakes

### DIFF
--- a/pkg/node/requester.go
+++ b/pkg/node/requester.go
@@ -52,7 +52,7 @@ type Requester struct {
 	Endpoint *orchestrator.BaseEndpoint
 	JobStore jobstore.Store
 	// We need a reference to the node info store until libp2p is removed
-	NodeInfoStore      nodes.Store
+	NodeInfoStore      nodes.Lookup
 	cleanupFunc        func(ctx context.Context)
 	debugInfoProviders []models.DebugInfoProvider
 }
@@ -77,7 +77,7 @@ func NewRequesterNode(
 	}
 
 	nodeID := cfg.NodeID
-	nodesManager, nodeStore, err := createNodeManager(ctx, cfg, jobStore.GetEventStore(), nodeInfoProvider, natsConn)
+	nodesManager, _, err := createNodeManager(ctx, cfg, jobStore.GetEventStore(), nodeInfoProvider, natsConn)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func NewRequesterNode(
 
 	return &Requester{
 		Endpoint:           endpointV2,
-		NodeInfoStore:      nodeStore,
+		NodeInfoStore:      nodesManager,
 		JobStore:           jobStore,
 		cleanupFunc:        cleanupFunc,
 		debugInfoProviders: debugInfoProviders,

--- a/pkg/transport/nclprotocol/compute/controlplane.go
+++ b/pkg/transport/nclprotocol/compute/controlplane.go
@@ -224,6 +224,9 @@ func (cp *ControlPlane) Stop(ctx context.Context) error {
 
 	select {
 	case <-done:
+		if err := cp.checkpointProgress(ctx); err != nil {
+			log.Error().Err(err).Msg("Failed to checkpoint progress before stopping")
+		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/transport/nclprotocol/compute/manager.go
+++ b/pkg/transport/nclprotocol/compute/manager.go
@@ -313,6 +313,11 @@ func (cm *ConnectionManager) performHandshake(
 		return messages.HandshakeResponse{}, fmt.Errorf(
 			"handshake rejected by orchestrator due to %s", handshakeResponse.Reason)
 	}
+
+	// Always trust the orchestrator's starting sequence number as it may have been reset
+	// or decided to start from a different point
+	cm.incomingSeqTracker.UpdateLastSeqNum(handshakeResponse.StartingOrchestratorSeqNum)
+
 	return handshakeResponse, nil
 }
 

--- a/pkg/transport/nclprotocol/dispatcher/state.go
+++ b/pkg/transport/nclprotocol/dispatcher/state.go
@@ -11,6 +11,12 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
 )
 
+type State struct {
+	LastAckedSeqNum    uint64
+	LastObservedSeqNum uint64
+	LastCheckpoint     uint64
+}
+
 // dispatcherState manages all state tracking for the dispatcher including
 // sequence numbers, pending messages, and recovery state
 type dispatcherState struct {
@@ -27,6 +33,17 @@ type dispatcherState struct {
 func newDispatcherState() *dispatcherState {
 	return &dispatcherState{
 		pending: newPendingMessageStore(),
+	}
+}
+
+// GetState returns
+func (s *dispatcherState) GetState() State {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return State{
+		LastAckedSeqNum:    s.lastAckedSeqNum,
+		LastObservedSeqNum: s.lastObservedSeq,
+		LastCheckpoint:     s.lastCheckpoint,
 	}
 }
 

--- a/pkg/transport/nclprotocol/orchestrator/manager.go
+++ b/pkg/transport/nclprotocol/orchestrator/manager.go
@@ -258,7 +258,7 @@ func (cm *ComputeManager) handleHeartbeatRequest(ctx context.Context, msg *envel
 		return nil, err
 	}
 
-	return envelope.NewMessage(response), nil
+	return envelope.NewMessage(response).WithMetadataValue(envelope.KeyMessageType, messages.HeartbeatResponseType), nil
 }
 
 // handleNodeInfoUpdateRequest processes node info updates from compute nodes.
@@ -278,7 +278,8 @@ func (cm *ComputeManager) handleNodeInfoUpdateRequest(ctx context.Context, msg *
 		return nil, err
 	}
 
-	return envelope.NewMessage(response), nil
+	return envelope.NewMessage(response).
+		WithMetadataValue(envelope.KeyMessageType, messages.NodeInfoUpdateResponseType), nil
 }
 
 // handleConnectionStateChange responds to node connection state changes
@@ -294,7 +295,7 @@ func (cm *ComputeManager) handleConnectionStateChange(event nodes.NodeConnection
 	if event.Current == models.NodeStates.DISCONNECTED {
 		if dataPlane, ok := cm.dataPlanes.LoadAndDelete(event.NodeID); ok {
 			if dp, ok := dataPlane.(*DataPlane); ok {
-				if err := dp.Stop(context.Background()); err != nil {
+				if err := dp.Stop(context.TODO()); err != nil {
 					log.Error().Err(err).
 						Str("nodeID", event.NodeID).
 						Msg("Failed to stop data plane for disconnected node")


### PR DESCRIPTION
## Problem
When nodes restart or lose state, the current sequence number synchronization can lead to message gaps or duplicates. This occurs because nodes unconditionally trust each other's sequence numbers during handshake, without considering local state recovery scenarios.

## Solution
This PR implements a "trust your own state" approach for sequence number synchronization during handshakes. Each node relies on its local state to determine its starting point, while using the handshake to inform the other party of its position.

### Changes in Handshake Flow
- **Orchestrator Behavior**
  - Uses its local knowledge of the compute node's last received sequence number
  - Starts streaming from 0 if no prior state exists, regardless of compute node's reported position
  - Tracks compute node's progress through heartbeat updates

- **Compute Node Behavior**
  - Starts from its local checkpoint, preserved across restarts
  - Ignores orchestrator's suggested sequence position if local state exists
  - Continues reporting processed sequence numbers via heartbeats


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new methods for managing node sequence numbers and state handling.
  - Added functionality to ensure message publishing starts correctly after node restarts.
  - Enhanced dispatcher state management with a new structured format.

- **Bug Fixes**
  - Improved error handling for sequence number resolution and checkpointing processes.

- **Tests**
  - Added new tests to verify the behavior of the data plane and dispatcher during various scenarios.

- **Documentation**
  - Updated comments and documentation to reflect changes in methods and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->