### PR TITLE
Fix SSO Login regression

### DIFF
--- a/pkg/publicapi/client/v2/client.go
+++ b/pkg/publicapi/client/v2/client.go
@@ -486,10 +486,6 @@ type AuthenticatingClient struct {
 	// NewAuthenticationFlowEnabled is true when new auth flow is detected.
 	// This is kept here for backward compatibility reasons only
 	NewAuthenticationFlowEnabled bool
-
-	// SkipAuthentication is true when new auth flow is detected.
-	// This is kept here for backward compatibility reasons only
-	SkipAuthentication bool
 }
 
 func (t *AuthenticatingClient) Get(ctx context.Context, path string, in apimodels.GetRequest, out apimodels.GetResponse) error {
@@ -536,10 +532,6 @@ func (t *AuthenticatingClient) Dial(
 }
 
 func doRequest[R apimodels.Request](ctx context.Context, t *AuthenticatingClient, request R, runRequest func(R) error) (err error) {
-	if t.SkipAuthentication {
-		return runRequest(request)
-	}
-
 	if t.NewAuthenticationFlowEnabled {
 		// Skip all legacy credential flow
 		request.SetCredential(t.Credential)

--- a/test_integration/17_basic_auth_config_suite_test.go
+++ b/test_integration/17_basic_auth_config_suite_test.go
@@ -171,6 +171,44 @@ func (s *BasicAuthConfigSuite) TestAuthInfoCommand() {
 	s.Require().Contains(result, "To use SSO login, please unset Auth related environment variables first.", result)
 }
 
+func (s *BasicAuthConfigSuite) TestAuthInfoNoCredentialsCommand() {
+	// Auth Info
+	result, err := s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "auth", "info"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "Target environment: http://bacalhau-orchestrator-node:1234", result)
+	s.Require().Contains(result, "Environment Variables:", result)
+	s.Require().Contains(result, "API Key: Not Set", result)
+	s.Require().Contains(result, "Username: Not Set", result)
+	s.Require().Contains(result, "Password: Not Set", result)
+	s.Require().Contains(result, "Node SSO Authentication:", result)
+	s.Require().Contains(result, "Server does not support SSO login", result)
+	s.Require().Contains(result, "Note: Environment variables take precedence over other authentication mechanisms including SSO.", result)
+	s.Require().Contains(result, "To use SSO login, please unset Auth related environment variables first.", result)
+}
+
+func (s *BasicAuthConfigSuite) TestAuthIsSkippedForCertainCommands() {
+	result, err := s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "version"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "SERVER", result)
+
+	result, err = s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "agent", "version"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "BuildDate")
+	s.Require().Contains(result, "GitCommit")
+
+	result, err = s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "agent", "alive"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "Status: OK")
+}
+
 func (s *BasicAuthConfigSuite) TestConfigRedactedContent() {
 	// Auth Info
 	result, err := s.executeCommandInDefaultJumpbox(

--- a/test_integration/18_sso_auth_config_suite_test.go
+++ b/test_integration/18_sso_auth_config_suite_test.go
@@ -1,0 +1,78 @@
+package test_integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+// cSpell:disable
+type SSAuthConfigSuite struct {
+	BaseDockerComposeTestSuite
+}
+
+func NewSSAuthConfigSuite() *SSAuthConfigSuite {
+	s := &SSAuthConfigSuite{}
+	s.GlobalRunIdentifier = globalTestExecutionId
+	s.SuiteRunIdentifier = strings.ToLower(strings.Split(uuid.New().String(), "-")[0])
+	return s
+}
+
+func (s *SSAuthConfigSuite) SetupSuite() {
+	rawDockerComposeFilePath := "./common_assets/docker_compose_files/orchestrator-and-compute-custom-startup.yml"
+	s.Context, s.Cancel = context.WithCancel(context.Background())
+
+	orchestratorConfigFile := s.commonAssets("nodes_configs/18_sso_auth_enabled_orchestrator.yaml")
+	orchestratorStartCommand := fmt.Sprintf("bacalhau serve --config=%s", orchestratorConfigFile)
+
+	computeConfigFile := s.commonAssets("nodes_configs/18_sso_auth_enabled_compute_node.yaml")
+	computeStartCommand := fmt.Sprintf("bacalhau serve --config=%s", computeConfigFile)
+	extraRenderingData := map[string]interface{}{
+		"OrchestratorStartCommand": orchestratorStartCommand,
+		"ComputeStartCommand":      computeStartCommand,
+	}
+	s.BaseDockerComposeTestSuite.SetupSuite(rawDockerComposeFilePath, extraRenderingData)
+}
+
+func (s *SSAuthConfigSuite) TearDownSuite() {
+	s.T().Log("Tearing down [Test Suite] in SSAuthConfigSuite...")
+	s.BaseDockerComposeTestSuite.TearDownSuite()
+}
+
+func (s *SSAuthConfigSuite) TestAuthIsSkippedForSSOLoginCommand() {
+	// We rely on the error to verify we were able to fetch authconfig
+	_, err := s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "auth", "sso", "login"},
+	)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "unable to initiate SSO login flow")
+}
+
+func (s *SSAuthConfigSuite) TestAuthIsSkippedForCertainCommands() {
+	result, err := s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "version"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "SERVER", result)
+
+	result, err = s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "agent", "version"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "BuildDate")
+	s.Require().Contains(result, "GitCommit")
+
+	result, err = s.executeCommandInDefaultJumpbox(
+		[]string{"bacalhau", "agent", "alive"},
+	)
+	s.Require().NoError(err)
+	s.Require().Contains(result, "Status: OK")
+}
+
+func TestSSAuthConfigSuite(t *testing.T) {
+	suite.Run(t, NewSSAuthConfigSuite())
+}

--- a/test_integration/common_assets/nodes_configs/18_sso_auth_enabled_compute_node.yaml
+++ b/test_integration/common_assets/nodes_configs/18_sso_auth_enabled_compute_node.yaml
@@ -1,0 +1,9 @@
+NameProvider: "uuid"
+API:
+  Port: 1234
+Compute:
+  Enabled: true
+  Orchestrators:
+    - nats://bacalhau-orchestrator-node:4222
+  Auth:
+    Token: "i_am_very_secret_token"

--- a/test_integration/common_assets/nodes_configs/18_sso_auth_enabled_orchestrator.yaml
+++ b/test_integration/common_assets/nodes_configs/18_sso_auth_enabled_orchestrator.yaml
@@ -1,0 +1,21 @@
+NameProvider: "uuid"
+API:
+  Port: 1234
+  Auth:
+    Oauth2:
+      ProviderId: "auth0"
+      ProviderName: "Auth0"
+      DeviceAuthorizationEndpoint: "https://example.com/oauth/device/code"
+      TokenEndpoint: "https://example.com/oauth/token"
+      Issuer: "https://example.com/.well-known"
+      JWKSUri: "https://example.com/.well-known/jwks.json"
+      DeviceClientId: "abc123abc123abc123"
+      PollingInterval: 5
+      Audience: "https://example.com/orchestrator"
+      Scopes:
+        - "openid"
+        - "profile"
+Orchestrator:
+  Enabled: true
+  Auth:
+    Token: "i_am_very_secret_token"


### PR DESCRIPTION
# Fix SSO Login regression

The command `bacalhau auth sso login` was failing since we did not skip authentication flow for it.

This PR fix that, improved the code flow, and added integration tests to catch similar regressions. 

Linear: https://linear.app/expanso/issue/ENG-736/fix-sso-login-regression