### PR TITLE
Modify auth sso login syntax and add logout command

### DIFF
--- a/cmd/cli/auth/root.go
+++ b/cmd/cli/auth/root.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"github.com/bacalhau-project/bacalhau/cmd/cli/auth/sso"
 	"github.com/bacalhau-project/bacalhau/cmd/util/hook"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,7 @@ func NewCmd() *cobra.Command {
 		PersistentPostRunE: hook.AfterParentPostRunHook(hook.RemoteCmdPostRunHooks),
 	}
 
-	cmd.AddCommand(NewSSOCmd())
+	cmd.AddCommand(sso.NewSSORootCmd())
 	cmd.AddCommand(NewHashPasswordCmd())
 	cmd.AddCommand(NewInfoCmd())
 	return cmd

--- a/cmd/cli/auth/sso/login.go
+++ b/cmd/cli/auth/sso/login.go
@@ -1,4 +1,4 @@
-package auth
+package sso
 
 import (
 	"context"
@@ -23,23 +23,23 @@ import (
 const errorHint = "Please rerun command with DEBUG LOG_LEVEL for more details"
 
 // SSOOptions is a struct to support node command
-type SSOOptions struct {
+type SSOLoginOptions struct {
 	OutputOpts    output.NonTabularOutputOptions
 	ShowAuthToken bool
 }
 
-// NewSSOOptions returns initialized Options
-func NewSSOOptions() *SSOOptions {
-	return &SSOOptions{
+// NewSSOLoginOptions returns initialized Options
+func NewSSOLoginOptions() *SSOLoginOptions {
+	return &SSOLoginOptions{
 		OutputOpts:    output.NonTabularOutputOptions{Format: output.YAMLFormat},
 		ShowAuthToken: false,
 	}
 }
 
-func NewSSOCmd() *cobra.Command {
-	o := NewSSOOptions()
+func NewSSOLoginCmd() *cobra.Command {
+	o := NewSSOLoginOptions()
 	nodeCmd := &cobra.Command{
-		Use:   "sso",
+		Use:   "login",
 		Short: "Login using SSO",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -57,7 +57,7 @@ func NewSSOCmd() *cobra.Command {
 				return bacerrors.New("failed to initialize API call").
 					WithHint(errorHint)
 			}
-			return o.runSSO(cmd, api, cfg)
+			return o.runSSOLogin(cmd, api, cfg)
 		},
 	}
 	nodeCmd.Flags().AddFlagSet(cliflags.OutputNonTabularFormatFlags(&o.OutputOpts))
@@ -66,7 +66,7 @@ func NewSSOCmd() *cobra.Command {
 }
 
 // Run executes node command
-func (o *SSOOptions) runSSO(cmd *cobra.Command, api client.API, cfg types.Bacalhau) error {
+func (o *SSOLoginOptions) runSSOLogin(cmd *cobra.Command, api client.API, cfg types.Bacalhau) error {
 	ctx := cmd.Context()
 
 	apiURL, urlScheme := util.ConstructAPIEndpoint(cfg.API)

--- a/cmd/cli/auth/sso/login_test.go
+++ b/cmd/cli/auth/sso/login_test.go
@@ -1,4 +1,4 @@
-package auth
+package sso
 
 import (
 	"bytes"
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewSSOCmd tests the creation of the SSO command
-func TestNewSSOCmd(t *testing.T) {
-	cmd := NewSSOCmd()
+// TestNewSSOLoginCmd tests the creation of the SSO command
+func TestNewSSOLoginCmd(t *testing.T) {
+	cmd := NewSSOLoginCmd()
 
 	assert.NotNil(t, cmd, "Command should not be nil")
-	assert.Equal(t, "sso", cmd.Use, "Command use should be 'sso'")
+	assert.Equal(t, "login", cmd.Use, "Command use should be 'sso'")
 	assert.Contains(t, cmd.Short, "Login using SSO", "Command should have appropriate short description")
 }
 

--- a/cmd/cli/auth/sso/logout.go
+++ b/cmd/cli/auth/sso/logout.go
@@ -51,7 +51,10 @@ func (o *LogoutOptions) runSSOLogout(cmd *cobra.Command, cfg types.Bacalhau) err
 	if !o.Force {
 		fmt.Fprintf(cmd.OutOrStdout(), "Are you sure you want to logout from %s? (y/N): ", apiURL)
 		var response string
-		if _, err := fmt.Fscanln(cmd.InOrStdin(), &response); err != nil {
+
+		_, err := fmt.Fscanln(cmd.InOrStdin(), &response)
+		// Ignore EOF and unexpected newline errors which happen when user just presses Enter
+		if err != nil && err.Error() != "EOF" && err.Error() != "unexpected newline" {
 			return err
 		}
 		if response != "y" && response != "Y" {

--- a/cmd/cli/auth/sso/logout.go
+++ b/cmd/cli/auth/sso/logout.go
@@ -1,0 +1,74 @@
+package sso
+
+import (
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/spf13/cobra"
+
+	"github.com/bacalhau-project/bacalhau/cmd/util"
+)
+
+// LogoutOptions is a struct to support SSO logout functionality
+type LogoutOptions struct {
+	Force bool // Skip confirmation prompt
+}
+
+// NewLogoutOptions returns initialized LogoutOptions
+func NewLogoutOptions() *LogoutOptions {
+	return &LogoutOptions{
+		Force: false,
+	}
+}
+
+func NewSSOLogoutCmd() *cobra.Command {
+	o := NewLogoutOptions()
+	logoutCmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Logout from current SSO session",
+		Long:  `Logout from the current SSO session and remove stored credentials.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := util.SetupRepoConfig(cmd)
+			if err != nil {
+				return bacerrors.New("failed to setup bacalhau repository config")
+			}
+			return o.runSSOLogout(cmd, cfg)
+		},
+	}
+
+	// Add force flag to skip confirmation
+	logoutCmd.Flags().BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+
+	return logoutCmd
+}
+
+// runSSOLogout handles the SSO logout process
+func (o *LogoutOptions) runSSOLogout(cmd *cobra.Command, cfg types.Bacalhau) error {
+	apiURL, _ := util.ConstructAPIEndpoint(cfg.API)
+
+	if !o.Force {
+		fmt.Fprintf(cmd.OutOrStdout(), "Are you sure you want to logout from %s? (y/N): ", apiURL)
+		var response string
+		if _, err := fmt.Fscanln(cmd.InOrStdin(), &response); err != nil {
+			return err
+		}
+		if response != "y" && response != "Y" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Logout cancelled")
+			return nil
+		}
+	}
+
+	authTokenPath, err := cfg.JWTTokensPath()
+	if err != nil {
+		return bacerrors.New("unable to find local SSO session file")
+	}
+
+	if err = util.WriteToken(authTokenPath, apiURL, nil); err != nil {
+		return bacerrors.New("unable to delete SSO session credentials")
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\nSuccessfully logged out from %s\n", apiURL)
+	return nil
+}

--- a/cmd/cli/auth/sso/logout_test.go
+++ b/cmd/cli/auth/sso/logout_test.go
@@ -1,0 +1,162 @@
+package sso
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestCmd creates a new command and buffer for testing
+func setupTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{Use: "test"}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	return cmd, buf
+}
+
+// createTempTokenFile creates a temporary JWT token file for testing
+func createTempTokenFile(t *testing.T) (string, func()) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "jwt-tokens.json")
+	// Write initial token data with exact format
+	err := os.WriteFile(tokenPath, []byte(`{"http://test-api:1234":"test-token"}`), 0600)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		os.RemoveAll(tmpDir)
+	}
+	return tokenPath, cleanup
+}
+
+func TestLogout_ForceFlag(t *testing.T) {
+	// Setup
+	cmd, buf := setupTestCmd(t)
+	tokenPath, cleanup := createTempTokenFile(t)
+	defer cleanup()
+
+	// Create test config with token path
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath), // Set DataDir directly in config
+	}
+
+	// Test with force flag
+	o := &LogoutOptions{Force: true}
+	err := o.runSSOLogout(cmd, cfg)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Successfully logged out from http://test-api:1234")
+
+	// Verify token file is updated correctly
+	content, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	expectedContent := "{}\n"
+	assert.Equal(t, expectedContent, string(content))
+}
+
+func TestLogout_ConfirmYes(t *testing.T) {
+	// Setup
+	cmd, _ := setupTestCmd(t)
+	tokenPath, cleanup := createTempTokenFile(t)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath),
+	}
+
+	// Create a buffer for input simulation with "y" response
+	inBuf := bytes.NewBufferString("y\n")
+	outBuf := new(bytes.Buffer)
+
+	// Set up the command's input and output
+	cmd.SetIn(inBuf)
+	cmd.SetOut(outBuf)
+
+	// Create a new reader for Scanf
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	// Create a pipe and use it for stdin
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+
+	// Write "y" to the pipe
+	go func() {
+		w.Write([]byte("y\n"))
+		w.Close()
+	}()
+
+	o := &LogoutOptions{Force: false}
+	err := o.runSSOLogout(cmd, cfg)
+
+	// Assertions
+	assert.NoError(t, err)
+	output := outBuf.String()
+	assert.Contains(t, output, "Are you sure you want to logout")
+	assert.Contains(t, output, "Successfully logged out")
+
+	// Verify token file is updated
+	content, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	expectedContent := "{}\n"
+	assert.Equal(t, expectedContent, string(content))
+}
+
+func TestLogout_ConfirmNo(t *testing.T) {
+	// Setup
+	cmd, buf := setupTestCmd(t)
+	tokenPath, cleanup := createTempTokenFile(t)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath), // Set DataDir directly in config
+	}
+
+	// Simulate user input "n"
+	cmd.SetIn(bytes.NewBufferString("n\n"))
+
+	o := &LogoutOptions{Force: false}
+	err := o.runSSOLogout(cmd, cfg)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Logout cancelled")
+
+	// Verify token file is unchanged
+	content, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	expectedContent := `{"http://test-api:1234":"test-token"}`
+	assert.Equal(t, expectedContent, string(content))
+}
+
+func TestNewSSOLogoutCmd(t *testing.T) {
+	cmd := NewSSOLogoutCmd()
+
+	// Test command structure
+	assert.Equal(t, "logout", cmd.Use)
+	assert.Equal(t, "Logout from current SSO session", cmd.Short)
+
+	// Test force flag
+	forceFlag := cmd.Flags().Lookup("force")
+	assert.NotNil(t, forceFlag)
+	assert.Equal(t, "f", forceFlag.Shorthand)
+	assert.Equal(t, "false", forceFlag.DefValue)
+}

--- a/cmd/cli/auth/sso/logout_test.go
+++ b/cmd/cli/auth/sso/logout_test.go
@@ -147,6 +147,37 @@ func TestLogout_ConfirmNo(t *testing.T) {
 	assert.Equal(t, expectedContent, string(content))
 }
 
+func TestLogout_ConfirmEmpty(t *testing.T) {
+	// Setup
+	cmd, buf := setupTestCmd(t)
+	tokenPath, cleanup := createTempTokenFile(t)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath),
+	}
+
+	// Simulate user just pressing Enter (empty input)
+	cmd.SetIn(bytes.NewBufferString("\n"))
+
+	o := &LogoutOptions{Force: false}
+	err := o.runSSOLogout(cmd, cfg)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Logout cancelled")
+
+	// Verify token file is unchanged
+	content, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	expectedContent := `{"http://test-api:1234":"test-token"}`
+	assert.Equal(t, expectedContent, string(content))
+}
+
 func TestNewSSOLogoutCmd(t *testing.T) {
 	cmd := NewSSOLogoutCmd()
 

--- a/cmd/cli/auth/sso/root.go
+++ b/cmd/cli/auth/sso/root.go
@@ -1,0 +1,16 @@
+package sso
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewSSORootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sso",
+		Short: "SSO Authentication commands for Bacalhau",
+	}
+
+	cmd.AddCommand(NewSSOLoginCmd())
+	cmd.AddCommand(NewSSOLogoutCmd())
+	return cmd
+}


### PR DESCRIPTION
# Add SSO Logout Command and Improve SSO Authentication Structure

This PR enhances the SSO authentication functionality by adding a logout command and improving the overall command structure. The changes provide users with a complete authentication lifecycle, allowing them to both login and logout from their SSO sessions.

### Changes
1. Added new `logout` command to SSO authentication
2. Restructured SSO commands under `auth sso` namespace
3. Added force flag option for logout to skip confirmation
4. Added comprehensive unit tests for logout functionality

### New Commands
- `bacalhau auth sso login` - Login using SSO (existing command, moved)
- `bacalhau auth sso logout` - Logout from current SSO session (new command)
   - Optional `-f, --force` flag to skip confirmation prompt

### Usage Examples
```bash
# Login using SSO
bacalhau auth sso login

# Logout with confirmation prompt
bacalhau auth sso logout

# Force logout without confirmation
bacalhau auth sso logout --force
```

## Checklist
- [x] Added new logout command
- [x] Implemented force flag option
- [x] Added comprehensive unit tests
- [x] Tested manually

Linear: https://linear.app/expanso/issue/ENG-714/add-logout-option-for-sso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an SSO logout command with a force option to bypass confirmation prompts.
	- Enhanced the SSO login functionality with clearer, more specific command labels.
	- Added a root command for SSO authentication, consolidating login and logout functionalities.
- **Refactor**
	- Streamlined the overall SSO authentication command structure to provide a unified and intuitive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->