### PR TITLE
More detailed instructions for up local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,33 +98,15 @@ For a more detailed tutorial, check out our [Getting Started tutorial](https://d
 
 The Bacalhau docs is the best starting point as it contains all the information to ensure that everyone who uses Bacalhau is doing so efficiently.
 
-## Developers guide
+## Contributing
+If you are interested in contributing to the Bacalhau project:
+* Learn the [Ways To Contribute](#ways-to-contribute)
+* Set up your [local environment](docs/dev/local-env.md)
+* Submit an [issue](#issues-feature-requests-and-questions)
 
 ### Running Bacalhau locally
 
-Developers can spin up bacalhau and run a local demo using the `devstack` command.
-
-Please see [running_locally.md](docs/docs/dev/running-locally.md) for instructions. Also, see [debugging_locally.md](docs/docs/dev/debugging_locally.md) for some useful tricks for debugging.
-
-### Notes for Dev contributors
-
-Bacalhau's CI pipeline performs a variety of linting and formatting checks on new pull requests.
-To have these checks run locally when you make a new commit, you can use the precommit hook in `./githooks`:
-
-```bash
-make install-pre-commit
-
-# check if pre-commit works
-make precommit
-```
-If you want to run the linter manually:
-
-```bash
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/go/bin
-golangci-lint --version
-make lint
-```
-The config lives in `.golangci.yml`
+Learn how to set up your local environment in the [Developer guide](docs/dev/local-env.md)
 
 ### OpenAPI
 
@@ -152,7 +134,7 @@ We are excited to hear your feedback!
 * For questions, give feedback or answer questions that will help other user product please use [GitHub Discussions](https://github.com/bacalhau-project/bacalhau/discussions).
 * To engage with other members in the community, join us in our [slack community](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ) `#bacalhau` channel :raising_hand:
 
-## Ways to contribute
+## Ways To Contribute
 **All manner of contributions are more than welcome!**
 
 We have highlighted the different ways you can contribute in our [contributing guide](https://docs.bacalhau.org/community/ways-to-contribute). You can be part of community discussions, development, and more.

--- a/docs/dev/local-env.md
+++ b/docs/dev/local-env.md
@@ -1,0 +1,99 @@
+# Developer guide
+
+This guide helps you get started developing the Bacalhau project.
+
+## Dependencies
+
+* [Git](https://git-scm.com/)
+* [Python](https://www.python.org/) (see [pyproject.toml](../../pyproject.toml) for supported versions)
+* [Go](https://go.dev/)
+* [Earthly](https://github.com/earthly/earthly)
+* [Docker](https://docs.docker.com/) (optional for building, required for running integration tests)
+
+## Download Bacalhau
+
+Clone the Bacalhau repository using your preferred tool. Refer to GitHub's [documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) for different options.
+
+To clone Bacalhau repository using Git CLI:
+```bash
+git clone https://github.com/bacalhau-project/bacalhau.git
+cd bacalhau
+```
+
+## Create and activate Python virtual environment (optional)
+
+We recommend using Python [virtual environments](https://docs.python.org/3/library/venv.html) to avoid version conflicts.
+
+Create a virtual environment in the `.venv` folder:
+```bash
+python -m venv .venv
+```
+
+And activate it:
+```bash
+source .venv/bin/activate
+```
+
+## Configure pre-commit hooks
+
+Bacalhau uses pre-commit hooks for linting and formatting code. These checks will also be executed by Bacalhau's CI pipeline on all new pull requests. Check [.golangci.yml](../../.golangci.yml) for the linter rules.
+
+To install the pre-commit hooks:
+
+```bash
+make install-pre-commit
+```
+
+To check if pre-commit passes:
+```bash
+make precommit
+```
+
+## Build Bacalhau
+
+You can check individual build targets in the [Makefile](../../Makefile) or build all of them together.
+Refer to [Key Concepts](https://docs.bacalhau.org/overview/architecture#core-components) to learn more about different Bacalhau components.
+
+To build all Bacalhau components:
+
+```bash
+make build
+```
+
+## Run locally
+
+You can spin up a local Bacalhau stack and interact with it. For a detailed guide, check Bacalhau [documentation](https://docs.bacalhau.org/getting-started/network-setup#option-3-devstack).
+
+To run a local stack:
+```bash
+make devstack
+```
+
+You can run the local stack with a number of different configurations. For details, check the `devstack-*` targets in the [Makefile](../../Makefile).
+
+## Run tests
+
+Bacalhau tests can be generally divided into these categories:
+* Unit tests
+* Tests against a local stack
+* Integration tests using Docker
+
+### Unit tests
+
+To run all unit tests:
+```bash
+make unit-test
+```
+
+### Tests against local stack
+
+These tests will run a Bacalhau stack in local processes and execute tests against it. No Docker is required.
+
+To run tests against a local stack:
+```bash
+make integration-test
+```
+
+### Integration tests
+
+These tests mimic a real-life distributed installation of Bacalhau by running node processes in Docker containers (using [Testcontainers](https://docs.docker.com/testcontainers/)). Refer to the Integration Test [guide](../../test_integration/README.md) for detailed steps.


### PR DESCRIPTION
Current section for setting up a local Bacalhau stack is insufficient (missing/outdated info, dead links, etc.). This change added more detailed instruction for setting up local environment for new contributors.

- Dependencies needed for local dev environment
- Build steps
- Steps to run tests

https://linear.app/expanso/issue/ENG-664
