### PR TITLE
fix backward compatibility with full network type

### DIFF
--- a/cmd/cli/docker/docker_run_cli_test.go
+++ b/cmd/cli/docker/docker_run_cli_test.go
@@ -403,9 +403,18 @@ func TestJobFlagParsing(t *testing.T) {
 			assertJob: func(t *testing.T, j *models.Job) {
 				defaultJobAssertions(t, j)
 				task := j.Task()
-				assert.Equal(t, models.NetworkHost, task.Network.Type)
+				assert.Equal(t, models.NetworkFull, task.Network.Type)
 			},
 			expectedError: false,
+		},
+		{
+			name:  "with network host",
+			flags: []string{"--network=host", "image:tag"},
+			assertJob: func(t *testing.T, j *models.Job) {
+				defaultJobAssertions(t, j)
+				task := j.Task()
+				assert.Equal(t, models.NetworkHost, task.Network.Type)
+			},
 		},
 		{
 			name:          "with network invalid",

--- a/cmd/cli/wasm/wasm_run_cli_test.go
+++ b/cmd/cli/wasm/wasm_run_cli_test.go
@@ -333,8 +333,8 @@ func TestJobFlagParsing(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:  "with network full",
-			flags: []string{"--network=full", "./main.wasm"},
+			name:  "with network host",
+			flags: []string{"--network=host", "./main.wasm"},
 			assertJob: func(t *testing.T, j *models.Job) {
 				defaultJobAssertions(t, j)
 				task := j.Task()

--- a/pkg/bidstrategy/semantic/networking_allowlist_test.go
+++ b/pkg/bidstrategy/semantic/networking_allowlist_test.go
@@ -36,11 +36,14 @@ func (tc networkAllowlistTestCase) String() string {
 var networkAllowlistTestCases []networkAllowlistTestCase = []networkAllowlistTestCase{
 	{models.NetworkNone, []string{}, true},
 	{models.NetworkHost, []string{}, false},
+	{models.NetworkFull, []string{}, false},
 	{models.NetworkHTTP, []string{}, true},
 	{models.NetworkHTTP, []string{"example.com"}, true},
 	{models.NetworkHost, []string{"example.com"}, false},
+	{models.NetworkFull, []string{"example.com"}, false},
 	{models.NetworkHTTP, []string{"malware.com"}, false},
 	{models.NetworkHost, []string{"malware.com"}, false},
+	{models.NetworkFull, []string{"malware.com"}, false},
 	{models.NetworkHTTP, []string{"example.com", "proxy.golang.org"}, true},
 	{models.NetworkHTTP, []string{"malware.com", "proxy.golang.org"}, false},
 }

--- a/pkg/bidstrategy/semantic/networking_test.go
+++ b/pkg/bidstrategy/semantic/networking_test.go
@@ -34,8 +34,10 @@ func (test networkingStrategyTestCase) String() string {
 var networkingStrategyTestCases = []networkingStrategyTestCase{
 	{false, models.NetworkConfig{Type: models.NetworkNone}, true}, // Local job, not rejecting -> should bid
 	{false, models.NetworkConfig{Type: models.NetworkHost}, true}, // Network job, not rejecting -> should bid
+	{false, models.NetworkConfig{Type: models.NetworkFull}, true}, // Network job, not rejecting -> should bid
 	{true, models.NetworkConfig{Type: models.NetworkNone}, true},  // Local job, rejecting -> should bid
 	{true, models.NetworkConfig{Type: models.NetworkHost}, false}, // Network job, rejecting -> should not bid
+	{true, models.NetworkConfig{Type: models.NetworkFull}, false}, // Network job, rejecting -> should not bid
 }
 
 func TestNetworkingStrategy(t *testing.T) {

--- a/pkg/compute/port_allocator.go
+++ b/pkg/compute/port_allocator.go
@@ -53,7 +53,7 @@ func NewPortAllocator(start, end int) (PortAllocator, error) {
 // - The execution has invalid network configuration
 func (pa *portAllocator) AllocatePorts(execution *models.Execution) (models.PortMap, error) {
 	networkCfg := execution.Job.Task().Network
-	if networkCfg == nil || (networkCfg.Type != models.NetworkHost && networkCfg.Type != models.NetworkBridge) {
+	if networkCfg == nil || !networkCfg.Type.SupportPortAllocation() {
 		return models.PortMap{}, nil
 	}
 

--- a/pkg/executor/docker/network.go
+++ b/pkg/executor/docker/network.go
@@ -76,7 +76,7 @@ func (e *Executor) setupNetworkForJob(
 	case models.NetworkNone:
 		hostConfig.NetworkMode = dockerNetworkNone
 
-	case models.NetworkHost:
+	case models.NetworkHost, models.NetworkFull:
 		hostConfig.NetworkMode = dockerNetworkHost
 		hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, dockerHostAddCommand)
 		// In host mode, ports are directly accessible on the host network

--- a/pkg/models/network_string.go
+++ b/pkg/models/network_string.go
@@ -10,13 +10,14 @@ func _() {
 	var x [1]struct{}
 	_ = x[NetworkNone-0]
 	_ = x[NetworkHost-1]
-	_ = x[NetworkHTTP-2]
-	_ = x[NetworkBridge-3]
+	_ = x[NetworkFull-2]
+	_ = x[NetworkHTTP-3]
+	_ = x[NetworkBridge-4]
 }
 
-const _Network_name = "NoneHostHTTPBridge"
+const _Network_name = "NoneHostFullHTTPBridge"
 
-var _Network_index = [...]uint8{0, 4, 8, 12, 18}
+var _Network_index = [...]uint8{0, 4, 8, 12, 16, 22}
 
 func (i Network) String() string {
 	if i < 0 || i >= Network(len(_Network_index)-1) {

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -1886,11 +1886,13 @@ const docTemplate = `{
                 0,
                 1,
                 2,
-                3
+                3,
+                4
             ],
             "x-enum-varnames": [
                 "NetworkNone",
                 "NetworkHost",
+                "NetworkFull",
                 "NetworkHTTP",
                 "NetworkBridge"
             ]

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -1882,11 +1882,13 @@
                 0,
                 1,
                 2,
-                3
+                3,
+                4
             ],
             "x-enum-varnames": [
                 "NetworkNone",
                 "NetworkHost",
+                "NetworkFull",
                 "NetworkHTTP",
                 "NetworkBridge"
             ]

--- a/webui/lib/api/schema/swagger.json
+++ b/webui/lib/api/schema/swagger.json
@@ -1882,11 +1882,13 @@
                 0,
                 1,
                 2,
-                3
+                3,
+                4
             ],
             "x-enum-varnames": [
                 "NetworkNone",
                 "NetworkHost",
+                "NetworkFull",
                 "NetworkHTTP",
                 "NetworkBridge"
             ]


### PR DESCRIPTION
`Full` network type has been renamed to `Host` in a previous release. While the orchestrator maintained backward compatibility by still accepting `Full` network types and transforming them to `Host`, this broke older clients as they couldn't parse `Host` network type in the job response  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced network settings now support an additional mode that provides full host network capabilities, offering improved port accessibility.
  
- **Refactor**
  - Streamlined network configuration validation and processing to ensure consistent behavior across different network modes.

- **Tests**
  - Expanded test coverage to verify accurate handling of various network configurations under multiple scenarios, including new cases for `NetworkFull`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->