### PR TITLE
Expose execution to storage providers

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -67,7 +67,8 @@ func prepareInputVolumes(
 	execution *models.Execution) (
 	[]storage.PreparedStorage, func(context.Context) error, error,
 ) {
-	inputVolumes, err := storage.ParallelPrepareStorage(ctx, storageProvider, storageDirectory, execution)
+	inputVolumes, err := storage.ParallelPrepareStorage(
+		ctx, storageProvider, storageDirectory, execution, execution.Job.Task().InputSources...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -63,10 +63,11 @@ func NewBaseExecutor(params BaseExecutorParams) *BaseExecutor {
 func prepareInputVolumes(
 	ctx context.Context,
 	storageProvider storage.StorageProvider,
-	storageDirectory string, inputSources ...*models.InputSource) (
+	storageDirectory string,
+	execution *models.Execution) (
 	[]storage.PreparedStorage, func(context.Context) error, error,
 ) {
-	inputVolumes, err := storage.ParallelPrepareStorage(ctx, storageProvider, storageDirectory, inputSources...)
+	inputVolumes, err := storage.ParallelPrepareStorage(ctx, storageProvider, storageDirectory, execution)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -78,15 +79,19 @@ func prepareInputVolumes(
 func prepareWasmVolumes(
 	ctx context.Context,
 	storageProvider storage.StorageProvider,
-	storageDirectory string, wasmEngine wasmmodels.EngineSpec) (
+	storageDirectory string,
+	execution *models.Execution,
+	wasmEngine wasmmodels.EngineSpec) (
 	map[string][]storage.PreparedStorage, func(context.Context) error, error,
 ) {
-	importModuleVolumes, err := storage.ParallelPrepareStorage(ctx, storageProvider, storageDirectory, wasmEngine.ImportModules...)
+	importModuleVolumes, err := storage.ParallelPrepareStorage(
+		ctx, storageProvider, storageDirectory, execution, wasmEngine.ImportModules...)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	entryModuleVolumes, err := storage.ParallelPrepareStorage(ctx, storageProvider, storageDirectory, wasmEngine.EntryModule)
+	entryModuleVolumes, err := storage.ParallelPrepareStorage(
+		ctx, storageProvider, storageDirectory, execution, wasmEngine.EntryModule)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,7 +135,7 @@ func PrepareRunArguments(
 ) (*executor.RunCommandRequest, InputCleanupFn, error) {
 	var cleanupFuncs []func(context.Context) error
 
-	inputVolumes, inputCleanup, err := prepareInputVolumes(ctx, storageProvider, storageDirectory, execution.Job.Task().InputSources...)
+	inputVolumes, inputCleanup, err := prepareInputVolumes(ctx, storageProvider, storageDirectory, execution)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -159,7 +164,7 @@ func PrepareRunArguments(
 			return nil, nil, err
 		}
 
-		volumes, wasmCleanup, err := prepareWasmVolumes(ctx, storageProvider, storageDirectory, wasmEngine)
+		volumes, wasmCleanup, err := prepareWasmVolumes(ctx, storageProvider, storageDirectory, execution, wasmEngine)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/downloader/download_test.go
+++ b/pkg/downloader/download_test.go
@@ -139,14 +139,16 @@ func publishToIPFS(ds *DownloaderSuite, dir string) *models.SpecConfig {
 // Publish to S3
 func publishToS3(ds *DownloaderSuite, dir string) *models.SpecConfig {
 	publisherSpec := ds.PreparePublisherSpec(true)
-	storageSpec := ds.PublishResultSilently(publisherSpec, dir)
+	execution := ds.MockExecution(publisherSpec)
+	storageSpec := ds.PublishResultSilently(execution, dir)
 	ds.Require().NoError(ds.s3Signer.Transform(ds.Ctx, &storageSpec))
 	return &storageSpec
 }
 
 func publishToS3Unsigned(ds *DownloaderSuite, dir string) *models.SpecConfig {
 	publisherSpec := ds.PreparePublisherSpec(false)
-	storageSpec := ds.PublishResultSilently(publisherSpec, dir)
+	execution := ds.MockExecution(publisherSpec)
+	storageSpec := ds.PublishResultSilently(execution, dir)
 	return &storageSpec
 }
 

--- a/pkg/executor/wasm/loader_test.go
+++ b/pkg/executor/wasm/loader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/inline"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 	"github.com/bacalhau-project/bacalhau/testdata/wasm/dynamic"
 	"github.com/bacalhau-project/bacalhau/testdata/wasm/easter"
 	"github.com/bacalhau-project/bacalhau/testdata/wasm/noop"
@@ -23,7 +24,7 @@ func prepareModule(t *testing.T, alias string, program []byte) storage.PreparedS
 	store := inline.NewStorage()
 	spec := store.StoreBytes(program)
 	inputSource := models.InputSource{Source: &spec, Alias: alias, Target: "/" + uuid.NewString()}
-	preparedVolume, err := store.PrepareStorage(context.Background(), t.TempDir(), inputSource)
+	preparedVolume, err := store.PrepareStorage(context.Background(), t.TempDir(), mock.Execution(), inputSource)
 	require.NoError(t, err)
 
 	return storage.PreparedStorage{

--- a/pkg/publisher/s3/publisher_test.go
+++ b/pkg/publisher/s3/publisher_test.go
@@ -199,7 +199,8 @@ func (s *PublisherTestSuite) TestPublish() {
 			}
 
 			resultPath := s.PrepareResultsPath()
-			storageSpec, err := s.PublishResult(params, resultPath)
+			execution := s.MockExecution(params)
+			storageSpec, err := s.PublishResult(execution, resultPath)
 
 			if err != nil {
 				var ae smithy.APIError
@@ -224,7 +225,7 @@ func (s *PublisherTestSuite) TestPublish() {
 			s.NotEmptyf(sourceSpec.ChecksumSHA256, "ChecksumSHA256 should not be empty")
 			s.NotEmptyf(sourceSpec.VersionID, "VersionID should not be empty")
 
-			fetchedResults := s.GetResult(&storageSpec)
+			fetchedResults := s.GetResult(execution, &storageSpec)
 			uncompressedResults, err := os.MkdirTemp(s.TempDir, "")
 			s.Require().NoError(err)
 			s.Require().NoError(gzip.Decompress(fetchedResults, uncompressedResults))

--- a/pkg/storage/inline/storage.go
+++ b/pkg/storage/inline/storage.go
@@ -95,8 +95,11 @@ func (*InlineStorage) IsInstalled(context.Context) (bool, error) {
 // PrepareStorage extracts the data from the "data:" URL and writes it to a
 // temporary directory. If the data was a compressed tarball, it decompresses it
 // into a directory structure.
-func (i *InlineStorage) PrepareStorage(_ context.Context, storageDirectory string, spec models.InputSource) (storage.StorageVolume, error) {
-	source, err := DecodeSpec(spec.Source)
+func (i *InlineStorage) PrepareStorage(_ context.Context,
+	storageDirectory string,
+	_ *models.Execution,
+	input models.InputSource) (storage.StorageVolume, error) {
+	source, err := DecodeSpec(input.Source)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -121,7 +124,7 @@ func (i *InlineStorage) PrepareStorage(_ context.Context, storageDirectory strin
 		return storage.StorageVolume{
 			Type:   storage.StorageVolumeConnectorBind,
 			Source: tempdir,
-			Target: spec.Target,
+			Target: input.Target,
 		}, err
 	} else {
 		tempfile, err := os.CreateTemp(tempdir, "file")
@@ -134,7 +137,7 @@ func (i *InlineStorage) PrepareStorage(_ context.Context, storageDirectory strin
 		return storage.StorageVolume{
 			Type:   storage.StorageVolumeConnectorBind,
 			Source: tempfile.Name(),
-			Target: spec.Target,
+			Target: input.Target,
 		}, errors.Join(wErr, cErr)
 	}
 }

--- a/pkg/storage/inline/storage_test.go
+++ b/pkg/storage/inline/storage_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/storage/util"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +32,7 @@ func TestPlaintextInlineStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(len("test")), size)
 
-	root, err := storage.PrepareStorage(context.Background(), t.TempDir(), inputSource)
+	root, err := storage.PrepareStorage(context.Background(), t.TempDir(), mock.Execution(), inputSource)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(root.Source)
@@ -57,7 +59,7 @@ func TestDirectoryInlineStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(len("test")+len("more")), size)
 
-	root, err := storage.PrepareStorage(context.Background(), t.TempDir(), inputSource)
+	root, err := storage.PrepareStorage(context.Background(), t.TempDir(), mock.Execution(), inputSource)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(root.Source, filepath.Base(tempdir), "file1"))

--- a/pkg/storage/ipfs/storage.go
+++ b/pkg/storage/ipfs/storage.go
@@ -78,8 +78,9 @@ func (s *StorageProvider) GetVolumeSize(ctx context.Context, volume models.Input
 func (s *StorageProvider) PrepareStorage(
 	ctx context.Context,
 	storageDirectory string,
-	storageSpec models.InputSource) (storage.StorageVolume, error) {
-	source, err := DecodeSpec(storageSpec.Source)
+	_ *models.Execution,
+	input models.InputSource) (storage.StorageVolume, error) {
+	source, err := DecodeSpec(input.Source)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -93,9 +94,9 @@ func (s *StorageProvider) PrepareStorage(
 	}
 
 	var volume storage.StorageVolume
-	volume, err = s.getFileFromIPFS(ctx, source.CID, storageDirectory, storageSpec.Target)
+	volume, err = s.getFileFromIPFS(ctx, source.CID, storageDirectory, input.Target)
 	if err != nil {
-		return storage.StorageVolume{}, fmt.Errorf("failed to copy %s to volume: %w", storageSpec.Target, err)
+		return storage.StorageVolume{}, fmt.Errorf("failed to copy %s to volume: %w", input.Target, err)
 	}
 
 	return volume, nil

--- a/pkg/storage/ipfs/storage.go
+++ b/pkg/storage/ipfs/storage.go
@@ -79,8 +79,8 @@ func (s *StorageProvider) PrepareStorage(
 	ctx context.Context,
 	storageDirectory string,
 	_ *models.Execution,
-	input models.InputSource) (storage.StorageVolume, error) {
-	source, err := DecodeSpec(input.Source)
+	storageSpec models.InputSource) (storage.StorageVolume, error) {
+	source, err := DecodeSpec(storageSpec.Source)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -94,9 +94,9 @@ func (s *StorageProvider) PrepareStorage(
 	}
 
 	var volume storage.StorageVolume
-	volume, err = s.getFileFromIPFS(ctx, source.CID, storageDirectory, input.Target)
+	volume, err = s.getFileFromIPFS(ctx, source.CID, storageDirectory, storageSpec.Target)
 	if err != nil {
-		return storage.StorageVolume{}, fmt.Errorf("failed to copy %s to volume: %w", input.Target, err)
+		return storage.StorageVolume{}, fmt.Errorf("failed to copy %s to volume: %w", storageSpec.Target, err)
 	}
 
 	return volume, nil

--- a/pkg/storage/ipfs/storage_test.go
+++ b/pkg/storage/ipfs/storage_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 	testutils "github.com/bacalhau-project/bacalhau/pkg/test/utils"
 )
 
@@ -79,7 +80,7 @@ func (s *StorageSuite) TestPrepareStorageRespectsTimeouts() {
 			cid, err := ipfs.AddTextToNodes(ctx, []byte("testString"), *s.ipfsClient)
 			s.Require().NoError(err)
 
-			_, err = s.storage.PrepareStorage(ctx, s.T().TempDir(), models.InputSource{
+			_, err = s.storage.PrepareStorage(ctx, s.T().TempDir(), mock.Execution(), models.InputSource{
 				Source: &models.SpecConfig{
 					Type: models.StorageSourceIPFS,
 					Params: Source{

--- a/pkg/storage/local_directory/storage.go
+++ b/pkg/storage/local_directory/storage.go
@@ -68,9 +68,10 @@ func (driver *StorageProvider) GetVolumeSize(_ context.Context, volume models.In
 func (driver *StorageProvider) PrepareStorage(
 	_ context.Context,
 	_ string,
-	storageSpec models.InputSource,
+	_ *models.Execution,
+	input models.InputSource,
 ) (storage.StorageVolume, error) {
-	source, err := DecodeSpec(storageSpec.Source)
+	source, err := DecodeSpec(input.Source)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -81,7 +82,7 @@ func (driver *StorageProvider) PrepareStorage(
 		Type:     storage.StorageVolumeConnectorBind,
 		ReadOnly: !source.ReadWrite,
 		Source:   source.SourcePath,
-		Target:   storageSpec.Target,
+		Target:   input.Target,
 	}, nil
 }
 

--- a/pkg/storage/local_directory/storage_test.go
+++ b/pkg/storage/local_directory/storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 )
 
 type LocalDirectorySuite struct {
@@ -236,7 +237,7 @@ func (s *LocalDirectorySuite) TestPrepareStorage() {
 				path += ":rw"
 			}
 			spec := s.prepareStorageSpec(path)
-			volume, err := storageProvider.PrepareStorage(context.Background(), s.T().TempDir(), spec)
+			volume, err := storageProvider.PrepareStorage(context.Background(), s.T().TempDir(), mock.Execution(), spec)
 			require.NoError(s.T(), err)
 			require.Equal(s.T(), volume.Source, folderPath)
 			require.Equal(s.T(), volume.Target, spec.Target)

--- a/pkg/storage/noop/noop.go
+++ b/pkg/storage/noop/noop.go
@@ -80,10 +80,11 @@ func (s *NoopStorage) GetVolumeSize(ctx context.Context, volume models.InputSour
 func (s *NoopStorage) PrepareStorage(
 	ctx context.Context,
 	storageDir string,
-	storageSpec models.InputSource) (storage.StorageVolume, error) {
+	execution *models.Execution,
+	input models.InputSource) (storage.StorageVolume, error) {
 	if s.Config.ExternalHooks.PrepareStorage != nil {
 		handler := s.Config.ExternalHooks.PrepareStorage
-		return handler(ctx, storageDir, storageSpec)
+		return handler(ctx, storageDir, input)
 	}
 	return storage.StorageVolume{
 		Type:   storage.StorageVolumeConnectorBind,

--- a/pkg/storage/parallel.go
+++ b/pkg/storage/parallel.go
@@ -45,9 +45,6 @@ func ParallelPrepareStorage(
 		return nil
 	}
 
-	if len(inputs) == 0 {
-		inputs = execution.Job.Task().InputSources
-	}
 	out := make([]PreparedStorage, len(inputs))
 	for i, spec := range inputs {
 		// NB: https://golang.org/doc/faq#closures_and_goroutines

--- a/pkg/storage/parallel.go
+++ b/pkg/storage/parallel.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 
-	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/rs/zerolog/log"
 	"go.ptx.dk/multierrgroup"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
 )
 
 type PreparedStorage struct {
@@ -21,7 +22,8 @@ func ParallelPrepareStorage(
 	ctx context.Context,
 	provider StorageProvider,
 	storageDirectory string,
-	specs ...*models.InputSource,
+	execution *models.Execution,
+	inputs ...*models.InputSource,
 ) ([]PreparedStorage, error) {
 	waitgroup := multierrgroup.Group{}
 
@@ -31,7 +33,7 @@ func ParallelPrepareStorage(
 			return err
 		}
 
-		volumeMount, err := storageProvider.PrepareStorage(ctx, storageDirectory, input)
+		volumeMount, err := storageProvider.PrepareStorage(ctx, storageDirectory, execution, input)
 		if err != nil {
 			return err
 		}
@@ -43,8 +45,11 @@ func ParallelPrepareStorage(
 		return nil
 	}
 
-	out := make([]PreparedStorage, len(specs))
-	for i, spec := range specs {
+	if len(inputs) == 0 {
+		inputs = execution.Job.Task().InputSources
+	}
+	out := make([]PreparedStorage, len(inputs))
+	for i, spec := range inputs {
 		// NB: https://golang.org/doc/faq#closures_and_goroutines
 		index := i
 		input := spec

--- a/pkg/storage/parallel_test.go
+++ b/pkg/storage/parallel_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 	testutils "github.com/bacalhau-project/bacalhau/pkg/test/utils"
 )
 
@@ -61,7 +62,7 @@ func (s *ParallelStorageSuite) TestIPFSCleanup() {
 		},
 		Target: "/inputs/test.txt",
 	}
-	volumes, err := storage.ParallelPrepareStorage(ctx, s.provider, s.T().TempDir(), artifact)
+	volumes, err := storage.ParallelPrepareStorage(ctx, s.provider, s.T().TempDir(), mock.Execution(), artifact)
 	require.NoError(s.T(), err)
 
 	// Make a list of which files we expect to find written to local disk and check they are
@@ -98,7 +99,7 @@ func (s *ParallelStorageSuite) TestURLCleanup() {
 		Target: "/inputs/test.txt",
 	}
 
-	volumes, err := storage.ParallelPrepareStorage(ctx, s.provider, s.T().TempDir(), artifact)
+	volumes, err := storage.ParallelPrepareStorage(ctx, s.provider, s.T().TempDir(), mock.Execution(), artifact)
 	require.NoError(s.T(), err)
 
 	// Make a list of which files we expect to find written to local disk and check they are

--- a/pkg/storage/s3/storage.go
+++ b/pkg/storage/s3/storage.go
@@ -107,8 +107,9 @@ func (s *StorageProvider) GetVolumeSize(ctx context.Context, volume models.Input
 func (s *StorageProvider) PrepareStorage(
 	ctx context.Context,
 	storageDirectory string,
-	storageSpec models.InputSource) (storage.StorageVolume, error) {
-	source, err := s3helper.DecodeSourceSpec(storageSpec.Source)
+	execution *models.Execution,
+	input models.InputSource) (storage.StorageVolume, error) {
+	source, err := s3helper.DecodeSourceSpec(input.Source)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -141,7 +142,7 @@ func (s *StorageProvider) PrepareStorage(
 	volume := storage.StorageVolume{
 		Type:   storage.StorageVolumeConnectorBind,
 		Source: outputDir,
-		Target: storageSpec.Target,
+		Target: input.Target,
 	}
 
 	return volume, nil

--- a/pkg/storage/s3/storage_test.go
+++ b/pkg/storage/s3/storage_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	s3helper "github.com/bacalhau-project/bacalhau/pkg/s3"
 	s3test "github.com/bacalhau-project/bacalhau/pkg/s3/test"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -235,7 +236,7 @@ func (s *StorageTestSuite) TestStorage() {
 			s.Require().NoError(err)
 			s.Equal(uint64(len(tc.expectedOutputs)*4), size) // each file is 4 bytes long
 
-			volume, err := s.Storage.PrepareStorage(ctx, s.T().TempDir(), storageSpec)
+			volume, err := s.Storage.PrepareStorage(ctx, s.T().TempDir(), mock.Execution(), storageSpec)
 			s.Require().NoError(err)
 
 			// check that the files are there
@@ -273,7 +274,7 @@ func (s *StorageTestSuite) TestNotFound() {
 	_, err := s.Storage.GetVolumeSize(ctx, storageSpec)
 	s.Require().Error(err)
 
-	_, err = s.Storage.PrepareStorage(ctx, s.T().TempDir(), storageSpec)
+	_, err = s.Storage.PrepareStorage(ctx, s.T().TempDir(), mock.Execution(), storageSpec)
 	s.Require().Error(err)
 }
 

--- a/pkg/storage/tracing/tracing.go
+++ b/pkg/storage/tracing/tracing.go
@@ -48,21 +48,22 @@ func (t *tracingStorage) GetVolumeSize(ctx context.Context, spec models.InputSou
 func (t *tracingStorage) PrepareStorage(
 	ctx context.Context,
 	storageDirectory string,
-	spec models.InputSource) (storage.StorageVolume, error) {
+	execution *models.Execution,
+	input models.InputSource) (storage.StorageVolume, error) {
 	ctx, span := telemetry.NewSpan(ctx, telemetry.GetTracer(), fmt.Sprintf("%s.PrepareStorage", t.name))
 	defer span.End()
 
-	stopwatch := telemetry.Timer(ctx, jobStoragePrepareDurationMilliseconds, spec.Source.MetricAttributes()...)
+	stopwatch := telemetry.Timer(ctx, jobStoragePrepareDurationMilliseconds, input.Source.MetricAttributes()...)
 	defer func() {
 		dur := stopwatch()
 		log.Ctx(ctx).Debug().
 			Dur("Duration", dur).
-			Str("Alias", spec.Alias).
+			Str("Alias", input.Alias).
 			Str("Dir", storageDirectory).
 			Msg("storage prepared")
 	}()
 
-	return t.delegate.PrepareStorage(ctx, storageDirectory, spec)
+	return t.delegate.PrepareStorage(ctx, storageDirectory, execution, input)
 }
 
 func (t *tracingStorage) CleanupStorage(ctx context.Context, spec models.InputSource, volume storage.StorageVolume) error {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -20,7 +20,10 @@ type Storage interface {
 
 	// PrepareStorage is provided an output directory, and an InputSource and
 	// is expected to retrieve the InputSource into the output directory.
-	PrepareStorage(context.Context, string, models.InputSource) (StorageVolume, error)
+	PrepareStorage(ctx context.Context,
+		storageDirectory string,
+		execution *models.Execution,
+		storageSpec models.InputSource) (StorageVolume, error)
 
 	CleanupStorage(context.Context, models.InputSource, StorageVolume) error
 

--- a/pkg/storage/url/urldownload/storage.go
+++ b/pkg/storage/url/urldownload/storage.go
@@ -120,8 +120,9 @@ func (sp *StorageProvider) GetVolumeSize(ctx context.Context, storageSpec models
 func (sp *StorageProvider) PrepareStorage(
 	ctx context.Context,
 	storageDirectory string,
-	storageSpec models.InputSource) (storage.StorageVolume, error) {
-	source, err := DecodeSpec(storageSpec.Source)
+	execution *models.Execution,
+	input models.InputSource) (storage.StorageVolume, error) {
+	source, err := DecodeSpec(input.Source)
 	if err != nil {
 		return storage.StorageVolume{}, err
 	}
@@ -197,7 +198,7 @@ func (sp *StorageProvider) PrepareStorage(
 		return storage.StorageVolume{}, fmt.Errorf("failed to sync file %s: %w", filePath, err)
 	}
 
-	targetPath := filepath.Join(storageSpec.Target, fileName)
+	targetPath := filepath.Join(input.Target, fileName)
 
 	log.Ctx(ctx).Debug().
 		Stringer("url", u).

--- a/pkg/storage/url/urldownload/storage_test.go
+++ b/pkg/storage/url/urldownload/storage_test.go
@@ -18,6 +18,7 @@ import (
 	legacy_types "github.com/bacalhau-project/bacalhau/pkg/config_legacy/types"
 	"github.com/bacalhau-project/bacalhau/pkg/logger"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 )
 
 // Define the suite, and absorb the built-in basic suite
@@ -320,7 +321,7 @@ func (s *StorageSuite) TestPrepareStorageURL() {
 				Target: "/inputs",
 			}
 
-			vol, err := subject.PrepareStorage(context.Background(), s.T().TempDir(), spec)
+			vol, err := subject.PrepareStorage(context.Background(), s.T().TempDir(), mock.Execution(), spec)
 			s.Require().NoError(err)
 
 			actualFilename := filepath.Base(vol.Source)

--- a/pkg/test/ipfs/ipfs_host_storage_test.go
+++ b/pkg/test/ipfs/ipfs_host_storage_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/setup"
 	"github.com/bacalhau-project/bacalhau/pkg/storage"
 	ipfs_storage "github.com/bacalhau-project/bacalhau/pkg/storage/ipfs"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
 	testutils "github.com/bacalhau-project/bacalhau/pkg/test/utils"
 )
 
@@ -92,7 +93,7 @@ func (suite *IPFSHostStorageSuite) runFileTest(getStorageDriver getStorageFunc) 
 
 	suite.verifyHasCID(ctx, storageDriver, inputSource, fileCid)
 
-	volume, err := storageDriver.PrepareStorage(ctx, suite.T().TempDir(), inputSource)
+	volume, err := storageDriver.PrepareStorage(ctx, suite.T().TempDir(), mock.Execution(), inputSource)
 	suite.Require().NoError(err)
 
 	// we should now be able to read our file content
@@ -133,7 +134,7 @@ func (suite *IPFSHostStorageSuite) runFolderTest(getStorageDriver getStorageFunc
 
 	suite.verifyHasCID(ctx, storageDriver, inputSource, folderCid)
 
-	volume, err := storageDriver.PrepareStorage(ctx, suite.T().TempDir(), inputSource)
+	volume, err := storageDriver.PrepareStorage(ctx, suite.T().TempDir(), mock.Execution(), inputSource)
 	suite.Require().NoError(err)
 
 	// we should now be able to read our file content


### PR DESCRIPTION
This PR makes execution information available to storage providers in preparation for enabling partitioned inputs https://linear.app/expanso/issue/ENG-520/partitioned-s3-input-source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Updated storage preparation methods across multiple packages to include execution context.
  - Modified method signatures to support more comprehensive input handling.
  - Enhanced flexibility in the storage preparation process.

- **Testing**
  - Updated test suites to incorporate mock execution contexts.
  - Improved test coverage for storage-related functionality.

These changes represent a significant architectural refinement in how storage and execution contexts are managed throughout the system, focusing on more robust and context-aware storage preparation mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->