### PR TITLE
fix golangci-lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir -p webui/build && touch webui/build/index.html
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v6.5.0
         with:
           skip-cache: true
-          version: v1.64.2
+          version: v1.64.5
 
   # TODO: Decouple Each Component Linting
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   go-lint:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +25,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           skip-cache: true
+          version: v1.64.2
 
   # TODO: Decouple Each Component Linting
   lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters-settings:
   lll:
     line-length: 140
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: true # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,6 +3,6 @@ nodejs 21.5.0
 direnv 2.33.0
 golang 1.21.11
 pre-commit 3.6.0
-golangci-lint 1.55.2
+golangci-lint 1.64.2
 earthly 0.8.3
 pnpm 9.0.6

--- a/docker/buildkite-hosted-agent-bacalhau/Dockerfile
+++ b/docker/buildkite-hosted-agent-bacalhau/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/buildkite/hosted-agent-base:ubuntu-v1.0.0@sha256:af0d05215252cc0d
 
 # When updatin the golang version golangci-lint may also need its version updated for compatibility.
 ENV GOLANG_VERSION 1.23.0
-ENV GOLANGCI_LINT_VERSION v1.60.1
+ENV GOLANGCI_LINT_VERSION v1.64.2
 
 RUN apt-get update && apt-get install -y wget make iproute2 gh
 

--- a/docker/buildkite-hosted-agent-bacalhau/Dockerfile
+++ b/docker/buildkite-hosted-agent-bacalhau/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/buildkite/hosted-agent-base:ubuntu-v1.0.0@sha256:af0d05215252cc0d
 
 # When updatin the golang version golangci-lint may also need its version updated for compatibility.
 ENV GOLANG_VERSION 1.23.0
-ENV GOLANGCI_LINT_VERSION v1.64.2
+ENV GOLANGCI_LINT_VERSION v1.64.5
 
 RUN apt-get update && apt-get install -y wget make iproute2 gh
 


### PR DESCRIPTION
The workflow is failing because `golangci-lint-action` added config validation, and our config are still using outdated lints that have been dropped couple of years ago.

This PR fixes the issue by removing the dropped configs, but also mitigates future similars issues by:
- Pinning the `golangci-lint` version used by the action to latest version v1.64.5 to avoid always using the latest version which may be incompatible with our configs
- Pinning `golangci-lint-action` to current latest version v6.5.0 to avoid change in behaviour, such as config validation

This allows us to update whenever we are ready and not block our pipeline when latest versions are incompatible with our repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated and streamlined automated quality checks for improved consistency.
	- Upgraded linting tool versions across the development process to enhance code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->