### PR TITLE
Add "bacalhau auth sso token" command

### DIFF
--- a/cmd/cli/auth/sso/root.go
+++ b/cmd/cli/auth/sso/root.go
@@ -12,5 +12,6 @@ func NewSSORootCmd() *cobra.Command {
 
 	cmd.AddCommand(NewSSOLoginCmd())
 	cmd.AddCommand(NewSSOLogoutCmd())
+	cmd.AddCommand(NewSSOTokenCmd())
 	return cmd
 }

--- a/cmd/cli/auth/sso/token.go
+++ b/cmd/cli/auth/sso/token.go
@@ -1,0 +1,98 @@
+package sso
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/spf13/cobra"
+
+	"github.com/bacalhau-project/bacalhau/cmd/util"
+)
+
+// SSOTokenOptions is a struct to support SSO Token functionality
+type SSOTokenOptions struct {
+	Decode bool // Decode JWT Token
+}
+
+// NewSSOTokenOptions returns initialized SSOTokenOptions
+func NewSSOTokenOptions() *SSOTokenOptions {
+	return &SSOTokenOptions{
+		Decode: false,
+	}
+}
+
+func NewSSOTokenCmd() *cobra.Command {
+	o := NewSSOTokenOptions()
+	tokenCmd := &cobra.Command{
+		Use:   "token",
+		Short: "Show current environment SSO JWT token",
+		Long:  `Show current environment SSO JWT token if present.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := util.SetupRepoConfig(cmd)
+			if err != nil {
+				return bacerrors.New("failed to setup bacalhau repository config")
+			}
+			return o.runSSOToken(cmd, cfg)
+		},
+	}
+
+	// Add force flag to skip confirmation
+	tokenCmd.Flags().BoolVarP(&o.Decode, "decode", "d", false, "Decode JWT Token")
+
+	return tokenCmd
+}
+
+// runSSOToken handles the SSO token command
+func (o *SSOTokenOptions) runSSOToken(cmd *cobra.Command, cfg types.Bacalhau) error {
+	apiURL, _ := util.ConstructAPIEndpoint(cfg.API)
+
+	authTokenPath, err := cfg.JWTTokensPath()
+	if err != nil {
+		return bacerrors.New("unable to find local SSO session file")
+	}
+
+	existingCred, readErr := util.ReadToken(authTokenPath, apiURL)
+	if readErr != nil {
+		return bacerrors.New("unable to retrieve saved SSO credentials")
+	}
+
+	if existingCred == nil {
+		fmt.Fprintln(cmd.OutOrStdout(), "No authentication token found")
+		return nil
+	}
+
+	if o.Decode {
+		// Parse the token without verification
+		token, err := jwt.Parse(existingCred.Value, func(token *jwt.Token) (interface{}, error) {
+			return nil, nil // We're not verifying, just decoding
+		})
+		if err != nil && !strings.Contains(err.Error(), "key is of invalid type") {
+			return bacerrors.New("failed to parse token: %s", err)
+		}
+
+		// Pretty print the header
+		headerJSON, err := json.MarshalIndent(token.Header, "", "  ")
+		if err != nil {
+			return bacerrors.New("failed to marshal header: %s", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Header:")
+		fmt.Fprintln(cmd.OutOrStdout(), string(headerJSON))
+
+		// Pretty print the claims
+		claimsJSON, err := json.MarshalIndent(token.Claims, "", "  ")
+		if err != nil {
+			return bacerrors.New("failed to marshal claims: %s", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "\nClaims:")
+		fmt.Fprintln(cmd.OutOrStdout(), string(claimsJSON))
+	} else {
+		fmt.Fprintln(cmd.OutOrStdout(), existingCred.Value)
+	}
+
+	return nil
+}

--- a/cmd/cli/auth/sso/token_test.go
+++ b/cmd/cli/auth/sso/token_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// cSpell:disable
 // setupTestCmd creates a new command and buffer for testing
 func setupTokenTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
 	cmd := &cobra.Command{Use: "test"}

--- a/cmd/cli/auth/sso/token_test.go
+++ b/cmd/cli/auth/sso/token_test.go
@@ -1,0 +1,139 @@
+package sso
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestCmd creates a new command and buffer for testing
+func setupTokenTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{Use: "test"}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	return cmd, buf
+}
+
+// createTestTokenFile creates a temporary JWT token file for testing
+func createTestTokenFile(t *testing.T, token string) (string, func()) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "jwt-tokens.json")
+	// Write initial token data
+	err := os.WriteFile(tokenPath, []byte(token), 0600)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		os.RemoveAll(tmpDir)
+	}
+	return tokenPath, cleanup
+}
+
+func TestToken_ShowRawToken(t *testing.T) {
+	// Setup
+	cmd, buf := setupTokenTestCmd(t)
+	tokenPath, cleanup := createTestTokenFile(t, `{"http://test-api:1234":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"}`)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath),
+	}
+
+	o := &SSOTokenOptions{Decode: false}
+	err := o.runSSOToken(cmd, cfg)
+
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+}
+
+func TestToken_DecodeValidToken(t *testing.T) {
+	// Setup
+	cmd, buf := setupTokenTestCmd(t)
+	// Using a valid JWT token
+	tokenPath, cleanup := createTestTokenFile(t, `{"http://test-api:1234":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"}`)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath),
+	}
+
+	o := &SSOTokenOptions{Decode: true}
+	err := o.runSSOToken(cmd, cfg)
+
+	assert.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "Header:")
+	assert.Contains(t, output, `"alg": "HS256"`)
+	assert.Contains(t, output, "Claims:")
+	assert.Contains(t, output, `"name": "John Doe"`)
+}
+
+func TestToken_NoTokenFound(t *testing.T) {
+	// Setup
+	cmd, buf := setupTokenTestCmd(t)
+	tokenPath, cleanup := createTestTokenFile(t, `{}`)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath),
+	}
+
+	o := &SSOTokenOptions{Decode: false}
+	err := o.runSSOToken(cmd, cfg)
+
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "No authentication token found")
+}
+
+func TestToken_DecodeInvalidToken(t *testing.T) {
+	// Setup
+	cmd, _ := setupTokenTestCmd(t)
+	// Using an invalid JWT token
+	tokenPath, cleanup := createTestTokenFile(t, `{"http://test-api:1234":"invalid-token"}`)
+	defer cleanup()
+
+	cfg := types.Bacalhau{
+		API: types.API{
+			Host: "test-api",
+			Port: 1234,
+		},
+		DataDir: filepath.Dir(tokenPath),
+	}
+
+	o := &SSOTokenOptions{Decode: true}
+	err := o.runSSOToken(cmd, cfg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse token")
+}
+
+func TestNewSSOTokenCmd(t *testing.T) {
+	cmd := NewSSOTokenCmd()
+
+	// Test command structure
+	assert.Equal(t, "token", cmd.Use)
+	assert.Equal(t, "Show current environment SSO JWT token", cmd.Short)
+
+	// Test decode flag
+	decodeFlag := cmd.Flags().Lookup("decode")
+	assert.NotNil(t, decodeFlag)
+	assert.Equal(t, "d", decodeFlag.Shorthand)
+	assert.Equal(t, "false", decodeFlag.DefValue)
+}


### PR DESCRIPTION
# Add `bacalhau auth sso token` command

## Description
Added a new CLI command `bacalhau auth sso token` that allows users to view and decode their current SSO JWT token. This command helps users inspect their authentication state and debug SSO-related issues.

### Features
- Display the raw JWT token currently in use
- Optional `--decode/-d` flag to decode and pretty-print the token's contents:
  - Header information
  - Claims data (such as subject, name, and issuance time)

### Usage Examples
```bash
# Show raw token
bacalhau auth sso token

# Decode and display token contents
bacalhau auth sso token --decode
```

### Testing
Added test suite covering:
- Raw token display
- Decoded token validation
- Error handling for invalid tokens
- Missing token scenarios
- Command structure and flag verification


Linear: https://linear.app/expanso/issue/ENG-711/show-auth-token-should-be-its-own-command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command to view SSO JWT tokens with an option to decode and display detailed token information.
- **Refactor**
	- Streamlined the SSO login process by removing extraneous display options, providing a more focused authentication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->