### PR TITLE
run devstack with default ports

### DIFF
--- a/cmd/cli/devstack/devstack.go
+++ b/cmd/cli/devstack/devstack.go
@@ -54,6 +54,7 @@ type options struct {
 	CPUProfilingFile    string
 	MemoryProfilingFile string
 	BasePath            string
+	RandomPorts         bool // Use random ports for the nodes. Useful to avoid conflicts with active orchestrators
 }
 
 func (o *options) devstackOptions() []devstack.ConfigOption {
@@ -65,6 +66,7 @@ func (o *options) devstackOptions() []devstack.ConfigOption {
 		devstack.WithCPUProfilingFile(o.CPUProfilingFile),
 		devstack.WithMemoryProfilingFile(o.MemoryProfilingFile),
 		devstack.WithBasePath(o.BasePath),
+		devstack.WithUseStandardPorts(!o.RandomPorts),
 	}
 	return opts
 }
@@ -163,6 +165,11 @@ func NewCmd() *cobra.Command {
 	devstackCmd.PersistentFlags().StringVar(
 		&ODs.BasePath, "stack-repo", ODs.BasePath,
 		"Folder to act as the devstack configuration repo",
+	)
+
+	devstackCmd.PersistentFlags().BoolVar(&ODs.RandomPorts, "random-ports", ODs.RandomPorts,
+		"Use random ports for the nodes. Otherwise will start with standard ports (e.g. 1234). "+
+			"Useful to avoid conflicts with active orchestrators",
 	)
 
 	return devstackCmd

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -142,11 +142,9 @@ var Default = types.Bacalhau{
 
 var testOverrides = types.Bacalhau{
 	API: types.API{
-		Port: -1,
 		Auth: types.AuthConfig{},
 	},
 	Orchestrator: types.Orchestrator{
-		Port: -1,
 		NodeManager: types.NodeManager{
 			DisconnectTimeout: types.Duration(30 * time.Second),
 		},
@@ -170,9 +168,7 @@ var testOverrides = types.Bacalhau{
 	},
 	Publishers: types.PublishersConfig{
 		Types: types.PublisherTypes{
-			Local: types.LocalPublisher{
-				Port: -1,
-			},
+			Local: types.LocalPublisher{},
 		},
 	},
 	Logging: types.Logging{

--- a/pkg/devstack/devstack.go
+++ b/pkg/devstack/devstack.go
@@ -76,24 +76,12 @@ func Setup(
 		log.Ctx(ctx).Debug().Msgf(`Creating Node #%d as {RequesterNode: %t, ComputeNode: %t}`, i+1, isRequesterNode, isComputeNode)
 
 		if isRequesterNode {
-			if os.Getenv("PREDICTABLE_API_PORT") != "" {
-				cfg.Orchestrator.Port = 4222 + i
+			if stackConfig.UseStandardPorts {
+				cfg.Orchestrator.Port = cfg.Orchestrator.Port + i
 			} else {
 				if cfg.Orchestrator.Port, err = network.GetFreePort(); err != nil {
 					return nil, errors.Wrap(err, "failed to get free port for nats server")
 				}
-			}
-
-			if os.Getenv("PREDICTABLE_API_PORT") != "" {
-				cfg.Orchestrator.Cluster.Port = 6222 + i
-			} else {
-				if cfg.Orchestrator.Cluster.Port, err = network.GetFreePort(); err != nil {
-					return nil, errors.Wrap(err, "failed to get free port for nats cluster")
-				}
-			}
-
-			if cfg.Orchestrator.Cluster.Name == "" {
-				cfg.Orchestrator.Cluster.Name = "devstack"
 			}
 			cfg.Compute.Orchestrators = append(cfg.Compute.Orchestrators, fmt.Sprintf("127.0.0.1:%d", cfg.Orchestrator.Port))
 		}
@@ -101,8 +89,8 @@ func Setup(
 		// ////////////////////////////////////
 		// port for API
 		// ////////////////////////////////////
-		if os.Getenv("PREDICTABLE_API_PORT") != "" {
-			cfg.API.Port = 1234 + i
+		if stackConfig.UseStandardPorts {
+			cfg.API.Port = cfg.API.Port + i
 			// add one more if using an external orchestrator to avoid port conflict
 			if requesterNodeCount == 0 {
 				cfg.API.Port += 1

--- a/pkg/devstack/option.go
+++ b/pkg/devstack/option.go
@@ -3,6 +3,7 @@ package devstack
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/rs/zerolog"
 
@@ -19,11 +20,14 @@ func defaultDevStackConfig() (*DevStackConfig, error) {
 		return nil, err
 	}
 
+	useStandardPorts := os.Getenv("PREDICTABLE_API_PORT") != ""
+
 	return &DevStackConfig{
 		BacalhauConfig:         bacalhauConfig,
 		SystemConfig:           node.TestSystemConfig(),
 		NodeDependencyInjector: node.NodeDependencyInjector{},
 		NodeOverrides:          nil,
+		UseStandardPorts:       useStandardPorts,
 
 		NumberOfRequesterOnlyNodes: 1,
 		NumberOfComputeOnlyNodes:   3,
@@ -44,6 +48,7 @@ type DevStackConfig struct {
 	SystemConfig           node.SystemConfig
 	NodeDependencyInjector node.NodeDependencyInjector
 	NodeOverrides          []node.NodeConfig
+	UseStandardPorts       bool // if true, use the standard ports (e.g. 1234) for the services, otherwise random ports
 
 	// DevStackOptions
 	NumberOfHybridNodes        int // Number of nodes to start in the cluster
@@ -192,5 +197,12 @@ func WithSelfSignedCertificate(cert string, key string) ConfigOption {
 	return func(cfg *DevStackConfig) {
 		cfg.BacalhauConfig.API.TLS.CertFile = cert
 		cfg.BacalhauConfig.API.TLS.KeyFile = key
+	}
+}
+
+// WithUseStandardPorts sets the standard ports for the services
+func WithUseStandardPorts(standardPorts bool) ConfigOption {
+	return func(cfg *DevStackConfig) {
+		cfg.UseStandardPorts = standardPorts
 	}
 }


### PR DESCRIPTION
This PR implements a significant UX improvement for the development workflow by allowing the devstack orchestrator to use a default port instead of randomly assigned ports.

## What's Changing

- Added default port assignment for the orchestrator in devstack mode
- Introduced `--random-ports` flag for cases where random port assignment is preferred
- Maintained compatibility with existing port configuration methods:
  - `--api-port=<port>` flag
  - `-c API.Port=<port>` configuration option

## Why This Matters

Previously, the orchestrator and compute nodes would get randomly assigned ports on startup, with these ports only being printed to stdout. This required developers to manually set the API host and port as environment variables in the client to establish connections, which needed to be done for every new session.

With this change, the orchestrator now uses a default port that allows clients to connect automatically without additional configuration, significantly streamlining the development process.

## Usage Examples

Default behavior (uses default port: 1234):
```
bacalhau devstack
```

For custom port assignment:
```
bacalhau devstack --api-port=2222
bacalhau devstack -c api.port=2222
```

For the previous random port behavior:
```
bacalhau devstack --random-ports
```