### PR TITLE
increase ncl publish and subscribe timeouts

### DIFF
--- a/pkg/lib/ncl/publisher_config.go
+++ b/pkg/lib/ncl/publisher_config.go
@@ -110,7 +110,7 @@ type OrderedPublisherConfig struct {
 func DefaultOrderedPublisherConfig() OrderedPublisherConfig {
 	return OrderedPublisherConfig{
 		MessageSerializer: envelope.NewSerializer(),
-		AckWait:           5 * time.Second,
+		AckWait:           30 * time.Second,
 		MaxPending:        1000,
 		RetryAttempts:     3,
 		RetryWait:         time.Second,

--- a/pkg/lib/ncl/subscriber_config.go
+++ b/pkg/lib/ncl/subscriber_config.go
@@ -42,7 +42,7 @@ type SubscriberConfig struct {
 }
 
 const (
-	DefaultProcessingTimeout   = 5 * time.Second
+	DefaultProcessingTimeout   = 30 * time.Second
 	DefaultBackoffInitialDelay = 100 * time.Millisecond
 	DefaultBackoffMaximumDelay = 5 * time.Second
 )


### PR DESCRIPTION
existing timeout values are too aggressive and cause lots of timeouts and retries with larger networks 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Increased default acknowledgment wait time from 5 to 30 seconds for publisher configurations
	- Extended default processing timeout from 5 to 30 seconds for subscriber configurations

These changes provide more generous timeout and acknowledgment periods, potentially improving system resilience and message processing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->