### PR TITLE
Fix boltdb transaction panic on context cancellation

### DIFF
--- a/pkg/lib/boltdblib/operations.go
+++ b/pkg/lib/boltdblib/operations.go
@@ -7,70 +7,64 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// Update is a helper function that will update the job in the store
-// it accepts a context, an update function and creates a new transaction to
-// perform the update if no transaction is provided in the context
+// Update is a helper function that will update the job in the store.
+// It checks context cancellation before starting any operation.
 func Update(ctx context.Context, db *bolt.DB, update func(tx *bolt.Tx) error) error {
-	var err error
-	var tx *bolt.Tx
+	// Check context cancellation before starting
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context cancelled before starting update: %w", err)
+	}
 
-	// if ctx has a transaction value, then we can use that transaction, otherwise we need to create one
-	var externalTx bool
-	tx, externalTx = TxFromContext(ctx)
+	// Check for existing transaction in context
+	tx, externalTx := TxFromContext(ctx)
 	if externalTx {
 		if !tx.Writable() {
 			return fmt.Errorf("readonly transaction provided in context for update operation")
 		}
-	} else {
-		tx, err = db.Begin(true)
-		if err != nil {
-			return err
-		}
+		return update(tx)
 	}
 
-	// always rollback the transaction if there was an error
-	// and the transaction was created internally in this call
+	// Start new writable transaction
+	tx, err := db.Begin(true)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	// Always rollback on error for internally created transactions
 	defer func() {
-		if !externalTx && err != nil {
+		if err != nil {
 			_ = tx.Rollback()
 		}
 	}()
 
-	err = update(tx)
-	if err != nil {
+	if err = update(tx); err != nil {
 		return err
 	}
 
-	// only commit the transaction if it was created internally in this call
-	if !externalTx {
-		err = tx.Commit()
-	}
-	return err
+	return tx.Commit()
 }
 
-// View is a helper function that will perform a read-only operation on the store
-// it accepts a context, a view function and creates a new transaction to
-// perform the view if no transaction is provided in the context
+// View is a helper function that will perform a read-only operation on the store.
+// It checks context cancellation before starting any operation.
 func View(ctx context.Context, db *bolt.DB, view func(tx *bolt.Tx) error) error {
-	var err error
-
-	// if ctx has a transaction value, then we can use that transaction, otherwise we need to create one
-	tx, externalTx := TxFromContext(ctx)
-	if !externalTx {
-		tx, err = db.Begin(false)
-		if err != nil {
-			return err
-		}
+	// Check context cancellation before starting
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context cancelled before starting view: %w", err)
 	}
 
-	// always rollback the transaction if the transaction
-	// was created internally in this call
-	// note that we don't commit the transaction as it's read-only
-	defer func() {
-		if !externalTx {
-			_ = tx.Rollback()
-		}
-	}()
+	// Check for existing transaction in context
+	tx, externalTx := TxFromContext(ctx)
+	if externalTx {
+		return view(tx)
+	}
+
+	// Start new read-only transaction
+	tx, err := db.Begin(false)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	// Always rollback read-only transactions
+	defer tx.Rollback() // nolint: errcheck
 
 	return view(tx)
 }

--- a/pkg/lib/boltdblib/operations.go
+++ b/pkg/lib/boltdblib/operations.go
@@ -64,7 +64,7 @@ func View(ctx context.Context, db *bolt.DB, view func(tx *bolt.Tx) error) error 
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	// Always rollback read-only transactions
-	defer tx.Rollback() // nolint: errcheck
+	defer tx.Rollback() //nolint:errcheck
 
 	return view(tx)
 }

--- a/pkg/orchestrator/callback.go
+++ b/pkg/orchestrator/callback.go
@@ -69,11 +69,7 @@ func (e *Callback) OnBidComplete(ctx context.Context, response legacy.BidResult)
 		return
 	}
 
-	defer func() {
-		if err != nil {
-			_ = txContext.Rollback()
-		}
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	if err = e.store.UpdateExecution(txContext, updateRequest); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msgf("[OnBidComplete] failed to update execution")
@@ -104,9 +100,7 @@ func (e *Callback) OnRunComplete(ctx context.Context, result legacy.RunResult) {
 		return
 	}
 
-	defer func() {
-		_ = txContext.Rollback()
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	job, err := e.store.GetJob(txContext, result.JobID)
 	if err != nil {
@@ -173,9 +167,7 @@ func (e *Callback) OnComputeFailure(ctx context.Context, result legacy.ComputeEr
 		return
 	}
 
-	defer func() {
-		_ = txContext.Rollback()
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	// update execution state
 	if err = e.store.UpdateExecution(txContext, jobstore.UpdateExecutionRequest{

--- a/pkg/orchestrator/endpoint.go
+++ b/pkg/orchestrator/endpoint.go
@@ -71,11 +71,7 @@ func (e *BaseEndpoint) SubmitJob(ctx context.Context, request *SubmitJobRequest)
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	defer func() {
-		if err != nil {
-			_ = txContext.Rollback()
-		}
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	if err = e.store.CreateJob(txContext, *job); err != nil {
 		return nil, err
@@ -114,12 +110,7 @@ func (e *BaseEndpoint) StopJob(ctx context.Context, request *StopJobRequest) (St
 	if err != nil {
 		return StopJobResponse{}, jobstore.NewJobStoreError(err.Error())
 	}
-
-	defer func() {
-		if err != nil {
-			_ = txContext.Rollback()
-		}
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	job, err := e.store.GetJob(txContext, request.JobID)
 	if err != nil {

--- a/pkg/orchestrator/message_handler.go
+++ b/pkg/orchestrator/message_handler.go
@@ -96,9 +96,7 @@ func (m *MessageHandler) OnBidComplete(ctx context.Context, message *envelope.Me
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	defer func() {
-		_ = txContext.Rollback()
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	if err = m.store.UpdateExecution(txContext, updateRequest); err != nil {
 		return err
@@ -124,9 +122,7 @@ func (m *MessageHandler) OnRunComplete(ctx context.Context, message *envelope.Me
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	defer func() {
-		_ = txContext.Rollback()
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	job, err := m.store.GetJob(txContext, result.JobID)
 	if err != nil {
@@ -182,9 +178,7 @@ func (m *MessageHandler) OnComputeFailure(ctx context.Context, message *envelope
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	defer func() {
-		_ = txContext.Rollback()
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	// update execution state
 	if err = m.store.UpdateExecution(txContext, jobstore.UpdateExecutionRequest{

--- a/pkg/orchestrator/planner/state_updater.go
+++ b/pkg/orchestrator/planner/state_updater.go
@@ -51,11 +51,7 @@ func (s *StateUpdater) Process(ctx context.Context, plan *models.Plan) (err erro
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	defer func() {
-		if err != nil {
-			_ = txContext.Rollback()
-		}
-	}()
+	defer txContext.Rollback() //nolint:errcheck
 
 	if err = s.processExecutions(ctx, txContext, plan, metrics); err != nil {
 		return err

--- a/pkg/orchestrator/planner/state_updater_test.go
+++ b/pkg/orchestrator/planner/state_updater_test.go
@@ -39,6 +39,7 @@ func (suite *StateUpdaterSuite) TestStateUpdater_Process_CreateExecutions_Succes
 	suite.mockStore.EXPECT().BeginTx(suite.ctx).Return(suite.mockTxContext, nil).Times(1)
 	suite.mockStore.EXPECT().CreateExecution(suite.mockTxContext, *execution1).Times(1)
 	suite.mockStore.EXPECT().CreateExecution(suite.mockTxContext, *execution2).Times(1)
+	suite.mockTxContext.EXPECT().Rollback() // always rollback in defer
 	suite.mockTxContext.EXPECT().Commit()
 
 	suite.NoError(suite.stateUpdater.Process(suite.ctx, plan))
@@ -63,6 +64,7 @@ func (suite *StateUpdaterSuite) TestStateUpdater_Process_UpdateExecutions_Succes
 	suite.mockStore.EXPECT().BeginTx(suite.ctx).Return(suite.mockTxContext, nil).Times(1)
 	suite.mockStore.EXPECT().UpdateExecution(suite.mockTxContext, NewUpdateExecutionMatcherFromPlanUpdate(suite.T(), update1)).Times(1)
 	suite.mockStore.EXPECT().UpdateExecution(suite.mockTxContext, NewUpdateExecutionMatcherFromPlanUpdate(suite.T(), update2)).Times(1)
+	suite.mockTxContext.EXPECT().Rollback() // always rollback in defer
 	suite.mockTxContext.EXPECT().Commit()
 	suite.NoError(suite.stateUpdater.Process(suite.ctx, plan))
 }
@@ -73,6 +75,7 @@ func (suite *StateUpdaterSuite) TestStateUpdater_Process_UpdateJobState_Success(
 
 	suite.mockStore.EXPECT().BeginTx(suite.ctx).Return(suite.mockTxContext, nil).Times(1)
 	suite.mockStore.EXPECT().UpdateJobState(suite.mockTxContext, NewUpdateJobMatcherFromPlanUpdate(suite.T(), plan)).Times(1)
+	suite.mockTxContext.EXPECT().Rollback() // always rollback in defer
 	suite.mockTxContext.EXPECT().Commit()
 	suite.NoError(suite.stateUpdater.Process(suite.ctx, plan))
 }
@@ -94,6 +97,7 @@ func (suite *StateUpdaterSuite) TestStateUpdater_Process_CreateEvaluations_Succe
 	suite.mockStore.EXPECT().BeginTx(suite.ctx).Return(suite.mockTxContext, nil).Times(1)
 	suite.mockStore.EXPECT().CreateEvaluation(suite.mockTxContext, *evaluation1).Times(1)
 	suite.mockStore.EXPECT().CreateEvaluation(suite.mockTxContext, *evaluation2).Times(1)
+	suite.mockTxContext.EXPECT().Rollback() // always rollback in defer
 	suite.mockTxContext.EXPECT().Commit()
 
 	suite.NoError(suite.stateUpdater.Process(suite.ctx, plan))
@@ -131,6 +135,7 @@ func (suite *StateUpdaterSuite) TestStateUpdater_Process_MultiOp() {
 	suite.mockStore.EXPECT().UpdateJobState(suite.mockTxContext, NewUpdateJobMatcherFromPlanUpdate(suite.T(), plan)).Times(1)
 	suite.mockStore.EXPECT().CreateEvaluation(suite.mockTxContext, *evaluation1).Times(1)
 	suite.mockStore.EXPECT().CreateEvaluation(suite.mockTxContext, *evaluation2).Times(1)
+	suite.mockTxContext.EXPECT().Rollback() // always rollback in defer
 	suite.mockTxContext.EXPECT().Commit()
 
 	suite.NoError(suite.stateUpdater.Process(suite.ctx, plan))


### PR DESCRIPTION
This PR fixes critical issues with BoltDB transaction handling:
1. Panics occurring during context cancellation of long-running transactions
2. Potential transaction leaks in early-return scenarios

This issue is reproducible when running a job across hundreds of nodes where 
transactions can take long and context is timedout. Investigation on why 
transactions are taking long is handled in a separate issue.

Problem 1 - Transaction Panics:
- Current implementation attempts to rollback transactions in a separate goroutine 
  when context is cancelled
- This creates a race condition as the transaction may still be in use by the 
  main operation
- Results in panics when the cursor becomes invalid during concurrent rollback: 
  "panic: runtime error: invalid memory address or nil pointer dereference"
- Issue occurs because BoltDB transactions are not thread-safe, but we're trying 
  to access them concurrently

Problem 2 - Transaction Leaks:
- Current defer pattern only rolls back on error: `if err != nil { _ = tx.Rollback() }`
- However, some operations return early without error (e.g., stopping an already 
  stopped job)
- This leaves transactions open when they should be cleaned up
- Could lead to resource leaks and database locks

Solution:
1. For Transaction Panics:
   - Remove concurrent transaction rollback on context cancellation
   - Add explicit context cancellation checks at the start of operations
   - Keep transaction operations in a single goroutine

2. For Transaction Leaks:
   - Always rollback in defer (our txContext.Rollback() safely handles already committed transactions)
   - Simplify defer pattern to:
     ```go
     defer tx.Rollback() // Safe to call multiple times or after commit
     // ... operations ...
     return tx.Commit()
     ```

This aligns better with BoltDB's design which expects transactions to be 
handled in a single thread and ensures proper cleanup in all code paths. The 
changes improve reliability by preventing both race conditions and resource leaks.

Example stack trace of the fixed panic:
```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1041dae40]

goroutine 308 [running]:
go.etcd.io/bbolt.(*Cursor).seek(0x14000e1ea00, {0x14000d0d258, 0x4, 0x8})
    /Users/walid/.go/pkg/mod/go.etcd.io/bbolt@v1.3.10/cursor.go:159 +0x70
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Simplified transaction context management by removing synchronization mechanisms.
    - Streamlined error handling in database operations, including unconditional rollbacks.

- **Bug Fixes**
    - Added explicit context cancellation checks in database update and view operations.

- **Tests**
    - Updated test suite to verify context handling in database transactions.
    - Enhanced test cases for canceled and timeout contexts.
    - Improved transaction context tests to ensure proper rollback behavior under cancellation.
    - Added rollback expectations in various test cases to reinforce transactional integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->