### PR TITLE
Change .github/README.md to .github/DOCUMENTATION.md

### DIFF
--- a/.github/DOCUMENTATION.md
+++ b/.github/DOCUMENTATION.md
@@ -7,7 +7,7 @@ This guide documents the CI/CD infrastructure for the Bacalhau project, implemen
 
 The Bacalhau project uses GitHub Actions for continuous integration, testing, and deployment. The CI/CD pipeline consists of:
 
-### **PR Checks**  
+### **PR Checks**
 Run on all pull requests to validate code quality and correctness
 
 ```mermaid
@@ -21,7 +21,7 @@ flowchart TD
         IntegrationTests --> CovReport
     end
 ```
-### **Main Branch Builds** 
+### **Main Branch Builds**
 Triggered on pushes to the main branch to build and publish "edge" artifacts
 ```mermaid
 flowchart TD


### PR DESCRIPTION
# Fix  Repository README file order conflict

Currently, the Github repo is displaying the README file from the  .github directory instead of the root directory. This PR fixes that and renames the .github/README.md to .github/DOCUMENTATION.md so that the README file from the root directory is displayed.

From Github docs:

> If a repository contains more than one README file, then the file shown is chosen from locations in the following order: the .github directory, then the repository's root directory, and finally the docs directory.

Source: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes

## How the main repository page on Github looks right now

<img width="786" alt="Screenshot 2025-04-20 at 3 48 07 AM" src="https://github.com/user-attachments/assets/a6964a26-e7ce-45ba-9aff-08399a5fa46e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Cleaned up trailing spaces after specific headings to improve formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->