### PR TITLE
smaller job defaults requirements

### DIFF
--- a/cmd/cli/node/columns.go
+++ b/cmd/cli/node/columns.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/c2h5oh/datasize"
+	"github.com/dustin/go-humanize"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/samber/lo"
@@ -97,13 +97,17 @@ var toggleColumns = map[string][]output.TableColumn[*models.NodeState]{
 		{
 			ColumnConfig: table.ColumnConfig{Name: "memory", WidthMax: len("10.0 GB / "), WidthMaxEnforcer: text.WrapSoft},
 			Value: ifComputeNode(func(cni models.ComputeNodeInfo) string {
-				return fmt.Sprintf("%s / %s", datasize.ByteSize(cni.AvailableCapacity.Memory).HR(), datasize.ByteSize(cni.MaxCapacity.Memory).HR())
+				return fmt.Sprintf("%s / %s",
+					humanize.Bytes(cni.AvailableCapacity.Memory),
+					humanize.Bytes(cni.MaxCapacity.Memory))
 			}),
 		},
 		{
 			ColumnConfig: table.ColumnConfig{Name: "disk", WidthMax: len("100.0 GB / "), WidthMaxEnforcer: text.WrapSoft},
 			Value: ifComputeNode(func(cni models.ComputeNodeInfo) string {
-				return fmt.Sprintf("%s / %s", datasize.ByteSize(cni.AvailableCapacity.Disk).HR(), datasize.ByteSize(cni.MaxCapacity.Disk).HR())
+				return fmt.Sprintf("%s / %s",
+					humanize.Bytes(cni.AvailableCapacity.Disk),
+					humanize.Bytes(cni.MaxCapacity.Disk))
 			}),
 		},
 		{

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -51,9 +51,9 @@ var Default = types.Bacalhau{
 			Interval:           15 * types.Second,
 		},
 		AllocatedCapacity: types.ResourceScaler{
-			CPU:    "70%",
-			Memory: "70%",
-			Disk:   "70%",
+			CPU:    "80%",
+			Memory: "80%",
+			Disk:   "80%",
 			GPU:    "100%",
 		},
 	},
@@ -63,7 +63,7 @@ var Default = types.Bacalhau{
 			Task: types.BatchTaskDefaultConfig{
 				Resources: types.ResourcesConfig{
 					CPU:    "500m",
-					Memory: "1Gb",
+					Memory: "512Mb",
 				},
 			},
 		},
@@ -72,7 +72,7 @@ var Default = types.Bacalhau{
 			Task: types.BatchTaskDefaultConfig{
 				Resources: types.ResourcesConfig{
 					CPU:    "500m",
-					Memory: "1Gb",
+					Memory: "512Mb",
 				},
 			},
 		},
@@ -81,7 +81,7 @@ var Default = types.Bacalhau{
 			Task: types.LongRunningTaskDefaultConfig{
 				Resources: types.ResourcesConfig{
 					CPU:    "500m",
-					Memory: "1Gb",
+					Memory: "512Mb",
 				},
 			},
 		},
@@ -90,7 +90,7 @@ var Default = types.Bacalhau{
 			Task: types.LongRunningTaskDefaultConfig{
 				Resources: types.ResourcesConfig{
 					CPU:    "500m",
-					Memory: "1Gb",
+					Memory: "512Mb",
 				},
 			},
 		},

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -1821,7 +1821,6 @@ const docTemplate = `{
                     }
                 },
                 "NodeID": {
-                    "description": "TODO replace all access on this field with the ` + "`" + `ID()` + "`" + ` method",
                     "type": "string"
                 },
                 "NodeType": {

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -1817,7 +1817,6 @@
                     }
                 },
                 "NodeID": {
-                    "description": "TODO replace all access on this field with the `ID()` method",
                     "type": "string"
                 },
                 "NodeType": {

--- a/webui/lib/api/schema/swagger.json
+++ b/webui/lib/api/schema/swagger.json
@@ -1817,7 +1817,6 @@
                     }
                 },
                 "NodeID": {
-                    "description": "TODO replace all access on this field with the `ID()` method",
                     "type": "string"
                 },
                 "NodeType": {


### PR DESCRIPTION
Smaller job resource requirements so that jobs can run on smaller EC2 instances by default. 

This PR also introduce the following changes:
- Increase allocated capacity from 70% to 80%
- Unify the library used for printing human readable bytes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced memory and disk capacity outputs with improved human-readable formatting.
	- Updated default configuration settings for resource allocation in Bacalhau nodes.
	- Introduced new API endpoints for orchestrator nodes and version retrieval.

- **Bug Fixes**
	- Adjusted memory allocation settings for batch, daemon, and service jobs to optimize resource management.
	- Improved error handling and response schemas for various API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->