### PR TITLE
Stream container output to a file

### DIFF
--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -23,8 +23,7 @@ import (
 
 const StorageDirectoryPerms = 0o755
 const (
-	// executionRootCleanupDelay = 60 * time.Minute
-	executionRootCleanupDelay = 10 * time.Second
+	executionRootCleanupDelay = 10 * time.Minute
 	executionOutputDirName    = "output"
 )
 

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -319,8 +319,10 @@ func (e *BaseExecutor) Run(ctx context.Context, execution *models.Execution) (er
 				err = os.RemoveAll(executionRootDir)
 				if err != nil {
 					log.Error().Err(err).Msgf("Failed to remove execution root dir at %s", executionRootDir)
+					return
 				} else {
 					log.Debug().Msgf("Removed execution root dir at %s", executionRootDir)
+					return
 				}
 			}
 		}()

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -21,6 +22,11 @@ import (
 )
 
 const StorageDirectoryPerms = 0o755
+const (
+	// executionRootCleanupDelay = 60 * time.Minute
+	executionRootCleanupDelay = 10 * time.Second
+	executionOutputDirName    = "output"
+)
 
 type BaseExecutorParams struct {
 	ID                     string
@@ -84,6 +90,26 @@ func (e *BaseExecutor) prepareInputVolumes(
 	return inputVolumes, func(ctx context.Context) error {
 		return storage.ParallelCleanStorage(ctx, e.Storages, inputVolumes)
 	}, nil
+}
+
+func (e *BaseExecutor) prepareRootDir(ctx context.Context, execution *models.Execution) (string, string, error) {
+	executionRootPath := buildExecutionRootPath(e, execution)
+	executionResultsPath := buildExecutionOutputPath(executionRootPath)
+
+	if err := os.MkdirAll(executionRootPath, StorageDirectoryPerms); err != nil {
+		return executionRootPath, executionResultsPath, err
+	}
+
+	log.Ctx(ctx).Debug().Msgf("Execution root dir: %s", executionRootPath)
+
+	// Execution output directory
+	if err := os.MkdirAll(executionResultsPath, StorageDirectoryPerms); err != nil {
+		return executionRootPath, executionResultsPath, err
+	}
+
+	log.Ctx(ctx).Debug().Msgf("Execution output dir: %s", executionResultsPath)
+
+	return executionRootPath, executionResultsPath, nil
 }
 
 // InputCleanupFn is a function type that defines the contract for cleaning up
@@ -181,19 +207,19 @@ func (e *BaseExecutor) Start(ctx context.Context, execution *models.Execution) *
 		return result
 	}
 
-	resultFolder, err := e.resultsPath.PrepareResultsDir(execution.ID)
+	_, err = e.resultsPath.PrepareResultsDir(execution.ID)
 	if err != nil {
 		result.Err = fmt.Errorf("preparing results path: %w", err)
 		return result
 	}
 
-	executionStorage := filepath.Join(e.storageDirectory, execution.JobID, execution.ID)
-	if err := os.MkdirAll(executionStorage, StorageDirectoryPerms); err != nil {
-		result.Err = fmt.Errorf("preparing storage path: %w", err)
+	_, resultsDir, err := e.prepareRootDir(ctx, execution)
+	if err != nil {
+		result.Err = fmt.Errorf("preparing execution root directory: %w", err)
 		return result
 	}
 
-	args, cleanup, err := e.PrepareRunArguments(ctx, execution, resultFolder)
+	args, cleanup, err := e.PrepareRunArguments(ctx, execution, resultsDir)
 	result.cleanup = cleanup
 	if err != nil {
 		result.Err = fmt.Errorf("preparing arguments: %w", err)
@@ -281,6 +307,25 @@ func (e *BaseExecutor) Run(ctx context.Context, execution *models.Execution) (er
 			log.Ctx(ctx).Error().Err(err).Msg("failed to clean up start arguments")
 		}
 	}()
+
+	// schedule resource artifact cleanup
+	defer func() {
+		go func() {
+			ticker := time.NewTicker(executionRootCleanupDelay)
+			defer ticker.Stop()
+			executionRootDir := buildExecutionRootPath(e, execution)
+			log.Debug().Msgf("Scheduled execution root dir removal at %s", executionRootDir)
+			for range ticker.C {
+				err = os.RemoveAll(executionRootDir)
+				if err != nil {
+					log.Error().Err(err).Msgf("Failed to remove execution root dir at %s", executionRootDir)
+				} else {
+					log.Debug().Msgf("Removed execution root dir at %s", executionRootDir)
+				}
+			}
+		}()
+	}()
+
 	if err := res.Err; err != nil {
 		if bacerrors.IsErrorWithCode(err, executor.ExecutionAlreadyStarted) {
 			// by not returning this error to the caller when the execution has already been started/is already running
@@ -425,6 +470,15 @@ func (e *BaseExecutor) handleFailure(ctx context.Context, execution *models.Exec
 	if updateError != nil {
 		log.Ctx(ctx).Error().Err(updateError).Msgf("Failed to update execution (%s) state to failed: %s", execution.ID, updateError)
 	}
+}
+
+func buildExecutionRootPath(e *BaseExecutor, execution *models.Execution) string {
+	executionRootPath := filepath.Join(e.storageDirectory, execution.ID)
+	return executionRootPath
+}
+
+func buildExecutionOutputPath(executionRootPath string) string {
+	return filepath.Join(executionRootPath, executionOutputDirName)
 }
 
 // compile-time interface check

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -170,7 +170,7 @@ func (c *Client) FollowLogs(ctx context.Context, id string) (stdout, stderr io.R
 	return stdoutReader, stderrReader, nil
 }
 
-func (c *Client) GetOutputStream(ctx context.Context, id string, since string, follow bool) (io.ReadCloser, error) {
+func (c *Client) GetOutputStream(ctx context.Context, id string, since string, follow, timestamps bool) (io.ReadCloser, error) {
 	cont, err := c.ContainerInspect(ctx, id)
 	if err != nil {
 		return nil, NewDockerError(err)
@@ -184,6 +184,7 @@ func (c *Client) GetOutputStream(ctx context.Context, id string, since string, f
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     follow,
+		Timestamps: timestamps,
 	}
 	if since != "" {
 		logOptions.Since = since

--- a/pkg/executor/docker/handler.go
+++ b/pkg/executor/docker/handler.go
@@ -95,7 +95,11 @@ func (h *executionHandler) run(ctx context.Context) {
 	}
 
 	// start writing container output to the log file
-	go executor.WriteExecutionOutput(h.resultsDir, logStreamReader)
+	go func() {
+		if err := executor.WriteExecutionOutput(h.resultsDir, logStreamReader); err != nil {
+			h.logger.Error().Err(err).Msg("failed to write container output")
+		}
+	}()
 
 	// The container is now active
 	close(h.activeCh)

--- a/pkg/executor/docker/handler.go
+++ b/pkg/executor/docker/handler.go
@@ -70,7 +70,7 @@ func (h *executionHandler) run(ctx context.Context) {
 	h.logger.Info().Msg("starting container execution")
 
 	// remember a timestamp right before starting the container to guarantee all logs are captured
-	containerStartTs := strconv.FormatInt(time.Now().Unix(), 10)
+	containerStartTS := strconv.FormatInt(time.Now().Unix(), 10)
 
 	if err := h.client.ContainerStart(ctx, h.containerID, container.StartOptions{}); err != nil {
 		// Special error to alert people about bad executable
@@ -86,7 +86,7 @@ func (h *executionHandler) run(ctx context.Context) {
 		return
 	}
 
-	logStreamReader, err := h.client.GetOutputStream(ctx, h.containerID, containerStartTs, true)
+	logStreamReader, err := h.client.GetOutputStream(ctx, h.containerID, containerStartTS, true, true)
 	if err != nil {
 		logStreamErr := errors.Wrap(err, "failed create container output stream")
 		h.logger.Warn().Err(logStreamErr).Msg("failed to capture container output")
@@ -236,7 +236,7 @@ func (h *executionHandler) outputStream(ctx context.Context, request messages.Ex
 	// Gets the underlying reader, and provides data since the value of the `since` timestamp.
 	// If we want everything, we specify 1, a timestamp which we are confident we don't have
 	// logs before. If we want to just follow new logs, we pass `time.Now()` as a string.
-	return h.client.GetOutputStream(ctx, h.containerID, since, request.Follow)
+	return h.client.GetOutputStream(ctx, h.containerID, since, request.Follow, false)
 }
 
 func (h *executionHandler) active() bool {

--- a/pkg/executor/results.go
+++ b/pkg/executor/results.go
@@ -160,3 +160,20 @@ func NewFailedResult(reason string) *models.RunCommandResult {
 func FailResult(err error) (*models.RunCommandResult, error) {
 	return &models.RunCommandResult{ErrorMsg: err.Error()}, err
 }
+
+const (
+	executionOutputFileName  = "unifiedout"
+	executionOutputFileLimit = 10 * datasize.MB
+)
+
+func WriteExecutionOutput(resultsDir string, logReader io.Reader) error {
+	log.Debug().Msgf("Writing execution output at %s", resultsDir)
+	return writeOutputResult(resultsDir, outputResult{
+		contents:     logReader,
+		filename:     executionOutputFileName,
+		fileLimit:    executionOutputFileLimit,
+		summary:      nil,
+		summaryLimit: 1,
+		truncated:    nil,
+	})
+}

--- a/test_integration/common_assets/job_specs/log_emitter.yml
+++ b/test_integration/common_assets/job_specs/log_emitter.yml
@@ -1,0 +1,16 @@
+Name: Log emitter job
+Type: batch
+Count: 1
+Tasks:
+  - Name: main
+    Engine:
+      Type: docker
+      Params:
+        Image: busybox:1.37.0
+        Entrypoint:
+          - /bin/sh
+        Parameters:
+          - "-c"
+          - "x=1; while [ $x -le 30 ]; do echo $x; x=$((x+1)); sleep 1; done"
+    Publisher:
+      Type: local

--- a/test_integration/common_assets/job_specs/log_emitter.yml
+++ b/test_integration/common_assets/job_specs/log_emitter.yml
@@ -11,6 +11,6 @@ Tasks:
           - /bin/sh
         Parameters:
           - "-c"
-          - "x=1; while [ $x -le 30 ]; do echo $x; x=$((x+1)); sleep 1; done"
+          - "x=1; while [ $x -le 10 ]; do [[ $((x % 2)) -eq 0 ]] && echo $x>&2 || echo $x; x=$((x+1)); sleep 0.5; done"
     Publisher:
       Type: local


### PR DESCRIPTION
This is a preliminary step towards modifying the log streaming logic to use local files instead of asking Docker for the logs.

This PR adds logic to subscribe to Docker container logs at the start of the execution and write them to a local file on compute node. This file will later be used to stream logs back to the orchestrator. It also changes the clean up logic to delete the artifacts after a delay (currently 10 min) instead of removing them right after the execution has completed. This is a stub for a future execution garbage collection logic.

* This PR **does not** modify how `job logs` or `--follow` commands work. They still use Docker ContainerLogs
* The folder in which both the "old" results and the new unified output is stored has changed. Now both go to `$bacalhau_data/executions/$executionid/output`
* At this point there is no extra formatting in the unified output file (e.g. stderr/stdout flag) which will be added later

## Unified log format
The new log file contains both `stderr` and `stdout`. The record format follows Docker ContainerLog format (see [here](https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerLogs)) with each record timestamped. The timestamps will be utilized for `--since` and `--tail`.
 

https://linear.app/expanso/issue/ENG-732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of job working directories with structured setup and automated cleanup for more reliable execution.
	- Enhanced container logging that now captures complete output from startup with streamlined error reporting and unified output file management.
	- Introduced a new configuration for a log emitter job to facilitate batch log generation using a lightweight container image.
	- Added functionality to write execution output to a specified directory with defined file naming and size limits.
	- Added support for including timestamps in log output for better traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->