### PR TITLE
Improve job validation error messages (#4224)

### DIFF
--- a/pkg/models/input_source.go
+++ b/pkg/models/input_source.go
@@ -57,10 +57,10 @@ func (a *InputSource) Validate() error {
 		return nil
 	}
 	mErr := errors.Join(
-		validate.NotBlank(a.Target, "missing artifact target"),
+		validate.NotBlank(a.Target, "input source is missing a target"),
 	)
 	if err := a.Source.Validate(); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("invalid artifact source: %w", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid input source: %w", err))
 	}
 	return mErr
 }

--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -129,22 +129,22 @@ func (t *Task) ValidateSubmission() error {
 	)
 
 	if err := t.Engine.Validate(); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("engine validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid engine: %v", err))
 	}
 	if err := t.Publisher.ValidateAllowBlank(); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("publisher validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid publisher: %v", err))
 	}
 	if err := t.Timeouts.ValidateSubmission(); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("task timeouts validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid timeouts: %v", err))
 	}
 	if err := t.ResourcesConfig.Validate(); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("task resources validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid resources: %v", err))
 	}
 	if err := ValidateSlice(t.InputSources); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("artifact validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid input sources: %v", err))
 	}
 	if err := ValidateSlice(t.ResultPaths); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("output validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid output: %v", err))
 	}
 
 	if err := t.validateInputSources(); err != nil {
@@ -156,7 +156,7 @@ func (t *Task) ValidateSubmission() error {
 	}
 
 	if err := t.Network.Validate(); err != nil {
-		mErr = errors.Join(mErr, fmt.Errorf("network validation failed: %v", err))
+		mErr = errors.Join(mErr, fmt.Errorf("invalid network: %v", err))
 	}
 
 	return mErr

--- a/pkg/models/task_test.go
+++ b/pkg/models/task_test.go
@@ -113,6 +113,18 @@ func (suite *TaskTestSuite) TestTaskValidation() {
 			errMsg:         "input source with target '/input' already exists",
 		},
 		{
+			name: "Missing input source target",
+			task: &Task{
+				Name:   "missing-target",
+				Engine: &SpecConfig{Type: "docker"},
+				InputSources: []*InputSource{
+					{Alias: "input1", Source: &SpecConfig{Type: "http"}},
+				},
+			},
+			validationMode: submissionError,
+			errMsg:         "invalid input sources",
+		},
+		{
 			name: "Duplicate result path name",
 			task: &Task{
 				Name:   "duplicate-result-name",
@@ -175,7 +187,7 @@ func (suite *TaskTestSuite) TestTaskValidation() {
 				},
 			},
 			validationMode: submissionError,
-			errMsg:         "task timeouts validation failed",
+			errMsg:         "invalid timeouts",
 		},
 		{
 			name: "Invalid resources",
@@ -187,7 +199,7 @@ func (suite *TaskTestSuite) TestTaskValidation() {
 				},
 			},
 			validationMode: submissionError,
-			errMsg:         "task resources validation failed",
+			errMsg:         "invalid resources",
 		},
 		{
 			name: "Environment variable starting with BACALHAU_",


### PR DESCRIPTION
Our job spec verification sometimes return pretty cryptic error messages to the user. This is a quick fix to make some of those messages more readable.

Ideally we should plan a long-term solution for this. Maybe introduce a JSON schema for Job Spec and use one of the existing schema validators.

Additionally, we can look into job spec validation on client side and fail early if given yaml/json is invalid. We won't be able to check every rule (some require compute node info, like supported engines/hardware) but we can totally verify that the job satisfies the schema. For example https://github.com/bacalhau-project/bacalhau/issues/4224 is a schema error so can be caught before even sending any requests to the orchestrator.



### Before
```
Error: the job provided is invalid: task Task1 validation failed: artifact validation failed: missing artifact target
```

### After
```
Error: the job provided is invalid: task Task1 validation failed: invalid input sources: input source is missing a target
```


Addresses https://github.com/bacalhau-project/bacalhau/issues/4224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation error messages for input sources and tasks to be more specific and consistent.
- **Tests**
  - Added a new test case for missing input source targets.
  - Updated existing test cases to match revised error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->