### PR TITLE
Redact sensitive info from agent config command

### DIFF
--- a/pkg/publicapi/endpoint/agent/endpoint.go
+++ b/pkg/publicapi/endpoint/agent/endpoint.go
@@ -135,18 +135,12 @@ func (e *Endpoint) debug(c echo.Context) error {
 //	@Failure	500	{object}	string
 //	@Router		/api/v1/agent/config [get]
 func (e *Endpoint) config(c echo.Context) error {
-	cfg, err := e.bacalhauConfig.Copy()
+	clonedRedactedConfig, err := redactConfigSensitiveInfo(e.bacalhauConfig)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("could not copy bacalhau config: %s", err))
 	}
-	if cfg.Compute.Auth.Token != "" {
-		cfg.Compute.Auth.Token = "<redacted>"
-	}
-	if cfg.Orchestrator.Auth.Token != "" {
-		cfg.Orchestrator.Auth.Token = "<redacted>"
-	}
 	return c.JSON(http.StatusOK, apimodels.GetAgentConfigResponse{
-		Config: cfg,
+		Config: clonedRedactedConfig,
 	})
 }
 
@@ -183,12 +177,9 @@ func (e *Endpoint) license(c echo.Context) error {
 //	@Failure	500	{object}	string
 //	@Router		/api/v1/agent/authconfig [get]
 func (e *Endpoint) nodeAuthConfig(c echo.Context) error {
-	cfg, err := e.bacalhauConfig.Copy()
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error getting node oauth2 config: %s", err))
-	}
+	// No need to redact Oauth2 config since these are made to be public
 	return c.JSON(http.StatusOK, apimodels.GetAgentNodeAuthConfigResponse{
 		Version: "1.0.0",
-		Config:  cfg.API.Auth.Oauth2,
+		Config:  e.bacalhauConfig.API.Auth.Oauth2,
 	})
 }

--- a/pkg/publicapi/endpoint/agent/endpoint_test.go
+++ b/pkg/publicapi/endpoint/agent/endpoint_test.go
@@ -62,8 +62,8 @@ func TestEndpointConfigRedactFields(t *testing.T) {
 	var payload apimodels.GetAgentConfigResponse
 	err = json.NewDecoder(rr.Body).Decode(&payload)
 	require.NoError(t, err)
-	assert.Equal(t, payload.Config.Orchestrator.Auth.Token, "<redacted>")
-	assert.Equal(t, payload.Config.Compute.Auth.Token, "<redacted>")
+	assert.Equal(t, payload.Config.Orchestrator.Auth.Token, "********")
+	assert.Equal(t, payload.Config.Compute.Auth.Token, "********")
 }
 
 // TestEndpointLicenseValid tests the license endpoint when a valid license is configured

--- a/pkg/publicapi/endpoint/agent/util.go
+++ b/pkg/publicapi/endpoint/agent/util.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+)
+
+// RedactSensitiveInfo redacts sensitive information from the auth config
+func redactConfigSensitiveInfo(config types.Bacalhau) (types.Bacalhau, error) {
+	deepCopyOfConfig, err := config.Copy()
+	if err != nil {
+		return types.Bacalhau{}, err
+	}
+
+	if deepCopyOfConfig.Compute.Auth.Token != "" {
+		deepCopyOfConfig.Compute.Auth.Token = "********"
+	}
+	if deepCopyOfConfig.Orchestrator.Auth.Token != "" {
+		deepCopyOfConfig.Orchestrator.Auth.Token = "********"
+	}
+
+	// Redact user passwords and API keys
+	for userIdx := range deepCopyOfConfig.API.Auth.Users {
+		user := &deepCopyOfConfig.API.Auth.Users[userIdx]
+		if user.Password != "" {
+			user.Password = "********"
+		}
+		if user.APIKey != "" {
+			user.APIKey = "********"
+		}
+	}
+
+	return deepCopyOfConfig, nil
+}

--- a/pkg/publicapi/endpoint/agent/util.go
+++ b/pkg/publicapi/endpoint/agent/util.go
@@ -11,21 +11,22 @@ func redactConfigSensitiveInfo(config types.Bacalhau) (types.Bacalhau, error) {
 		return types.Bacalhau{}, err
 	}
 
+	const redactedMask = "********"
 	if deepCopyOfConfig.Compute.Auth.Token != "" {
-		deepCopyOfConfig.Compute.Auth.Token = "********"
+		deepCopyOfConfig.Compute.Auth.Token = redactedMask
 	}
 	if deepCopyOfConfig.Orchestrator.Auth.Token != "" {
-		deepCopyOfConfig.Orchestrator.Auth.Token = "********"
+		deepCopyOfConfig.Orchestrator.Auth.Token = redactedMask
 	}
 
 	// Redact user passwords and API keys
 	for userIdx := range deepCopyOfConfig.API.Auth.Users {
 		user := &deepCopyOfConfig.API.Auth.Users[userIdx]
 		if user.Password != "" {
-			user.Password = "********"
+			user.Password = redactedMask
 		}
 		if user.APIKey != "" {
-			user.APIKey = "********"
+			user.APIKey = redactedMask
 		}
 	}
 

--- a/pkg/publicapi/endpoint/agent/util_test.go
+++ b/pkg/publicapi/endpoint/agent/util_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactConfigSensitiveInfo(t *testing.T) {
+	originalConfig := types.Bacalhau{
+		API: types.API{
+			Auth: types.AuthConfig{
+				Users: []types.AuthUser{
+					{
+						Username: "testuser",
+						Password: "secretpassword",
+						APIKey:   "secretapikey",
+						Alias:    "testalias",
+						Capabilities: []types.Capability{
+							{Actions: []string{"read", "write"}},
+						},
+					},
+					{
+						Username: "user2",
+						Password: "",
+						APIKey:   "anotherapikey",
+					},
+				},
+			},
+		},
+	}
+
+	redactedConfig, err := redactConfigSensitiveInfo(originalConfig)
+	require.NoError(t, err)
+
+	// Verify sensitive information is redacted
+	require.Equal(t, "********", redactedConfig.API.Auth.Users[0].Password)
+	require.Equal(t, "********", redactedConfig.API.Auth.Users[0].APIKey)
+	require.Equal(t, "********", redactedConfig.API.Auth.Users[1].APIKey)
+
+	// Verify non-sensitive information remains unchanged
+	require.Equal(t, "testuser", redactedConfig.API.Auth.Users[0].Username)
+	require.Equal(t, "testalias", redactedConfig.API.Auth.Users[0].Alias)
+	require.Equal(t, []string{"read", "write"}, redactedConfig.API.Auth.Users[0].Capabilities[0].Actions)
+
+	// Verify empty values remain empty
+	require.Empty(t, redactedConfig.API.Auth.Users[1].Password)
+
+	// Verify original config is not modified
+	require.Equal(t, "secretpassword", originalConfig.API.Auth.Users[0].Password)
+	require.Equal(t, "secretapikey", originalConfig.API.Auth.Users[0].APIKey)
+	require.Equal(t, "anotherapikey", originalConfig.API.Auth.Users[1].APIKey)
+}

--- a/test_integration/17_basic_auth_config_suite_test.go
+++ b/test_integration/17_basic_auth_config_suite_test.go
@@ -149,6 +149,31 @@ func (s *BasicAuthConfigSuite) TestCommandsBypassingAuthentication() {
 	s.Require().Contains(result, "SERVER")
 }
 
+func (s *BasicAuthConfigSuite) TestConfigRedactedContent() {
+	// Auth Info
+	result, err := s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "agent", "config"},
+		exec.WithEnv([]string{
+			"BACALHAU_API_USERNAME=snoopyusername",
+			"BACALHAU_API_PASSWORD=snoopypassword",
+		}),
+	)
+
+	s.Require().NoError(err)
+
+	redactedPasswordsCount := strings.Count(result, "Password: '********'")
+	redactedAPIKeysCount := strings.Count(result, "APIKey: '********'")
+	redactedAuthTokenCount := strings.Count(result, "Token: '********'")
+	s.Require().Equal(2, redactedPasswordsCount)
+	s.Require().Equal(2, redactedAPIKeysCount)
+	s.Require().Equal(1, redactedAuthTokenCount)
+
+	s.Require().NotContains(result, "snoopypassword", result)
+	s.Require().NotContains(result, "readonlyuserpassword", result)
+	s.Require().NotContains(result, "P7D4CBB284634DD081FAC33868436ECCL", result)
+	s.Require().NotContains(result, "QWERTYHFGCBNSKFIREHFURHUFE7KEEFBN", result)
+	s.Require().NotContains(result, "i_am_very_secret_token", result)
+}
 func TestBasicAuthConfigSuite(t *testing.T) {
 	suite.Run(t, NewBasicAuthConfigSuite())
 }


### PR DESCRIPTION
## What does this PR do?
Improves the redaction of sensitive information in the config endpoint by:
- Adding redaction for node auth tokens
- Adding comprehensive tests for all redaction scenarios
- Ensuring original config is not modified via deep copy

## Testing
Added test cases to verify:
- User passwords and API keys are redacted
- Node auth tokens are redacted
- Empty values remain empty
- Non-sensitive information is preserved
- Original config remains unmodified

Linear: https://linear.app/expanso/issue/ENG-709/redact-auth-configs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration responses now securely mask sensitive credentials, ensuring that only public details are displayed.

- **Refactor**
  - Streamlined processes for handling configuration details improve consistency by centralizing sensitive data redaction.

- **Tests**
  - Expanded and updated tests verify that sensitive tokens, passwords, and keys are uniformly masked, reinforcing robust security in configuration outputs.
  - New test added to ensure sensitive information is not present in command outputs for configuration commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->