### PR TITLE
deploy v1.6.2 to demo network

### DIFF
--- a/ops/terraform/prod.tfvars
+++ b/ops/terraform/prod.tfvars
@@ -1,4 +1,4 @@
-bacalhau_version            = "v1.6.1"
+bacalhau_version            = "v1.6.2"
 bacalhau_port               = "1235"
 bacalhau_environment        = "production"
 ipfs_version                = "v0.18.1"

--- a/ops/terraform/stage.tfvars
+++ b/ops/terraform/stage.tfvars
@@ -1,4 +1,4 @@
-bacalhau_version            = "v1.6.1"
+bacalhau_version            = "v1.6.2"
 bacalhau_branch             = "" # deploy from a branch instead of the version above
 bacalhau_port               = "1235"
 bacalhau_environment        = "staging"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Bacalhau software version from v1.6.1 to v1.6.2 in production and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->