### PR TITLE
Add Shutdown Notice from Compute Nodes

### DIFF
--- a/pkg/models/messages/constants.go
+++ b/pkg/models/messages/constants.go
@@ -13,8 +13,10 @@ const (
 	HandshakeRequestMessageType      = "transport.HandshakeRequest"
 	HeartbeatRequestMessageType      = "transport.HeartbeatRequest"
 	NodeInfoUpdateRequestMessageType = "transport.UpdateNodeInfoRequest"
+	ShutdownNoticeRequestMessageType = "transport.ShutdownNoticeRequest"
 
 	HandshakeResponseType      = "transport.HandshakeResponse"
 	HeartbeatResponseType      = "transport.HeartbeatResponse"
 	NodeInfoUpdateResponseType = "transport.UpdateNodeInfoResponse"
+	ShutdownNoticeResponseType = "transport.ShutdownNoticeResponse"
 )

--- a/pkg/models/messages/control_plane.go
+++ b/pkg/models/messages/control_plane.go
@@ -40,3 +40,15 @@ type UpdateNodeInfoResponse struct {
 	Accepted bool   `json:"accepted"`
 	Reason   string `json:"reason,omitempty"`
 }
+
+// ShutdownNoticeRequest tells the orchestrator that this node is shutting down
+type ShutdownNoticeRequest struct {
+	NodeID                 string `json:"NodeID"`
+	Reason                 string `json:"Reason,omitempty"`
+	LastOrchestratorSeqNum uint64 `json:"LastOrchestratorSeqNum"` // Last seq received from orchestrator
+}
+
+// ShutdownNoticeResponse sends any final instructions back to the shutting-down node
+type ShutdownNoticeResponse struct {
+	LastComputeSeqNum uint64 `json:"LastComputeSeqNum"` // Last seq received from compute node
+}

--- a/pkg/orchestrator/nodes/manager.go
+++ b/pkg/orchestrator/nodes/manager.go
@@ -582,6 +582,63 @@ func (n *nodesManager) Heartbeat(
 	return messages.HeartbeatResponse{}, NewErrConcurrentModification()
 }
 
+// ShutdownNotice processes a shutdown notification from a node and updates its state.
+// It updates:
+//   - Final sequence numbers
+//   - Connection state to disconnected
+//   - Preserves the sequence numbers in persistent storage
+//
+// Returns ShutdownNoticeResponse with the last sequence number processed from that node.
+func (n *nodesManager) ShutdownNotice(
+	ctx context.Context, request ExtendedShutdownNoticeRequest) (messages.ShutdownNoticeResponse, error) {
+
+	// Get existing live state
+	existingEntry, ok := n.liveState.Load(request.NodeID)
+	if !ok {
+		return messages.ShutdownNoticeResponse{}, NewErrHandshakeRequired(request.NodeID)
+	}
+
+	existing := existingEntry.(*trackedLiveState)
+	if existing.connectionState.Status != models.NodeStates.CONNECTED {
+		return messages.ShutdownNoticeResponse{}, NewErrHandshakeRequired(request.NodeID)
+	}
+
+	// Update connection state with final sequence numbers
+	updated := existing.connectionState
+	updated.Status = models.NodeStates.DISCONNECTED
+	updated.DisconnectedSince = n.clock.Now().UTC()
+	n.updateSequenceNumbers(&updated, request.LastOrchestratorSeqNum, request.LastComputeSeqNum)
+	updated.LastError = "graceful shutdown"
+
+	// Attempt atomic update
+	if !n.liveState.CompareAndSwap(request.NodeID, existingEntry, &trackedLiveState{
+		connectionState:   updated,
+		availableCapacity: models.Resources{}, // Clear capacity since node is shutting down
+		queueUsedCapacity: models.Resources{},
+	}) {
+		return messages.ShutdownNoticeResponse{}, NewErrConcurrentModification()
+	}
+
+	log.Info().
+		Str("node", request.NodeID).
+		Str("reason", request.Reason).
+		Uint64("lastOrchestratorSeq", updated.LastOrchestratorSeqNum).
+		Uint64("lastComputeSeq", updated.LastComputeSeqNum).
+		Msg("Node shutdown notice received")
+
+	// Notify about state change
+	n.notifyConnectionStateChange(NodeConnectionEvent{
+		NodeID:    request.NodeID,
+		Previous:  models.NodeStates.CONNECTED,
+		Current:   models.NodeStates.DISCONNECTED,
+		Timestamp: updated.DisconnectedSince,
+	})
+
+	return messages.ShutdownNoticeResponse{
+		LastComputeSeqNum: updated.LastComputeSeqNum,
+	}, nil
+}
+
 // ApproveNode approves a node for cluster participation.
 // The node must be in PENDING state. The operation updates
 // both persistent and live state.

--- a/pkg/orchestrator/nodes/manager.go
+++ b/pkg/orchestrator/nodes/manager.go
@@ -591,7 +591,6 @@ func (n *nodesManager) Heartbeat(
 // Returns ShutdownNoticeResponse with the last sequence number processed from that node.
 func (n *nodesManager) ShutdownNotice(
 	ctx context.Context, request ExtendedShutdownNoticeRequest) (messages.ShutdownNoticeResponse, error) {
-
 	// Get existing live state
 	existingEntry, ok := n.liveState.Load(request.NodeID)
 	if !ok {

--- a/pkg/orchestrator/nodes/types.go
+++ b/pkg/orchestrator/nodes/types.go
@@ -64,6 +64,10 @@ type Manager interface {
 	// The node must be registered and not rejected.
 	UpdateNodeInfo(ctx context.Context, request messages.UpdateNodeInfoRequest) (messages.UpdateNodeInfoResponse, error)
 
+	// ShutdownNotice handles a node's graceful shutdown notification.
+	// It updates sequence numbers and marks the node as cleanly disconnected.
+	ShutdownNotice(ctx context.Context, request ExtendedShutdownNoticeRequest) (messages.ShutdownNoticeResponse, error)
+
 	// Heartbeat processes a node's heartbeat message and updates its state.
 	// It returns the last known sequence numbers for synchronization.
 	Heartbeat(ctx context.Context, request ExtendedHeartbeatRequest) (messages.HeartbeatResponse, error)
@@ -132,6 +136,14 @@ type ConnectionStateChangeHandler func(NodeConnectionEvent)
 // ExtendedHeartbeatRequest represents a heartbeat message with additional metadata.
 type ExtendedHeartbeatRequest struct {
 	messages.HeartbeatRequest
+
+	// LastComputeSeqNum is the last processed compute message sequence
+	LastComputeSeqNum uint64
+}
+
+// ExtendedShutdownNoticeRequest represents a shutdown message with additional metadata.
+type ExtendedShutdownNoticeRequest struct {
+	messages.ShutdownNoticeRequest
 
 	// LastComputeSeqNum is the last processed compute message sequence
 	LastComputeSeqNum uint64

--- a/pkg/transport/nclprotocol/registry.go
+++ b/pkg/transport/nclprotocol/registry.go
@@ -23,11 +23,13 @@ func CreateMessageRegistry() (*envelope.Registry, error) {
 		reg.Register(messages.HandshakeRequestMessageType, messages.HandshakeRequest{}),
 		reg.Register(messages.HeartbeatRequestMessageType, messages.HeartbeatRequest{}),
 		reg.Register(messages.NodeInfoUpdateRequestMessageType, messages.UpdateNodeInfoRequest{}),
+		reg.Register(messages.ShutdownNoticeRequestMessageType, messages.ShutdownNoticeRequest{}),
 
 		// Control plane responses
 		reg.Register(messages.HandshakeResponseType, messages.HandshakeResponse{}),
 		reg.Register(messages.HeartbeatResponseType, messages.HeartbeatResponse{}),
 		reg.Register(messages.NodeInfoUpdateResponseType, messages.UpdateNodeInfoResponse{}),
+		reg.Register(messages.ShutdownNoticeResponseType, messages.ShutdownNoticeResponse{}),
 	)
 	return reg, err
 }


### PR DESCRIPTION
When compute nodes shut down, they should notify the orchestrator with their final sequence numbers. While this info is already shared in heartbeats, a dedicated shutdown message confirms intentional shutdown vs connection failure and guarantees the orchestrator receives latest sequence numbers. This lets the orchestrator clean up node state immediately rather than waiting for missing heartbeats.

Changes:
- Added `sendShutdownNotification` method to ControlPlane for notifying orchestrator before shutdown
- Modified Stop() to send notification if node is connected and context isn't cancelled
- Added test cases covering successful notification, skipped notifications (when disconnected/cancelled), and error handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced constants for shutdown notice request and response message types.
	- Added structures for handling shutdown notice requests and responses.
	- Implemented a method for processing shutdown notifications in the node manager.
	- Enhanced control plane to send shutdown notifications to the orchestrator.
	- Updated the compute manager to handle shutdown requests from nodes.

- **Bug Fixes**
	- Improved error handling and state management during shutdown operations.

- **Tests**
	- Added comprehensive tests for shutdown functionality in node manager and control plane.
	- Enhanced mock responder to simulate shutdown notifications for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->