### PR TITLE
add option to opt-out networking

### DIFF
--- a/pkg/bidstrategy/semantic/networking.go
+++ b/pkg/bidstrategy/semantic/networking.go
@@ -7,13 +7,13 @@ import (
 )
 
 type NetworkingStrategy struct {
-	Accept bool
+	Reject bool
 }
 
 var _ bidstrategy.SemanticBidStrategy = (*NetworkingStrategy)(nil)
 
-func NewNetworkingStrategy(accept bool) *NetworkingStrategy {
-	return &NetworkingStrategy{accept}
+func NewNetworkingStrategy(reject bool) *NetworkingStrategy {
+	return &NetworkingStrategy{reject}
 }
 
 const (
@@ -29,5 +29,5 @@ func (s *NetworkingStrategy) ShouldBid(
 		return bidstrategy.NewBidResponse(true, localOnlyReason), nil
 	}
 
-	return bidstrategy.NewBidResponse(s.Accept, accessReason), nil
+	return bidstrategy.NewBidResponse(!s.Reject, accessReason), nil
 }

--- a/pkg/config/types/admission_control.go
+++ b/pkg/config/types/admission_control.go
@@ -10,7 +10,10 @@ type JobAdmissionControl struct {
 	// RejectStatelessJobs indicates whether to reject stateless jobs, i.e. jobs without inputs.
 	RejectStatelessJobs bool `yaml:"RejectStatelessJobs,omitempty" json:"RejectStatelessJobs,omitempty"`
 	// AcceptNetworkedJobs indicates whether to accept jobs that require network access.
+	// Will be deprecated in v1.7 in favor of RejectNetworkedJobs.
 	AcceptNetworkedJobs bool `yaml:"AcceptNetworkedJobs,omitempty" json:"AcceptNetworkedJobs,omitempty"`
+	// RejectNetworkedJobs indicates whether to reject jobs that require network access.
+	RejectNetworkedJobs bool `yaml:"RejectNetworkedJobs,omitempty" json:"RejectNetworkedJobs,omitempty"`
 	// ProbeHTTP specifies the HTTP endpoint for probing job submission.
 	ProbeHTTP string `yaml:"ProbeHTTP,omitempty" json:"ProbeHTTP,omitempty"`
 	// ProbeExec specifies the command to execute for probing job submission.

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -320,7 +320,8 @@ func NewBidder(
 	var semanticBidStrats []bidstrategy.SemanticBidStrategy
 	if cfg.SystemConfig.BidSemanticStrategy == nil {
 		semanticBidStrats = []bidstrategy.SemanticBidStrategy{
-			semantic.NewNetworkingStrategy(cfg.BacalhauConfig.JobAdmissionControl.AcceptNetworkedJobs),
+			semantic.NewNetworkingStrategy(cfg.BacalhauConfig.JobAdmissionControl.RejectNetworkedJobs ||
+				!cfg.BacalhauConfig.JobAdmissionControl.AcceptNetworkedJobs),
 			semantic.NewStatelessJobStrategy(semantic.StatelessJobStrategyParams{
 				RejectStatelessJobs: cfg.BacalhauConfig.JobAdmissionControl.RejectStatelessJobs,
 			}),

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -2801,7 +2801,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "AcceptNetworkedJobs": {
-                    "description": "AcceptNetworkedJobs indicates whether to accept jobs that require network access.",
+                    "description": "AcceptNetworkedJobs indicates whether to accept jobs that require network access.\nWill be deprecated in v1.7 in favor of RejectNetworkedJobs.",
                     "type": "boolean"
                 },
                 "Locality": {
@@ -2819,6 +2819,10 @@ const docTemplate = `{
                 "ProbeHTTP": {
                     "description": "ProbeHTTP specifies the HTTP endpoint for probing job submission.",
                     "type": "string"
+                },
+                "RejectNetworkedJobs": {
+                    "description": "RejectNetworkedJobs indicates whether to reject jobs that require network access.",
+                    "type": "boolean"
                 },
                 "RejectStatelessJobs": {
                     "description": "RejectStatelessJobs indicates whether to reject stateless jobs, i.e. jobs without inputs.",

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -2797,7 +2797,7 @@
             "type": "object",
             "properties": {
                 "AcceptNetworkedJobs": {
-                    "description": "AcceptNetworkedJobs indicates whether to accept jobs that require network access.",
+                    "description": "AcceptNetworkedJobs indicates whether to accept jobs that require network access.\nWill be deprecated in v1.7 in favor of RejectNetworkedJobs.",
                     "type": "boolean"
                 },
                 "Locality": {
@@ -2815,6 +2815,10 @@
                 "ProbeHTTP": {
                     "description": "ProbeHTTP specifies the HTTP endpoint for probing job submission.",
                     "type": "string"
+                },
+                "RejectNetworkedJobs": {
+                    "description": "RejectNetworkedJobs indicates whether to reject jobs that require network access.",
+                    "type": "boolean"
                 },
                 "RejectStatelessJobs": {
                     "description": "RejectStatelessJobs indicates whether to reject stateless jobs, i.e. jobs without inputs.",

--- a/webui/lib/api/schema/swagger.json
+++ b/webui/lib/api/schema/swagger.json
@@ -2797,7 +2797,7 @@
             "type": "object",
             "properties": {
                 "AcceptNetworkedJobs": {
-                    "description": "AcceptNetworkedJobs indicates whether to accept jobs that require network access.",
+                    "description": "AcceptNetworkedJobs indicates whether to accept jobs that require network access.\nWill be deprecated in v1.7 in favor of RejectNetworkedJobs.",
                     "type": "boolean"
                 },
                 "Locality": {
@@ -2815,6 +2815,10 @@
                 "ProbeHTTP": {
                     "description": "ProbeHTTP specifies the HTTP endpoint for probing job submission.",
                     "type": "string"
+                },
+                "RejectNetworkedJobs": {
+                    "description": "RejectNetworkedJobs indicates whether to reject jobs that require network access.",
+                    "type": "boolean"
                 },
                 "RejectStatelessJobs": {
                     "description": "RejectStatelessJobs indicates whether to reject stateless jobs, i.e. jobs without inputs.",


### PR DESCRIPTION
The current behaviour in bacalhau is that networking in disabled by default in jobs and in compute nodes. Users would have to opt-in for networking by setting `JobAdmissionControl.AcceptNetworkedJobs` config to true. This has caused lots of confusion as jobs that require networking would fail without a clear reason.

This PR is a first step towards making networking enabled by default in both compute node admission control and in job spec, and making networking opt-out instead of opt-in.

The PR just introduces the new opt-out config `JobAdmissionControl.RejectNetworkedJobs` to allow users to reject networking today and prepare for the change when networking is enabled by default in v1.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option that enables users to reject jobs requiring network access, providing finer control over job admission.
  
- **Documentation**
  - Updated API and configuration descriptions to reflect the new rejection-based approach, with notifications that the legacy acceptance option will be deprecated in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->