### PR TITLE
Add Partition Support in Job Orchestrator

### DIFF
--- a/pkg/models/execution.go
+++ b/pkg/models/execution.go
@@ -125,6 +125,10 @@ type Execution struct {
 	// that can be rescheduled in the future
 	FollowupEvalID string `json:"FollowupEvalID"`
 
+	// PartitionIndex is the index of this execution in the job's total partitions (0-based)
+	// Only relevant when Job.Count > 1
+	PartitionIndex int `json:"PartitionIndex,omitempty"`
+
 	// Revision is increment each time the execution is updated.
 	Revision uint64 `json:"Revision"`
 

--- a/pkg/orchestrator/scheduler/daemon_job_test.go
+++ b/pkg/orchestrator/scheduler/daemon_job_test.go
@@ -38,10 +38,13 @@ func (s *DaemonJobSchedulerTestSuite) TestProcess_ShouldCreateNewExecutions() {
 	s.mockMatchingNodes(scenario, "node0", "node1", "node2")
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
-		Evaluation:               scenario.evaluation,
-		JobState:                 models.JobStateTypeRunning,
-		NewExecutionDesiredState: models.ExecutionDesiredStateRunning,
-		NewExecutionsNodes:       []string{"node0", "node1", "node2"},
+		Evaluation: scenario.evaluation,
+		JobState:   models.JobStateTypeRunning,
+		NewExecutions: []*models.Execution{
+			{NodeID: "node0", DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStateRunning)},
+			{NodeID: "node1", DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStateRunning)},
+			{NodeID: "node2", DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStateRunning)},
+		},
 	})
 	s.planner.EXPECT().Process(gomock.Any(), matcher).Times(1)
 	s.Require().NoError(s.scheduler.Process(context.Background(), scenario.evaluation))
@@ -79,8 +82,7 @@ func (s *DaemonJobSchedulerTestSuite) TestProcess_ShouldMarkLostExecutionsOnUnhe
 	s.mockMatchingNodes(scenario, "node1")
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
-		Evaluation:         scenario.evaluation,
-		NewExecutionsNodes: []string{},
+		Evaluation: scenario.evaluation,
 		StoppedExecutions: []string{
 			scenario.executions[0].ID,
 		},

--- a/pkg/orchestrator/scheduler/ops_job_test.go
+++ b/pkg/orchestrator/scheduler/ops_job_test.go
@@ -43,13 +43,12 @@ func (s *OpsJobSchedulerTestSuite) TestProcess_ShouldCreateNewExecutions() {
 	s.mockMatchingNodes(scenario, "node0", "node1", "node2")
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
-		Evaluation:               scenario.evaluation,
-		JobState:                 models.JobStateTypeRunning,
-		NewExecutionDesiredState: models.ExecutionDesiredStateRunning,
-		NewExecutionsNodes: []string{
-			"node0",
-			"node1",
-			"node2",
+		Evaluation: scenario.evaluation,
+		JobState:   models.JobStateTypeRunning,
+		NewExecutions: []*models.Execution{
+			{NodeID: "node0", DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStateRunning)},
+			{NodeID: "node1", DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStateRunning)},
+			{NodeID: "node2", DesiredState: models.NewExecutionDesiredState(models.ExecutionDesiredStateRunning)},
 		},
 	})
 	s.planner.EXPECT().Process(gomock.Any(), matcher).Times(1)
@@ -84,8 +83,7 @@ func (s *OpsJobSchedulerTestSuite) TestProcess_ShouldMarkLostExecutionsOnUnhealt
 	s.mockAllNodes("node1")
 
 	matcher := NewPlanMatcher(s.T(), PlanMatcherParams{
-		Evaluation:         scenario.evaluation,
-		NewExecutionsNodes: []string{},
+		Evaluation: scenario.evaluation,
 		StoppedExecutions: []string{
 			scenario.executions[0].ID,
 		},

--- a/pkg/orchestrator/scheduler/types.go
+++ b/pkg/orchestrator/scheduler/types.go
@@ -46,12 +46,6 @@ func (set execSet) String() string {
 	return start + strings.Join(s, ", ") + "]"
 }
 
-// has returns true if the set contains the given execution id
-func (set execSet) has(key string) bool {
-	_, ok := set[key]
-	return ok
-}
-
 // keys returns the keys of the set as a slice
 //
 //nolint:unused
@@ -97,9 +91,16 @@ func (set execSet) filterByState(state models.ExecutionStateType) execSet {
 	return filtered
 }
 
-// filterRunning filters out non-running executions.
-func (set execSet) filterRunning() execSet {
-	return set.filterByState(models.ExecutionStateBidAccepted)
+// groupByState groups executions by their state
+func (set execSet) groupByState() map[models.ExecutionStateType]execSet {
+	grouped := make(map[models.ExecutionStateType]execSet)
+	for _, exec := range set {
+		if _, ok := grouped[exec.ComputeState.StateType]; !ok {
+			grouped[exec.ComputeState.StateType] = make(execSet)
+		}
+		grouped[exec.ComputeState.StateType][exec.ID] = exec
+	}
+	return grouped
 }
 
 // filterFailed filters out non-failed executions.
@@ -107,20 +108,9 @@ func (set execSet) filterFailed() execSet {
 	return set.filterByState(models.ExecutionStateFailed)
 }
 
-// filterOverSubscriptions partitions executions based on if they are more than the desired count.
-func (set execSet) filterByOverSubscriptions(desiredCount int) (remaining execSet, overSubscriptions execSet) {
-	remaining = make(execSet)
-	overSubscriptions = make(execSet)
-	count := 0
-	for _, exec := range set.ordered() {
-		if count >= desiredCount {
-			overSubscriptions[exec.ID] = exec
-		} else {
-			remaining[exec.ID] = exec
-		}
-		count++
-	}
-	return remaining, overSubscriptions
+// filterCompleted filters out non-completed executions
+func (set execSet) filterCompleted() execSet {
+	return set.filterByState(models.ExecutionStateCompleted)
 }
 
 // filterByNodeHealth partitions executions based on their node's health status.
@@ -152,60 +142,140 @@ func (set execSet) filterByExecutionTimeout(expirationTime time.Time) (remaining
 	return remaining, timedOut
 }
 
+// groupByPartition groups executions by their partition index, allowing operations
+// to be performed independently on each partition's set of executions. This is crucial
+// for maintaining partition isolation and ensuring correct scheduling behavior.
+func (set execSet) groupByPartition() map[int]execSet {
+	grouped := make(map[int]execSet)
+	for _, exec := range set {
+		if _, ok := grouped[exec.PartitionIndex]; !ok {
+			grouped[exec.PartitionIndex] = make(execSet)
+		}
+		grouped[exec.PartitionIndex][exec.ID] = exec
+	}
+	return grouped
+}
+
+// completedPartitions returns a map of partition indices that have successfully completed.
+// A partition is considered complete when at least one of its executions has reached
+// the Completed state. This is used primarily for batch jobs to track overall progress.
+func (set execSet) completedPartitions() map[int]bool {
+	completed := make(map[int]bool)
+	for _, exec := range set {
+		if exec.ComputeState.StateType == models.ExecutionStateCompleted {
+			completed[exec.PartitionIndex] = true
+		}
+	}
+	return completed
+}
+
+// usedPartitions returns map of partition indices that have active (non-discarded) executions.
+// An execution is considered "used" if it is either running or completed successfully.
+// Failed, cancelled, or rejected executions are discarded and their partitions become
+// available for retry. This is crucial for the retry mechanism to work correctly.
+func (set execSet) usedPartitions() map[int]bool {
+	used := make(map[int]bool)
+	for _, exec := range set {
+		if !exec.IsDiscarded() {
+			used[exec.PartitionIndex] = true
+		}
+	}
+	return used
+}
+
+// remainingPartitions returns slice of partition indices that need executions.
+// A partition needs an execution if it has no active or completed executions.
+// This happens either when:
+// 1. The partition has never been assigned an execution
+// 2. All previous executions for this partition have failed/been discarded
+// The returned indices are used to schedule new executions for retry or initial scheduling.
+func (set execSet) remainingPartitions(totalPartitions int) []int {
+	used := set.usedPartitions()
+	available := make([]int, 0, totalPartitions)
+	for i := 0; i < totalPartitions; i++ {
+		if !used[i] {
+			available = append(available, i)
+		}
+	}
+	return available
+}
+
 // executionsByApprovalStatus represents the different sets of executions based on their approval status.
 type executionsByApprovalStatus struct {
-	running   execSet
 	toApprove execSet
 	toReject  execSet
-	pending   execSet
+	toCancel  execSet
 }
 
-// activeCount returns the number of active executions, excluding rejected ones.
-func (e executionsByApprovalStatus) activeCount() int {
-	return len(e.running) + len(e.toApprove) + len(e.pending)
-}
+// getApprovalStatuses evaluates executions for a single partition and determines which
+// should be approved, rejected, or cancelled. The rules are:
+// - If any execution is completed, all other executions are rejected/cancelled
+// - If any execution is running (BidAccepted), keep the oldest and cancel others
+// - Otherwise approve the oldest AskForBidAccepted execution and reject others
+// This ensures exactly one active execution per partition at any time.
+func (set execSet) getApprovalStatuses() executionsByApprovalStatus {
+	result := executionsByApprovalStatus{
+		toApprove: make(execSet),
+		toReject:  make(execSet),
+		toCancel:  make(execSet),
+	}
 
-// filterByApprovalStatus partitions executions based on their approval status.
-func (set execSet) filterByApprovalStatus(desiredCount int) executionsByApprovalStatus {
-	nonTermExecs := set.filterNonTerminal()
-	running := nonTermExecs.filterRunning()
-	toApprove := make(execSet)
-	toReject := make(execSet)
-	pending := make(execSet)
+	// If partition has a completed execution, reject/cancel all non-terminal
+	if len(set.filterCompleted()) > 0 {
+		for _, exec := range set {
+			if exec.ComputeState.StateType == models.ExecutionStateAskForBidAccepted {
+				result.toReject[exec.ID] = exec
+			} else if !exec.IsTerminalState() {
+				result.toCancel[exec.ID] = exec
+			}
+		}
+		return result
+	}
 
 	//TODO: we are approving the oldest executions first, we should probably
 	// approve the ones with highest rank first
-	orderedExecs := nonTermExecs.ordered()
+	states := set.groupByState()
+	orderedExecs := set.ordered()
 
-	// Approve/Reject nodes
-	for _, exec := range orderedExecs {
-		// nothing left to approve
-		if (len(running) + len(toApprove)) >= desiredCount {
-			break
+	// If we have running executions, keep oldest and cancel/reject others
+	if len(states[models.ExecutionStateBidAccepted]) > 0 {
+		var foundFirst bool
+		for _, exec := range orderedExecs {
+			switch exec.ComputeState.StateType {
+			case models.ExecutionStateBidAccepted:
+				if !foundFirst {
+					foundFirst = true // keep oldest running
+				} else {
+					result.toCancel[exec.ID] = exec
+				}
+			case models.ExecutionStateAskForBidAccepted:
+				result.toReject[exec.ID] = exec
+			default:
+				if !exec.IsTerminalState() {
+					result.toCancel[exec.ID] = exec
+				}
+			}
 		}
-		if exec.ComputeState.StateType == models.ExecutionStateAskForBidAccepted {
-			toApprove[exec.ID] = exec
+		return result
+	}
+
+	// No running executions - approve oldest eligible and reject other eligible ones
+	var approved bool
+	for _, exec := range orderedExecs {
+		switch exec.ComputeState.StateType {
+		case models.ExecutionStateAskForBidAccepted:
+			if !approved {
+				result.toApprove[exec.ID] = exec
+				approved = true
+			} else {
+				result.toReject[exec.ID] = exec
+			}
+		default:
+			// Do nothing for other states - they're not ready for approval/rejection
 		}
 	}
 
-	// reject the rest
-	totalRunningCount := len(running) + len(toApprove)
-	for _, exec := range orderedExecs {
-		if running.has(exec.ID) || toApprove.has(exec.ID) {
-			continue
-		}
-		if totalRunningCount >= desiredCount {
-			toReject[exec.ID] = exec
-		} else {
-			pending[exec.ID] = exec
-		}
-	}
-	return executionsByApprovalStatus{
-		running:   running,
-		toApprove: toApprove,
-		toReject:  toReject,
-		pending:   pending,
-	}
+	return result
 }
 
 // markStopped
@@ -232,18 +302,4 @@ func (set execSet) union(other execSet) execSet {
 		union[exec.ID] = exec
 	}
 	return union
-}
-
-// countByState counts the number of executions in each state.
-func (set execSet) countByState() map[models.ExecutionStateType]int {
-	counts := map[models.ExecutionStateType]int{}
-	for _, exec := range set {
-		counts[exec.ComputeState.StateType]++
-	}
-	return counts
-}
-
-// countCompleted counts the number of completed executions.
-func (set execSet) countCompleted() int {
-	return set.countByState()[models.ExecutionStateCompleted]
 }


### PR DESCRIPTION
This PR introduces the foundation for partitioned execution support in bacalhau's orchestrator, allowing the scheduler to track and maintain partition assignments for parallel executions. This is the first step towards full partitioned execution support, focusing only on the orchestrator's ability to track partitions.

## Changes

- Added `PartitionIndex` field to `Execution` model to track which partition (0 to job.Count-1) an execution belongs to
- Modified scheduler to:
  - Assign unique partition indices during scheduling
  - Maintain partition assignments across retries/rescheduling
  - Handle approval/rejection independently per partition
- No changes to compute execution or engine - this purely adds orchestrator-side tracking

## Feature Details

When a job specifies Count > 1, the scheduler will now:
1. Create N partitions (0 to N-1) based on job.Count 
2. Track which execution belongs to which partition
3. Ensure exactly one active execution per partition
4. Preserve partition assignments during rescheduling/retries


## Future Work
Next steps will include:

2. Exposing partition information to compute nodes via environment variables
3. Modifying engine to populate partition environment

## Testing
Added comprehensive test coverage for partition tracking:

1. Verified partition assignment and maintenance
2. Tested per-partition scheduling decisions
3. Validated failure recovery with partition preservation
4. Confirmed batch vs service job partition handling


The PR sets up the foundation for partition-aware execution, which will be built upon in future PRs that modify the compute side.