### PR TITLE
Faster reconnect on handshake required response

### DIFF
--- a/pkg/transport/nclprotocol/compute/controlplane.go
+++ b/pkg/transport/nclprotocol/compute/controlplane.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -104,6 +105,10 @@ func (cp *ControlPlane) run(ctx context.Context) {
 
 		case <-heartbeat.C:
 			if err := cp.heartbeat(ctx); err != nil {
+				if strings.Contains(err.Error(), "handshake required") {
+					cp.healthTracker.HandshakeRequired()
+					return
+				}
 				log.Error().Err(err).Msg("Failed to send heartbeat")
 			}
 		case <-nodeInfo.C:

--- a/pkg/transport/nclprotocol/compute/manager.go
+++ b/pkg/transport/nclprotocol/compute/manager.go
@@ -421,6 +421,7 @@ func (cm *ConnectionManager) checkConnectionHealth() {
 	// Consider connection unhealthy if:
 	// 1. No heartbeat succeeded within HeartbeatMissFactor intervals
 	// 2. NATS connection is closed/draining
+	// 3. Health tracker reports a handshake required
 	now := cm.config.Clock.Now()
 	heartbeatDeadline := now.Add(-time.Duration(cm.config.HeartbeatMissFactor) * cm.config.HeartbeatInterval)
 
@@ -432,6 +433,9 @@ func (cm *ConnectionManager) checkConnectionHealth() {
 		unhealthy = true
 	} else if cm.natsConn.IsClosed() {
 		reason = "NATS connection closed"
+		unhealthy = true
+	} else if cm.healthTracker.IsHandshakeRequired() {
+		reason = "handshake required"
 		unhealthy = true
 	}
 

--- a/pkg/transport/nclprotocol/types.go
+++ b/pkg/transport/nclprotocol/types.go
@@ -50,6 +50,7 @@ type ConnectionHealth struct {
 	ConsecutiveFailures     int
 	LastError               error
 	ConnectedSince          time.Time
+	HandshakeRequired       bool
 }
 
 const (


### PR DESCRIPTION
When orchestrator restarts, compute nodes wait for 5 failed heartbeats (~75s) before attempting to reconnect, even though orchestrator immediately returns "Handshake required" errors.

Modify compute nodes to detect this specific error and trigger immediate reconnection, rather than waiting for the heartbeat failure threshold.