### PR TITLE
Preserve LastComputeSeqNum if 0

### DIFF
--- a/pkg/orchestrator/nodes/manager.go
+++ b/pkg/orchestrator/nodes/manager.go
@@ -850,7 +850,13 @@ func (n *nodesManager) resolveStartingOrchestratorSeqNum(
 // We should implement proper comparison logic to ensure sequence numbers only advance forward.
 func (n *nodesManager) updateSequenceNumbers(state *models.ConnectionState, orchestratorSeq, computeSeq uint64) {
 	state.LastOrchestratorSeqNum = orchestratorSeq
-	state.LastComputeSeqNum = computeSeq
+
+	// Only update LastComputeSeqNum if greater than 0, as zero can indicate
+	// either no messages processed yet or a connection that has just been
+	// established. This preserves the existing sequence number in those cases.
+	if computeSeq > 0 {
+		state.LastComputeSeqNum = computeSeq
+	}
 }
 
 // enrichState adds live tracking data to a node state.


### PR DESCRIPTION
Only update LastComputeSeqNum if greater than 0, as zero can indicate
either no messages processed yet or a connection that has just been
established. This preserves the existing sequence number in those cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced node management with improved health monitoring and state persistence.
	- Added conditional logic to prevent overwriting sequence numbers with zero.
	- Improved handling of disconnected nodes to retain existing connection states.

- **Bug Fixes**
	- Adjusted control flow and error handling for better robustness in node state updates.

- **Documentation**
	- Added logging statements for improved visibility into state transitions and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->