### PR TITLE
Count field defaults to 1 if not provided

### DIFF
--- a/pkg/lib/marshaller/utils_test.go
+++ b/pkg/lib/marshaller/utils_test.go
@@ -132,7 +132,7 @@ func TestUnmarshalJob(t *testing.T) {
 		j, err := UnmarshalJob([]byte(jobWithUnknownFields))
 		assert.Nil(t, j)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "field: 'Count' in 'Job' is invalid type: 'string' expected: 'int'")
+		assert.ErrorContains(t, err, "field: 'Count' in 'job' is invalid type: 'string' expected: 'int'")
 	})
 
 }

--- a/pkg/models/job.go
+++ b/pkg/models/job.go
@@ -415,12 +415,13 @@ func (j *Job) OrchestrationProtocol() Protocol {
 // 1. Set default Count=1 for batch and service jobs when omitted in JSON
 // 2. Preserve explicit Count=0 when specified (used to stop all executions)
 func (j *Job) UnmarshalJSON(data []byte) error {
-	type Alias Job // Create alias to avoid recursion
-	aux := &struct {
-		*Alias
+	type alias Job // Create alias to avoid recursion
+	type job struct {
+		*alias
 		Count *int `json:"Count,omitempty"`
-	}{
-		Alias: (*Alias)(j),
+	}
+	aux := &job{
+		alias: (*alias)(j),
 	}
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -1701,7 +1701,7 @@ const docTemplate = `{
                     }
                 },
                 "Count": {
-                    "description": "Count is the number of replicas that should be scheduled.",
+                    "description": "Count is the number of replicas that should be scheduled.\nFor batch and service jobs:\n- If not present in JSON, defaults to 1\n- If explicitly set to 0, means stop all executions\n- If \u003e 0, specifies exact number of replicas\nFor daemon and ops jobs:\n- Values of 0 or 1 are ignored (job runs on all matching nodes)\n- Values \u003e 1 are invalid and will cause validation to fail",
                     "type": "integer"
                 },
                 "CreateTime": {

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -1697,7 +1697,7 @@
                     }
                 },
                 "Count": {
-                    "description": "Count is the number of replicas that should be scheduled.",
+                    "description": "Count is the number of replicas that should be scheduled.\nFor batch and service jobs:\n- If not present in JSON, defaults to 1\n- If explicitly set to 0, means stop all executions\n- If \u003e 0, specifies exact number of replicas\nFor daemon and ops jobs:\n- Values of 0 or 1 are ignored (job runs on all matching nodes)\n- Values \u003e 1 are invalid and will cause validation to fail",
                     "type": "integer"
                 },
                 "CreateTime": {

--- a/webui/lib/api/schema/swagger.json
+++ b/webui/lib/api/schema/swagger.json
@@ -1697,7 +1697,7 @@
                     }
                 },
                 "Count": {
-                    "description": "Count is the number of replicas that should be scheduled.",
+                    "description": "Count is the number of replicas that should be scheduled.\nFor batch and service jobs:\n- If not present in JSON, defaults to 1\n- If explicitly set to 0, means stop all executions\n- If \u003e 0, specifies exact number of replicas\nFor daemon and ops jobs:\n- Values of 0 or 1 are ignored (job runs on all matching nodes)\n- Values \u003e 1 are invalid and will cause validation to fail",
                     "type": "integer"
                 },
                 "CreateTime": {


### PR DESCRIPTION
Currently when users submit a job without specifying a count, it's not clear what happens:
- Batch/service jobs silently fail to run as count defaults to 0, which means no executions are needed.
- Users have to debug why their job isn't executing
- No indication that count needs to be set

This change makes it more intuitive:
- Batch/service jobs default to count=1 if not specified
- Explicit count=0 is still respected (useful for stopping jobs)
- No changes to daemon/ops jobs which run on all matching nodes

This should reduce confusion and make job submission more user-friendly, especially 
for new users trying out the system.

### Examples
Job will run and default to count=1
```
Type: batch
Tasks:
  - Name: main
    Engine:
      Type: docker
      Params:
        Image: ubuntu
        Parameters:
          - echo
          - hello
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced job submission logic with improved handling of the count field, setting default and validation rules based on job types.

- **Documentation**
  - Updated API and Swagger documentation to clearly describe how the count field behaves for different job scenarios.

- **Tests**
  - Expanded test coverage with descriptive cases to verify proper handling, normalization, and validation of the count field.
  - Improved error message assertions for invalid field types in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->