### PR TITLE
Support bacerrors.Newf in local directory provider

### DIFF
--- a/pkg/storage/local_directory/storage.go
+++ b/pkg/storage/local_directory/storage.go
@@ -124,9 +124,9 @@ func (driver *StorageProvider) matchAllowedPath(storageSpec Source) (*AllowedPat
 
 	var err bacerrors.Error
 	if insufficientPermissions {
-		err = bacerrors.New("volume %s is not granted write access", storageSpec.SourcePath)
+		err = bacerrors.Newf("volume %s is not granted write access", storageSpec.SourcePath)
 	} else {
-		err = bacerrors.New("volume %s is not allowlisted", storageSpec.SourcePath)
+		err = bacerrors.Newf("volume %s is not allowlisted", storageSpec.SourcePath)
 	}
 	err = err.WithCode(bacerrors.ConfigurationError).
 		WithHint("Verify Compute.AllowListedLocalPaths configuration property")


### PR DESCRIPTION
This is a fix for a merge conflict happened between https://github.com/bacalhau-project/bacalhau/commit/2a8c2e1d7c3a8440dbf5ca1981d19433f2eb4571 and https://github.com/bacalhau-project/bacalhau/commit/0586c9035083e7f545b7e23c0ed70cb8b218d34d merged together. 

No new or changed functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for cases where a volume lacks write access or is not allowlisted, ensuring clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->