### PR TITLE
fix: job stop doesn't stop the execution

### DIFF
--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Codespell
         run: |
           # Install cspell for spell checking
-          yarn global add cspell@latest
+          yarn global add cspell@8.19.4
           make spellcheck-code
 
       # Run swagger validation to ensure API documentation is correct

--- a/pkg/compute/executor.go
+++ b/pkg/compute/executor.go
@@ -437,7 +437,10 @@ func (e *BaseExecutor) handleFailure(ctx context.Context, execution *models.Exec
 	})
 
 	if updateError != nil {
-		log.Ctx(ctx).Error().Err(updateError).Msgf("Failed to update execution (%s) state to failed: %s", execution.ID, updateError)
+		var alreadyTerminalError store.ErrExecutionAlreadyTerminal
+		if !errors.As(updateError, &alreadyTerminalError) {
+			log.Ctx(ctx).Error().Err(updateError).Msgf("Failed to update execution (%s) state to failed: %s", execution.ID, updateError)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem
The `shouldCancel` function in the execution transition logic had an issue that prevented stop signals from properly propagating to compute nodes. While job states were correctly showing as stopped in the scheduler, the actual compute nodes weren't receiving the cancellation requests.

This happened because the function was incorrectly handling terminal state checking, causing the system to skip sending necessary cancellation requests to compute nodes when a job needed to be stopped.

## Solution
Modified the `shouldCancel` function to properly determine when a cancellation request should be sent, ensuring that stop signals propagate all the way to the compute nodes, not just the job state in the scheduler.

The improved logic now:
- Correctly checks only the previous compute state
- Recognizes that the current state is always marked terminal by the scheduler during cancellation
- Avoids skipping necessary cancellation requests

## Testing
Enhanced the test suite to verify both job state AND compute node state during cancellation operations. Previous tests only verified the job state in the scheduler without confirming that compute nodes actually received and processed the cancellation requests.

These additional tests now ensure proper end-to-end cancellation behavior and prevent regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent redundant error logs when execution is already in a terminal state.
  - Enhanced cancellation logic to ensure cancellation requests are sent only when appropriate, based on previous execution state.

- **Tests**
  - Expanded test coverage to verify that job stop requests are correctly propagated and processed at the compute node execution level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->