### PR TITLE
Update Hello World job as the previous version seems to be outdated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ curl -sL https://get.bacalhau.org/install.sh | bash
 Submit a "Hello World" job
 
 ```bash
-bacalhau docker run ubuntu echo Hello World
+bacalhau docker run \
+                -c API.Host=bootstrap.production.bacalhau.org \
+                --wait \
+                docker run \
+                docker.io/bacalhauproject/hello-world:latest
 ```
 
 Download your result


### PR DESCRIPTION
The previous README getting used to give me an error.

```bash
(base) ~ ❯❯❯ bacalhau docker run ubuntu echo Hello World              
Error: server is not running or not reachable at http://127.0.0.1:1234
Hint:  to resolve this, either:
1. Ensure that the server is running and reachable at http://127.0.0.1:1234
2. Update the configuration to use a different host and port using:
   a. The '--api-host=<new_address> --api-port=<new_port>' flags with your command
   b. The '-c API.Host=<new_host> -c API.Port=<new_port>' flags with your command
   c. Set the host in a configuration file with 'bacalhau config set API.Host=<new_address>' and port with 'bacalhau config set API.Port=<new_port>'
3. If you are trying to reach the demo network, use '--api-host=bootstrap.demo.bacalhau.org' to call the network
```

I think I corrected it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the quickstart guide with an enhanced command for job submission, now including options to specify a service host, wait for job completion, and use an updated Docker image for improved execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->