### PR TITLE
devstack: support node joining existing networks and config passing

### DIFF
--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -43,8 +43,7 @@ func SetupRepo(cfg types.Bacalhau) (*repo.FsRepo, error) {
 	return r, nil
 }
 
-func SetupConfigType(cmd *cobra.Command) (*config.Config, error) {
-	var opts []config.Option
+func SetupConfigType(cmd *cobra.Command, opts ...config.Option) (*config.Config, error) {
 	v := viper.GetViper()
 	// check if the user specified config files via the --config flag
 	configFiles := getConfigFiles(v)
@@ -85,16 +84,16 @@ func SetupConfigType(cmd *cobra.Command) (*config.Config, error) {
 	return cfg, nil
 }
 
-func SetupConfig(cmd *cobra.Command) (types.Bacalhau, error) {
-	cfg, err := SetupConfigType(cmd)
+func SetupConfig(cmd *cobra.Command, opts ...config.Option) (types.Bacalhau, error) {
+	cfg, err := SetupConfigType(cmd, opts...)
 	if err != nil {
 		return types.Bacalhau{}, err
 	}
 	return UnmarshalBacalhauConfig(cfg)
 }
 
-func SetupConfigs(cmd *cobra.Command) (types.Bacalhau, *config.Config, error) {
-	cfg, err := SetupConfigType(cmd)
+func SetupConfigs(cmd *cobra.Command, opts ...config.Option) (types.Bacalhau, *config.Config, error) {
+	cfg, err := SetupConfigType(cmd, opts...)
 	if err != nil {
 		return types.Bacalhau{}, nil, err
 	}

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -53,12 +53,17 @@ func Setup(
 
 	log.Ctx(ctx).Info().Object("Config", stackConfig).Msg("Starting Devstack")
 
-	cfg := stackConfig.BacalhauConfig
-
 	var nodes []*node.Node
 	totalNodeCount := stackConfig.NumberOfHybridNodes + stackConfig.NumberOfRequesterOnlyNodes + stackConfig.NumberOfComputeOnlyNodes
 	requesterNodeCount := stackConfig.NumberOfHybridNodes + stackConfig.NumberOfRequesterOnlyNodes
 	computeNodeCount := stackConfig.NumberOfHybridNodes + stackConfig.NumberOfComputeOnlyNodes
+
+	cfg := stackConfig.BacalhauConfig
+
+	// if running with local orchestrator, we clear the orchestrator list from the config
+	if requesterNodeCount > 0 {
+		cfg.Compute.Orchestrators = []string{}
+	}
 
 	for i := 0; i < totalNodeCount; i++ {
 		nodeID := fmt.Sprintf("node-%d", i)

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -56,16 +56,9 @@ func Setup(
 	cfg := stackConfig.BacalhauConfig
 
 	var nodes []*node.Node
-	orchestratorAddrs := make([]string, 0)
-	clusterPeersAddrs := make([]string, 0)
-
 	totalNodeCount := stackConfig.NumberOfHybridNodes + stackConfig.NumberOfRequesterOnlyNodes + stackConfig.NumberOfComputeOnlyNodes
 	requesterNodeCount := stackConfig.NumberOfHybridNodes + stackConfig.NumberOfRequesterOnlyNodes
 	computeNodeCount := stackConfig.NumberOfHybridNodes + stackConfig.NumberOfComputeOnlyNodes
-
-	if requesterNodeCount == 0 {
-		return nil, fmt.Errorf("at least one requester node is required")
-	}
 
 	for i := 0; i < totalNodeCount; i++ {
 		nodeID := fmt.Sprintf("node-%d", i)
@@ -75,34 +68,27 @@ func Setup(
 		isComputeNode := (totalNodeCount - i) <= computeNodeCount
 		log.Ctx(ctx).Debug().Msgf(`Creating Node #%d as {RequesterNode: %t, ComputeNode: %t}`, i+1, isRequesterNode, isComputeNode)
 
-		// ////////////////////////////////////
-		// Transport layer
-		// ////////////////////////////////////
-		if os.Getenv("PREDICTABLE_API_PORT") != "" {
-			cfg.Orchestrator.Port = 4222 + i
-		} else {
-			if cfg.Orchestrator.Port, err = network.GetFreePort(); err != nil {
-				return nil, errors.Wrap(err, "failed to get free port for nats server")
-			}
-		}
-
-		if os.Getenv("PREDICTABLE_API_PORT") != "" {
-			cfg.Orchestrator.Cluster.Port = 6222 + i
-		} else {
-			if cfg.Orchestrator.Cluster.Port, err = network.GetFreePort(); err != nil {
-				return nil, errors.Wrap(err, "failed to get free port for nats cluster")
-			}
-		}
-
-		// always override the default orchestrator address
-		// for the first orchestrator, this will be empty as it should be
-		// for the rest, it will be the address of the previous orchestrators
-		cfg.Compute.Orchestrators = orchestratorAddrs
-
 		if isRequesterNode {
-			cfg.Orchestrator.Cluster.Peers = clusterPeersAddrs
-			cfg.Orchestrator.Cluster.Name = "devstack"
-			orchestratorAddrs = append(orchestratorAddrs, fmt.Sprintf("127.0.0.1:%d", cfg.Orchestrator.Port))
+			if os.Getenv("PREDICTABLE_API_PORT") != "" {
+				cfg.Orchestrator.Port = 4222 + i
+			} else {
+				if cfg.Orchestrator.Port, err = network.GetFreePort(); err != nil {
+					return nil, errors.Wrap(err, "failed to get free port for nats server")
+				}
+			}
+
+			if os.Getenv("PREDICTABLE_API_PORT") != "" {
+				cfg.Orchestrator.Cluster.Port = 6222 + i
+			} else {
+				if cfg.Orchestrator.Cluster.Port, err = network.GetFreePort(); err != nil {
+					return nil, errors.Wrap(err, "failed to get free port for nats cluster")
+				}
+			}
+
+			if cfg.Orchestrator.Cluster.Name == "" {
+				cfg.Orchestrator.Cluster.Name = "devstack"
+			}
+			cfg.Compute.Orchestrators = append(cfg.Compute.Orchestrators, fmt.Sprintf("127.0.0.1:%d", cfg.Orchestrator.Port))
 		}
 
 		// ////////////////////////////////////
@@ -110,6 +96,10 @@ func Setup(
 		// ////////////////////////////////////
 		if os.Getenv("PREDICTABLE_API_PORT") != "" {
 			cfg.API.Port = 1234 + i
+			// add one more if using an external orchestrator to avoid port conflict
+			if requesterNodeCount == 0 {
+				cfg.API.Port += 1
+			}
 		} else {
 			if cfg.API.Port, err = network.GetFreePort(); err != nil {
 				return nil, errors.Wrap(err, "failed to get free port for API server")

--- a/pkg/lib/ncl/metrics.go
+++ b/pkg/lib/ncl/metrics.go
@@ -1,0 +1,1 @@
+package ncl


### PR DESCRIPTION
This PR refactors devstack to support two key features:

1. Allow compute nodes to join an existing orchestrator:
   - Added --computes flag (alias for --compute-nodes) to specify number of compute nodes
   - Added --orchestrators flag (alias for --requester-nodes) to specify number of orchestrator nodes
   - Added --hybrids flag (alias for --hybrid-nodes) to specify hybrid nodes
   - When no orchestrator nodes are specified and orchestrator address is provided via -c flag,
     devstack will run compute-only nodes that connect to the external orchestrator

2. Use test configuration as base:
   - Devstack now uses NewTestConfig() as base configuration
   - All configuration can be overridden using -c flags (same as bacalhau serve)
   - Node-specific settings are layered on top of base configuration
   - Maintains backward compatibility with existing devstack flags

This allows for:
```bash
# Run orchestrator node
bacalhau devstack --orchestrators 1

# Run compute nodes connecting to existing orchestrator
bacalhau devstack --computes 3 -c Compute.Orchestrators=127.0.0.1:4222

# Run both with custom config
bacalhau devstack --computes 3 --orchestrators 1 -c Compute.AllowListedLocalPaths=/tmp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated CLI command-line flags for devstack configuration with more intuitive naming.
	- Enhanced configuration setup process with more flexible option handling.
	- Introduced a new package for organizing related functionalities.

- **Refactor**
	- Simplified devstack node configuration terminology.
	- Improved configuration management in devstack and utility functions.
	- Streamlined node setup logic in devstack configuration.

- **Chores**
	- Updated method signatures to support more dynamic configuration options.
	- Maintained backward compatibility with existing flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->