### PR TITLE
add docker image telemetry with privacy-first approach

### DIFF
--- a/pkg/analytics/executions_test.go
+++ b/pkg/analytics/executions_test.go
@@ -1,0 +1,150 @@
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExecutionsTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestExecutionsSuite(t *testing.T) {
+	suite.Run(t, new(ExecutionsTestSuite))
+}
+
+func (s *ExecutionsTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *ExecutionsTestSuite) createTestExecution() models.Execution {
+	return models.Execution{
+		ID:        "test-execution-id",
+		JobID:     "test-job-id",
+		EvalID:    "test-eval-id",
+		NodeID:    "test-node-id",
+		Namespace: "test-namespace",
+		AllocatedResources: &models.AllocatedResources{
+			Tasks: map[string]*models.Resources{
+				"test-task": {
+					CPU:    1.0,
+					Memory: 1024,
+					Disk:   2048,
+					GPU:    1,
+					GPUs: []models.GPU{
+						{Name: "test-gpu", Vendor: "test-vendor"},
+					},
+				},
+			},
+		},
+		DesiredState: models.State[models.ExecutionDesiredStateType]{
+			StateType: models.ExecutionDesiredStateRunning,
+			Details: map[string]string{
+				models.DetailsKeyErrorCode: "test-error",
+			},
+		},
+		ComputeState: models.State[models.ExecutionStateType]{
+			StateType: models.ExecutionStateRunning,
+			Message:   "test-message",
+			Details: map[string]string{
+				models.DetailsKeyErrorCode: "test-error",
+			},
+		},
+		PublishedResult: &models.SpecConfig{
+			Type: "test-publisher",
+		},
+		RunOutput: &models.RunCommandResult{
+			StdoutTruncated: true,
+			StderrTruncated: false,
+			ExitCode:        0,
+		},
+		PreviousExecution: "prev-execution",
+		NextExecution:     "next-execution",
+		FollowupEvalID:    "followup-eval",
+		Revision:          1,
+		CreateTime:        time.Now().UnixNano(),
+		ModifyTime:        time.Now().UnixNano(),
+	}
+}
+
+func (s *ExecutionsTestSuite) TestCreatedExecutionEvent() {
+	execution := s.createTestExecution()
+	event := NewCreatedExecutionEvent(execution)
+	s.Equal(CreatedExecutionEventType, event.Type)
+
+	eventData, ok := event.Properties.(ExecutionEvent)
+	s.True(ok, "Properties should be of type ExecutionEvent")
+
+	s.Equal("test-job-id", eventData.JobID)
+	s.Equal("test-execution-id", eventData.ExecutionID)
+	s.Equal("test-eval-id", eventData.EvalID)
+	s.Equal(hashString("test-node-id"), eventData.NodeNameHash)
+	s.Equal(hashString("test-namespace"), eventData.NamespaceHash)
+	s.Equal(models.ExecutionDesiredStateRunning.String(), eventData.DesiredState)
+	s.Equal("test-error", eventData.DesiredStateErrorCode)
+	s.Equal(models.ExecutionStateRunning.String(), eventData.ComputeState)
+	s.Equal("test-error", eventData.ComputeStateErrorCode)
+	s.Equal("test-publisher", eventData.PublishedResultType)
+	s.True(eventData.RunResultStdoutTruncated)
+	s.False(eventData.RunResultStderrTruncated)
+	s.Equal(0, eventData.RunResultExitCode)
+	s.Equal("prev-execution", eventData.PreviousExecution)
+	s.Equal("next-execution", eventData.NextExecution)
+	s.Equal("followup-eval", eventData.FollowupEvalID)
+}
+
+func (s *ExecutionsTestSuite) TestTerminalExecutionEvent() {
+	execution := s.createTestExecution()
+	event := NewTerminalExecutionEvent(execution)
+	s.Equal(TerminalExecutionEventType, event.Type)
+
+	eventData, ok := event.Properties.(ExecutionEvent)
+	s.True(ok, "Properties should be of type ExecutionEvent")
+
+	s.Equal("test-job-id", eventData.JobID)
+	s.Equal("test-execution-id", eventData.ExecutionID)
+	s.Equal("test-eval-id", eventData.EvalID)
+	s.Equal(hashString("test-node-id"), eventData.NodeNameHash)
+	s.Equal(hashString("test-namespace"), eventData.NamespaceHash)
+	s.Equal(models.ExecutionDesiredStateRunning.String(), eventData.DesiredState)
+	s.Equal("test-error", eventData.DesiredStateErrorCode)
+	s.Equal(models.ExecutionStateRunning.String(), eventData.ComputeState)
+	s.Equal("test-error", eventData.ComputeStateErrorCode)
+	s.Equal("test-publisher", eventData.PublishedResultType)
+	s.True(eventData.RunResultStdoutTruncated)
+	s.False(eventData.RunResultStderrTruncated)
+	s.Equal(0, eventData.RunResultExitCode)
+	s.Equal("prev-execution", eventData.PreviousExecution)
+	s.Equal("next-execution", eventData.NextExecution)
+	s.Equal("followup-eval", eventData.FollowupEvalID)
+}
+
+func (s *ExecutionsTestSuite) TestComputeMessageEvent() {
+	execution := models.Execution{
+		ID:    "test-execution-id",
+		JobID: "test-job-id",
+		ComputeState: models.State[models.ExecutionStateType]{
+			StateType: models.ExecutionStateRunning,
+			Message:   "test-message",
+			Details: map[string]string{
+				models.DetailsKeyErrorCode: "test-error",
+			},
+		},
+	}
+
+	event := NewComputeMessageExecutionEvent(execution)
+	s.Equal(ComputeMessageExecutionEventType, event.Type)
+
+	eventData, ok := event.Properties.(ExecutionComputeMessage)
+	s.True(ok, "Properties should be of type ExecutionComputeMessage")
+
+	s.Equal("test-job-id", eventData.JobID)
+	s.Equal("test-execution-id", eventData.ExecutionID)
+	s.Equal("test-message", eventData.ComputeMessage)
+	s.Equal("test-error", eventData.ComputeErrorCode)
+}

--- a/pkg/analytics/job_submit.go
+++ b/pkg/analytics/job_submit.go
@@ -32,6 +32,11 @@ type SubmitJobEvent struct {
 	TaskMetaCount        int      `json:"task_meta_count"`
 	TaskInputSourceTypes []string `json:"task_input_source_types"`
 	TaskResultPathCount  int      `json:"task_result_path_count"`
+	// TaskDockerImage captures Docker image information, only populated when TaskEngineType is "docker".
+	// For non-trusted images (not from bacalhau or expanso), the image name is hashed for privacy.
+	// TODO: Consider adding WASM module tracking in the future, but WASM modules are typically
+	// provided as input sources rather than referenced images.
+	TaskDockerImage string `json:"task_docker_image,omitempty"`
 
 	Resources Resource `json:"resources,omitempty"`
 
@@ -97,6 +102,7 @@ func NewSubmitJobEvent(j models.Job, warnings ...string) SubmitJobEvent {
 		TaskMetaCount:        len(t.Meta),
 		TaskInputSourceTypes: taskInputTypes,
 		TaskResultPathCount:  len(t.ResultPaths),
+		TaskDockerImage:      GetDockerImageTelemetry(t.Engine),
 		Resources:            resource,
 		TaskNetworkType:      t.Network.Type.String(),
 		TaskDomainsCount:     len(t.Network.Domains),

--- a/pkg/analytics/job_submit_test.go
+++ b/pkg/analytics/job_submit_test.go
@@ -1,0 +1,100 @@
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+)
+
+type JobSubmitTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestJobSubmitSuite(t *testing.T) {
+	suite.Run(t, new(JobSubmitTestSuite))
+}
+
+func (s *JobSubmitTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *JobSubmitTestSuite) createTestJob() models.Job {
+	return models.Job{
+		ID:         "test-job-id",
+		Name:       "test-job",
+		Namespace:  "test-namespace",
+		Type:       "test-type",
+		Count:      1,
+		Labels:     map[string]string{"key": "value"},
+		Meta:       map[string]string{"meta": "value"},
+		Version:    1,
+		Revision:   1,
+		CreateTime: time.Now().UnixNano(),
+		ModifyTime: time.Now().UnixNano(),
+		Tasks: []*models.Task{
+			{
+				Name: "test-task",
+				Engine: &models.SpecConfig{
+					Type: models.EngineDocker,
+					Params: map[string]interface{}{
+						"Image": "ghcr.io/bacalhau-project/test:latest",
+					},
+				},
+				Publisher: &models.SpecConfig{
+					Type: "test-publisher",
+				},
+				Env: map[string]models.EnvVarValue{
+					"ENV": "test",
+				},
+				Meta: map[string]string{"task-meta": "value"},
+				InputSources: []*models.InputSource{
+					{Source: &models.SpecConfig{Type: "test-source"}},
+				},
+				ResultPaths: []*models.ResultPath{
+					{Name: "result1"},
+					{Name: "result2"},
+				},
+				Network: &models.NetworkConfig{
+					Type:    models.NetworkHTTP,
+					Domains: []string{"test.com"},
+				},
+				Timeouts: &models.TimeoutConfig{
+					ExecutionTimeout: 3600,
+					QueueTimeout:     1800,
+					TotalTimeout:     7200,
+				},
+			},
+		},
+	}
+}
+
+func (s *JobSubmitTestSuite) TestSubmitJobEvent() {
+	job := s.createTestJob()
+	event := NewSubmitJobEvent(job)
+
+	s.Equal("test-job-id", event.JobID)
+	s.True(event.NameSet)
+	s.Equal(hashString("test-namespace"), event.NamespaceHash)
+	s.Equal("test-type", event.Type)
+	s.Equal(1, event.Count)
+	s.Equal(1, event.LabelsCount)
+	s.Equal(1, event.MetaCount)
+	s.Equal(hashString("test-task"), event.TaskNameHash)
+	s.Equal(models.EngineDocker, event.TaskEngineType)
+	s.Equal("test-publisher", event.TaskPublisherType)
+	s.Equal(1, event.TaskEnvVarCount)
+	s.Equal(1, event.TaskMetaCount)
+	s.Equal([]string{"test-source"}, event.TaskInputSourceTypes)
+	s.Equal(2, event.TaskResultPathCount)
+	s.Equal("ghcr.io/bacalhau-project/test:latest", event.TaskDockerImage)
+	s.Equal(models.NetworkHTTP.String(), event.TaskNetworkType)
+	s.Equal(1, event.TaskDomainsCount)
+	s.Equal(int64(3600), event.TaskExecutionTimeout)
+	s.Equal(int64(1800), event.TaskQueueTimeout)
+	s.Equal(int64(7200), event.TaskTotalTimeout)
+}

--- a/pkg/analytics/job_terminal.go
+++ b/pkg/analytics/job_terminal.go
@@ -34,6 +34,9 @@ type JobTerminalEvent struct {
 	TaskMetaCount        int      `json:"task_meta_count"`
 	TaskInputSourceTypes []string `json:"task_input_source_types"`
 	TaskResultPathCount  int      `json:"task_result_path_count"`
+	// TaskDockerImage captures Docker image information, only populated when TaskEngineType is "docker".
+	// For non-trusted images (not from bacalhau or expanso), the image name is hashed for privacy.
+	TaskDockerImage string `json:"task_docker_image,omitempty"`
 
 	Resources Resource `json:"resources,omitempty"`
 
@@ -97,6 +100,7 @@ func NewJobTerminalEvent(j models.Job) *Event {
 		TaskMetaCount:        len(t.Meta),
 		TaskInputSourceTypes: taskInputTypes,
 		TaskResultPathCount:  len(t.ResultPaths),
+		TaskDockerImage:      GetDockerImageTelemetry(t.Engine),
 		Resources:            resource,
 		TaskNetworkType:      t.Network.Type.String(),
 		TaskDomainsCount:     len(t.Network.Domains),

--- a/pkg/analytics/job_terminal_test.go
+++ b/pkg/analytics/job_terminal_test.go
@@ -1,0 +1,106 @@
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+)
+
+type JobTerminalTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestJobTerminalSuite(t *testing.T) {
+	suite.Run(t, new(JobTerminalTestSuite))
+}
+
+func (s *JobTerminalTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *JobTerminalTestSuite) createTestJob() models.Job {
+	return models.Job{
+		ID:         "test-job-id",
+		Name:       "test-job",
+		Namespace:  "test-namespace",
+		Type:       "test-type",
+		Count:      1,
+		Labels:     map[string]string{"key": "value"},
+		Meta:       map[string]string{"meta": "value"},
+		Version:    1,
+		Revision:   1,
+		CreateTime: time.Now().UnixNano(),
+		ModifyTime: time.Now().UnixNano(),
+		Tasks: []*models.Task{
+			{
+				Name: "test-task",
+				Engine: &models.SpecConfig{
+					Type: models.EngineDocker,
+					Params: map[string]interface{}{
+						"Image": "ghcr.io/bacalhau-project/test:latest",
+					},
+				},
+				Publisher: &models.SpecConfig{
+					Type: "test-publisher",
+				},
+				Env: map[string]models.EnvVarValue{
+					"ENV": "test",
+				},
+				Meta: map[string]string{"task-meta": "value"},
+				InputSources: []*models.InputSource{
+					{Source: &models.SpecConfig{Type: "test-source"}},
+				},
+				ResultPaths: []*models.ResultPath{
+					{Name: "result1"},
+					{Name: "result2"},
+				},
+				Network: &models.NetworkConfig{
+					Type:    models.NetworkHTTP,
+					Domains: []string{"test.com"},
+				},
+				Timeouts: &models.TimeoutConfig{
+					ExecutionTimeout: 3600,
+					QueueTimeout:     1800,
+					TotalTimeout:     7200,
+				},
+			},
+		},
+	}
+}
+
+func (s *JobTerminalTestSuite) TestJobTerminalEvent() {
+	job := s.createTestJob()
+	job.State = models.NewJobState(models.JobStateTypeCompleted)
+
+	event := NewJobTerminalEvent(job)
+
+	eventData, ok := event.Properties.(JobTerminalEvent)
+	s.True(ok, "Properties should be of type JobTerminalEvent")
+
+	s.Equal("test-job-id", eventData.JobID)
+	s.True(eventData.NameSet)
+	s.Equal(hashString("test-namespace"), eventData.NamespaceHash)
+	s.Equal("test-type", eventData.Type)
+	s.Equal(1, eventData.Count)
+	s.Equal(1, eventData.LabelsCount)
+	s.Equal(1, eventData.MetaCount)
+	s.Equal(models.JobStateTypeCompleted.String(), eventData.State)
+	s.Equal(hashString("test-task"), eventData.TaskNameHash)
+	s.Equal(models.EngineDocker, eventData.TaskEngineType)
+	s.Equal("test-publisher", eventData.TaskPublisherType)
+	s.Equal(1, eventData.TaskEnvVarCount)
+	s.Equal(1, eventData.TaskMetaCount)
+	s.Equal([]string{"test-source"}, eventData.TaskInputSourceTypes)
+	s.Equal(2, eventData.TaskResultPathCount)
+	s.Equal("ghcr.io/bacalhau-project/test:latest", eventData.TaskDockerImage)
+	s.Equal(models.NetworkHTTP.String(), eventData.TaskNetworkType)
+	s.Equal(1, eventData.TaskDomainsCount)
+	s.Equal(int64(3600), eventData.TaskExecutionTimeout)
+	s.Equal(int64(1800), eventData.TaskQueueTimeout)
+	s.Equal(int64(7200), eventData.TaskTotalTimeout)
+}

--- a/pkg/analytics/models.go
+++ b/pkg/analytics/models.go
@@ -1,8 +1,6 @@
 package analytics
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"time"
 
@@ -40,10 +38,4 @@ func (e *Event) ToLogRecord() (otellog.Record, error) {
 	record.SetTimestamp(time.Now().UTC())
 	record.SetBody(otellog.StringValue(""))
 	return record, nil
-}
-
-func hashString(in string) string {
-	hash := sha256.New()
-	hash.Write([]byte(in))
-	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/pkg/analytics/models_test.go
+++ b/pkg/analytics/models_test.go
@@ -1,0 +1,103 @@
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.opentelemetry.io/otel/log"
+)
+
+type ModelsTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestModelsSuite(t *testing.T) {
+	suite.Run(t, new(ModelsTestSuite))
+}
+
+func (s *ModelsTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *ModelsTestSuite) TestEventCreation() {
+	// Test basic event creation
+	event := NewEvent("test.event", map[string]string{"key": "value"})
+	s.Equal("test.event", event.Type)
+	s.Equal(map[string]string{"key": "value"}, event.Properties)
+
+	// Test event to log record conversion
+	record, err := event.ToLogRecord()
+	s.NoError(err)
+	s.NotEmpty(record)
+
+	// Walk through attributes and verify they exist
+	attributes := make(map[string]string)
+	record.WalkAttributes(func(kv log.KeyValue) bool {
+		attributes[kv.Key] = kv.Value.AsString()
+		return true
+	})
+
+	s.Equal("test.event", attributes["event"])
+	s.Equal(`{"key":"value"}`, attributes["properties"])
+}
+
+func (s *ModelsTestSuite) TestEventToLogRecord() {
+	testCases := []struct {
+		name          string
+		event         *Event
+		expectedType  string
+		expectedProps string
+	}{
+		{
+			name:          "empty event",
+			event:         NewEvent("test.event", nil),
+			expectedType:  "test.event",
+			expectedProps: "null",
+		},
+		{
+			name:          "simple event",
+			event:         NewEvent("test.event", map[string]string{"key": "value"}),
+			expectedType:  "test.event",
+			expectedProps: `{"key":"value"}`,
+		},
+		{
+			name:          "complex event",
+			event:         NewEvent("test.event", map[string]interface{}{"key": 123, "nested": map[string]string{"foo": "bar"}}),
+			expectedType:  "test.event",
+			expectedProps: `{"key":123,"nested":{"foo":"bar"}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			record, err := tc.event.ToLogRecord()
+			s.NoError(err)
+			s.NotEmpty(record)
+
+			// Walk through attributes and verify they exist
+			attributes := make(map[string]string)
+			record.WalkAttributes(func(kv log.KeyValue) bool {
+				attributes[kv.Key] = kv.Value.AsString()
+				return true
+			})
+
+			s.Equal(tc.expectedType, attributes["event"])
+			s.Equal(tc.expectedProps, attributes["properties"])
+		})
+	}
+}
+
+func (s *ModelsTestSuite) TestEventTimestamp() {
+	event := NewEvent("test.event", map[string]string{"key": "value"})
+	record, err := event.ToLogRecord()
+	s.NoError(err)
+	s.NotEmpty(record)
+
+	// Check that timestamp is recent
+	timestamp := record.Timestamp()
+	s.True(timestamp.After(time.Now().Add(-time.Second)))
+	s.True(timestamp.Before(time.Now().Add(time.Second)))
+}

--- a/pkg/analytics/utils.go
+++ b/pkg/analytics/utils.go
@@ -1,0 +1,65 @@
+package analytics
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+)
+
+// GetDockerImageTelemetry returns the Docker image name for telemetry purposes.
+// For trusted images (from Bacalhau or Expanso), it returns the original image name.
+// For non-trusted images, it returns a hashed version of the image name for privacy.
+// Returns an empty string if the engine is not Docker or no image information is found.
+func GetDockerImageTelemetry(engineParams *models.SpecConfig) string {
+	// Only process Docker engines
+	if engineParams == nil || engineParams.Type != models.EngineDocker {
+		return ""
+	}
+
+	// Try both "Image" and "image" keys
+	imageParam, ok := engineParams.Params["Image"]
+	if !ok {
+		imageParam, ok = engineParams.Params["image"]
+		if !ok {
+			return ""
+		}
+	}
+
+	// Convert to string (should always be a string but handle just in case)
+	imageName, ok := imageParam.(string)
+	if !ok || imageName == "" {
+		return ""
+	}
+
+	// Check if image is from a trusted source (Bacalhau or Expanso)
+	trusted := false
+	trustedPrefixes := []string{
+		"ghcr.io/bacalhau-project/",
+		"expanso/",
+		"bacalhauproject/",
+	}
+
+	for _, prefix := range trustedPrefixes {
+		if strings.HasPrefix(strings.ToLower(imageName), strings.ToLower(prefix)) {
+			trusted = true
+			break
+		}
+	}
+
+	if trusted {
+		return imageName
+	} else {
+		// For non-trusted images, hash the image name for privacy
+		return hashString(imageName)
+	}
+}
+
+// hashString creates a SHA-256 hash of the input string and returns its hexadecimal representation.
+// Used for privacy-preserving analytics.
+func hashString(in string) string {
+	hash := sha256.New()
+	hash.Write([]byte(in))
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/pkg/analytics/utils_test.go
+++ b/pkg/analytics/utils_test.go
@@ -1,0 +1,149 @@
+package analytics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type UtilsTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestUtilsSuite(t *testing.T) {
+	suite.Run(t, new(UtilsTestSuite))
+}
+
+func (s *UtilsTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *UtilsTestSuite) TestHashString() {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:     "simple string",
+			input:    "test",
+			expected: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		},
+		{
+			name:     "complex string",
+			input:    "hello world",
+			expected: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			result := hashString(tc.input)
+			s.Equal(tc.expected, result)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestGetDockerImageTelemetry() {
+	testCases := []struct {
+		name     string
+		engine   *models.SpecConfig
+		expected string
+	}{
+		{
+			name:     "nil engine",
+			engine:   nil,
+			expected: "",
+		},
+		{
+			name: "non-docker engine",
+			engine: &models.SpecConfig{
+				Type: "wasm",
+			},
+			expected: "",
+		},
+		{
+			name: "docker engine with no image",
+			engine: &models.SpecConfig{
+				Type:   models.EngineDocker,
+				Params: map[string]interface{}{},
+			},
+			expected: "",
+		},
+		{
+			name: "trusted bacalhau image with Image key",
+			engine: &models.SpecConfig{
+				Type: models.EngineDocker,
+				Params: map[string]interface{}{
+					"Image": "ghcr.io/bacalhau-project/test:latest",
+				},
+			},
+			expected: "ghcr.io/bacalhau-project/test:latest",
+		},
+		{
+			name: "trusted bacalhau image with image key",
+			engine: &models.SpecConfig{
+				Type: models.EngineDocker,
+				Params: map[string]interface{}{
+					"image": "ghcr.io/bacalhau-project/test:latest",
+				},
+			},
+			expected: "ghcr.io/bacalhau-project/test:latest",
+		},
+		{
+			name: "trusted expanso image with Image key",
+			engine: &models.SpecConfig{
+				Type: models.EngineDocker,
+				Params: map[string]interface{}{
+					"Image": "expanso/test:latest",
+				},
+			},
+			expected: "expanso/test:latest",
+		},
+		{
+			name: "trusted expanso image with image key",
+			engine: &models.SpecConfig{
+				Type: models.EngineDocker,
+				Params: map[string]interface{}{
+					"image": "expanso/test:latest",
+				},
+			},
+			expected: "expanso/test:latest",
+		},
+		{
+			name: "non-trusted image with Image key",
+			engine: &models.SpecConfig{
+				Type: models.EngineDocker,
+				Params: map[string]interface{}{
+					"Image": "docker.io/random/image:latest",
+				},
+			},
+			expected: hashString("docker.io/random/image:latest"),
+		},
+		{
+			name: "non-trusted image with image key",
+			engine: &models.SpecConfig{
+				Type: models.EngineDocker,
+				Params: map[string]interface{}{
+					"image": "docker.io/random/image:latest",
+				},
+			},
+			expected: hashString("docker.io/random/image:latest"),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			result := GetDockerImageTelemetry(tc.engine)
+			s.Equal(tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description  
This PR adds privacy-first Docker image telemetry. We track only Bacalhau and Expanso images while hashing all others to protect user privacy.  

### Key Features  
- Tracks Docker images in job submissions  
- Preserves names only for Bacalhau and Expanso images  
- Hashes all other image names using SHA-256  

### Tracked Image Sources  
Only these image prefixes are preserved:  
- `ghcr.io/bacalhau-project/`  
- `expanso/`  
- `bacalhauproject/`  

All others are hashed.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced analytics events now include Docker image telemetry for job submissions and completions. Trusted image names are displayed directly, while non‑trusted ones are anonymized to protect sensitive details.
- **Refactor**
  - Streamlined event processing to improve the consistency and reliability of analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->