### PR TITLE
Fixed input provider behaviour for WASM engine (#2364)

### DIFF
--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -231,7 +231,7 @@ func (e *Executor) makeFsFromStorage(
 
 	// Validate input sources
 	for _, v := range volumes {
-		if v.InputSource.Target == "" {
+		if v.Volume.Target == "" {
 			return nil, NewInputConfigError("input source has no target path")
 		}
 		if v.Volume.Source == "" {
@@ -239,7 +239,7 @@ func (e *Executor) makeFsFromStorage(
 		}
 
 		log.Ctx(ctx).Debug().
-			Str("input", v.InputSource.Target).
+			Str("target", v.Volume.Target).
 			Str("source", v.Volume.Source).
 			Msg("Using input")
 
@@ -256,7 +256,7 @@ func (e *Executor) makeFsFromStorage(
 			inputFs = filefs.New(v.Volume.Source)
 		}
 
-		err = rootFs.Mount(v.InputSource.Target, inputFs)
+		err = rootFs.Mount(v.Volume.Target, inputFs)
 		if err != nil {
 			return nil, NewInputConfigError(fmt.Sprintf("failed to mount input %q: %s", v.InputSource.Target, err))
 		}
@@ -274,7 +274,7 @@ func (e *Executor) makeFsFromStorage(
 
 		// Check for conflicts with input paths
 		for _, v := range volumes {
-			if v.InputSource.Target == output.Name {
+			if v.Volume.Target == output.Name {
 				return nil, NewOutputError(fmt.Sprintf("output name %q conflicts with input target", output.Name))
 			}
 		}

--- a/pkg/executor/wasm/executor.go
+++ b/pkg/executor/wasm/executor.go
@@ -258,7 +258,7 @@ func (e *Executor) makeFsFromStorage(
 
 		err = rootFs.Mount(v.Volume.Target, inputFs)
 		if err != nil {
-			return nil, NewInputConfigError(fmt.Sprintf("failed to mount input %q: %s", v.InputSource.Target, err))
+			return nil, NewInputConfigError(fmt.Sprintf("failed to mount input %q: %s", v.Volume.Target, err))
 		}
 	}
 

--- a/pkg/test/devstack/url_test.go
+++ b/pkg/test/devstack/url_test.go
@@ -77,8 +77,8 @@ func runURLTest(
 					Engine: wasmmodels.NewWasmEngineBuilder("/app/cat.wasm").
 						WithEntrypoint("_start").
 						WithParameters(
-							testCase.mount1,
-							testCase.mount2,
+							path.Join(testCase.mount1, testCase.file1),
+							path.Join(testCase.mount2, testCase.file2),
 						).MustBuild(),
 					Publisher: publisher_local.NewSpecConfig(),
 				},
@@ -245,7 +245,7 @@ func (s *URLTestSuite) TestLocalURLCombo() {
 					},
 					Engine: wasmmodels.NewWasmEngineBuilder("/app/cat.wasm").
 						WithEntrypoint("_start").
-						WithParameters(urlmount, path.Join(localMount, localFile)).
+						WithParameters(path.Join(urlmount, urlfile), path.Join(localMount, localFile)).
 						MustBuild(),
 					Publisher: publisher_local.NewSpecConfig(),
 				},


### PR DESCRIPTION
WASM engine used incorrect `Target` path when mounting inputs provided by `urlDownload` and `s3` providers.
Now the behavior is unified with Docker engine.

* `local` provider: `Target` can be either a directory or a file depending on what `Source` is pointing to
* `urlDownload`: `Target` is always the parent directory in which the file downloaded from specified `URL` is placed
* `s3`: `Target` is always the parent directory in which all matching objects are placed.
* WASM engine docs improved with more examples to illustrate correct `Target` usage https://github.com/bacalhau-project/docs/pull/111


Addresses https://github.com/bacalhau-project/bacalhau/issues/2364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected references to input source targets in messages and validation to ensure accurate logging and error reporting.
	- Updated test scenarios to provide complete file paths to the Wasm engine, improving input file referencing during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->