### PR TITLE
change manifest artifact key to os_arch instead of os-arch

### DIFF
--- a/.github/workflows/_s3_publish.yml
+++ b/.github/workflows/_s3_publish.yml
@@ -235,7 +235,7 @@ jobs:
                   fi
           
                   # Add to the JSON using jq
-                  jq --arg key "${OS}-${ARCH}" \
+                  jq --arg key "${OS}_${ARCH}" \
                      --arg filename "$FILENAME" \
                      --arg path "$TARGET_PATH" \
                      --arg os "$OS" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the format of artifact keys in the manifest JSON generated during the publishing process. This change affects how artifacts are indexed but does not impact user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->