### PR TITLE
Add a linter to catch fmt.Print*

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,9 @@ linters-settings:
             desc: "logging is allowed only by zerolog"
   dupl:
     threshold: 100
+  forbidigo:
+    forbid:
+      - 'fmt\.Print.*'  # This will catch Printf, Println, Print
   funlen:
     lines: 100
     statements: 100
@@ -70,6 +73,7 @@ linters:
   - dogsled
   - errcheck
   - copyloopvar
+  - forbidigo
   - funlen
   - gochecknoinits
   - goconst

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 
@@ -97,7 +96,4 @@ func main() {
 	// Wait for the context to be cancelled
 	// either by a signal or by the command completing
 	<-localCtx.Done()
-
-	// Print a newline to ensure the next prompt is on a new line
-	fmt.Println()
 }

--- a/pkg/config/types/gen/generate.go
+++ b/pkg/config/types/gen/generate.go
@@ -16,8 +16,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Println("Please provide the path to the config directory.")
-		os.Exit(1)
+		log.Fatal("Please provide the path to the config directory")
 	}
 	pkgPath := os.Args[1]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new linter for improved logging practices.
  
- **Bug Fixes**
	- Removed unnecessary `fmt` package usage to streamline output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->