### PR TITLE
fix regression in not setting log level

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bacalhau-project/bacalhau/cmd/cli/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/bacalhau-project/bacalhau/cmd/cli/auth"
 
 	"github.com/bacalhau-project/bacalhau/cmd/cli/agent"
 	configcli "github.com/bacalhau-project/bacalhau/cmd/cli/config"
@@ -48,8 +49,9 @@ func NewRootCmd() *cobra.Command {
 	// when these flags are provided their value will be used instead of the value present in the config file.
 	// If no flg is provided, and the config file doesn't have a value defined then the default value will be used.
 	rootFlags := map[string][]configflags.Definition{
-		"api":  configflags.ClientAPIFlags,
-		"repo": configflags.DataDirFlag,
+		"api":     configflags.ClientAPIFlags,
+		"logging": configflags.LogFlags,
+		"repo":    configflags.DataDirFlag,
 	}
 	// register the flags on the command.
 	if err := configflags.RegisterFlags(RootCmd, rootFlags); err != nil {

--- a/cmd/util/flags/configflags/logging.go
+++ b/cmd/util/flags/configflags/logging.go
@@ -1,0 +1,31 @@
+package configflags
+
+import (
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/config"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+)
+
+// TODO: remove this once we have a proper way to register LOG_LEVEL env var into the config.
+//
+//	Currently we utilize cli flags to also register env vars.
+var LogFlags = []Definition{
+	{
+		FlagName:             "log-level",
+		DefaultValue:         config.Default.Logging.Level,
+		ConfigPath:           types.LoggingLevelKey,
+		Description:          `Log level: 'trace', 'debug', 'info', 'warn', 'error', 'fatal', 'panic'`,
+		EnvironmentVariables: []string{"LOG_LEVEL"},
+		Deprecated:           true,
+		DeprecatedMessage:    makeDeprecationMessage(types.LoggingLevelKey),
+	},
+}
+
+func makeDeprecationMessage(key string) string {
+	return fmt.Sprintf("Use %s to set this configuration", makeConfigFlagDeprecationCommand(key))
+}
+
+func makeConfigFlagDeprecationCommand(key string) string {
+	return fmt.Sprintf("--config %s=<value>", key)
+}


### PR DESCRIPTION
Fix regression introduced in https://github.com/bacalhau-project/bacalhau/pull/4874 where `LOG_LEVEL` env var stopped working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option to configure logging. Users can now set log levels and related parameters directly via CLI flags and environment variables, further enhancing the application's configurability while preserving existing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->