### PR TITLE
deploy v1.6.0 to demo network

### DIFF
--- a/ops/terraform/prod.tfvars
+++ b/ops/terraform/prod.tfvars
@@ -1,4 +1,4 @@
-bacalhau_version            = "v1.5.1"
+bacalhau_version            = "v1.6.0"
 bacalhau_port               = "1235"
 bacalhau_environment        = "production"
 ipfs_version                = "v0.18.1"

--- a/ops/terraform/remote_files/scripts/install-node.sh
+++ b/ops/terraform/remote_files/scripts/install-node.sh
@@ -87,10 +87,10 @@ function install-healthcheck() {
 
 function install-ipfs() {
   echo "Installing IPFS"
-  wget "https://dist.ipfs.tech/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_linux-amd64.tar.gz"
-  tar -xvzf "go-ipfs_${IPFS_VERSION}_linux-amd64.tar.gz"
+  wget "https://github.com/ipfs/kubo/releases/download/${IPFS_VERSION}/kubo_${IPFS_VERSION}_linux-amd64.tar.gz"
+  tar -xvzf "kubo_${IPFS_VERSION}_linux-amd64.tar.gz"
   # TODO should reset PWD to home dir after each function call
-  pushd go-ipfs
+  pushd kubo
   sudo bash install.sh
   ipfs --version
   popd

--- a/ops/terraform/stage.tfvars
+++ b/ops/terraform/stage.tfvars
@@ -1,4 +1,4 @@
-bacalhau_version            = "v1.5.1"
+bacalhau_version            = "v1.6.0"
 bacalhau_branch             = "" # deploy from a branch instead of the version above
 bacalhau_port               = "1235"
 bacalhau_environment        = "staging"


### PR DESCRIPTION
[dist.ipfs.tech](https://dist.ipfs.tech) is down and had to switch to deploying from github instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `bacalhau_version` to `"v1.6.0"` in production and staging configurations.
	- Enhanced the installation script for IPFS to download from a new source, targeting the Kubo project.

- **Bug Fixes**
	- Addressed versioning issues in the IPFS installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->