### PR TITLE
Add Managed S3 Publisher Support

### DIFF
--- a/cmd/util/opts/publisher_specconfig.go
+++ b/cmd/util/opts/publisher_specconfig.go
@@ -117,6 +117,11 @@ func publisherStringToSpecConfig(destinationURI string, options map[string]strin
 			Type:   models.PublisherS3,
 			Params: params,
 		}, nil
+	case "s3managed":
+		return &models.SpecConfig{
+			Type:   models.PublisherS3Managed,
+			Params: make(map[string]interface{}),
+		}, nil
 	case "local":
 		res = publisher_local.NewSpecConfig()
 	default:

--- a/pkg/config/types/publishers.go
+++ b/pkg/config/types/publishers.go
@@ -14,9 +14,10 @@ type PublishersConfig struct {
 }
 
 type PublisherTypes struct {
-	IPFS  IPFSPublisher  `yaml:"IPFS,omitempty" json:"IPFS,omitempty"`
-	S3    S3Publisher    `yaml:"S3,omitempty" json:"S3,omitempty"`
-	Local LocalPublisher `yaml:"Local,omitempty" json:"Local,omitempty"`
+	IPFS      IPFSPublisher      `yaml:"IPFS,omitempty" json:"IPFS,omitempty"`
+	S3        S3Publisher        `yaml:"S3,omitempty" json:"S3,omitempty"`
+	S3Managed S3ManagedPublisher `yaml:"S3Managed,omitempty" json:"S3Managed,omitempty"`
+	Local     LocalPublisher     `yaml:"Local,omitempty" json:"Local,omitempty"`
 }
 
 func (p PublishersConfig) IsNotDisabled(kind string) bool {
@@ -33,6 +34,19 @@ type IPFSPublisher struct {
 type S3Publisher struct {
 	// PreSignedURLDisabled specifies whether pre-signed URLs are enabled for the S3 provider.
 	PreSignedURLDisabled bool `yaml:"PreSignedURLDisabled,omitempty" json:"PreSignedURLDisabled,omitempty"`
+	// PreSignedURLExpiration specifies the duration before a pre-signed URL expires.
+	PreSignedURLExpiration Duration `yaml:"PreSignedURLExpiration,omitempty" json:"PreSignedURLExpiration,omitempty"`
+}
+
+type S3ManagedPublisher struct {
+	// BucketName specifies the S3 bucket name for managed storage
+	BucketName string `yaml:"BucketName,omitempty" json:"BucketName,omitempty"`
+	// KeyPrefix specifies an optional prefix for keys stored in the bucket
+	KeyPrefix string `yaml:"KeyPrefix,omitempty" json:"KeyPrefix,omitempty"`
+	// Region specifies the region the S3 bucket is in
+	Region string `yaml:"Region,omitempty" json:"Region,omitempty"`
+	// Endpoint specifies an optional custom S3 endpoint
+	Endpoint string `yaml:"Endpoint,omitempty" json:"Endpoint,omitempty"`
 	// PreSignedURLExpiration specifies the duration before a pre-signed URL expires.
 	PreSignedURLExpiration Duration `yaml:"PreSignedURLExpiration,omitempty" json:"PreSignedURLExpiration,omitempty"`
 }

--- a/pkg/lib/ncl/provider.go
+++ b/pkg/lib/ncl/provider.go
@@ -1,0 +1,30 @@
+package ncl
+
+type PublisherProvider interface {
+	// GetPublisher returns a publisher for the given subject
+	GetPublisher() (Publisher, error)
+}
+
+type LazyPublisherProvider struct {
+	Provider PublisherProvider
+}
+
+// NewLazyPublisherProvider creates a new LazyPublisherProvider
+func NewLazyPublisherProvider() *LazyPublisherProvider {
+	return &LazyPublisherProvider{
+		Provider: nil,
+	}
+}
+
+// SetProvider sets the requester provider for the delegated requester provider
+func (d *LazyPublisherProvider) SetProvider(provider PublisherProvider) {
+	d.Provider = provider
+}
+
+// GetPublisher returns a publisher for the given subject
+func (d *LazyPublisherProvider) GetPublisher() (Publisher, error) {
+	if d.Provider == nil {
+		return nil, nil
+	}
+	return d.Provider.GetPublisher()
+}

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -55,6 +55,7 @@ const (
 	StorageSourceIPFS           = "ipfs"
 	StorageSourceURL            = "urlDownload"
 	StorageSourceS3             = "s3"
+	StorageSourceS3Managed      = "s3managed"
 	StorageSourceS3PreSigned    = "s3PreSigned"
 	StorageSourceInline         = "inline"
 	StorageSourceLocalDirectory = "localDirectory" // Deprecated: use StorageSourceLocal instead
@@ -72,16 +73,18 @@ var StoragesNames = []string{
 }
 
 const (
-	PublisherNoop  = "noop"
-	PublisherIPFS  = "ipfs"
-	PublisherS3    = "s3"
-	PublisherLocal = "local"
+	PublisherNoop      = "noop"
+	PublisherIPFS      = "ipfs"
+	PublisherS3        = "s3"
+	PublisherS3Managed = "s3managed"
+	PublisherLocal     = "local"
 )
 
 var PublisherNames = []string{
 	PublisherNoop,
 	PublisherIPFS,
 	PublisherS3,
+	PublisherS3Managed,
 	PublisherLocal,
 }
 

--- a/pkg/models/messages/constants.go
+++ b/pkg/models/messages/constants.go
@@ -19,4 +19,7 @@ const (
 	HeartbeatResponseType      = "transport.HeartbeatResponse"
 	NodeInfoUpdateResponseType = "transport.UpdateNodeInfoResponse"
 	ShutdownNoticeResponseType = "transport.ShutdownNoticeResponse"
+
+	ManagedPublisherPreSignURLRequestType  = "managedPublisher.PreSignURLRequest"
+	ManagedPublisherPreSignURLResponseType = "managedPublisher.PreSignURLResponse"
 )

--- a/pkg/models/messages/managed_publisher.go
+++ b/pkg/models/messages/managed_publisher.go
@@ -1,0 +1,14 @@
+package messages
+
+type ManagedPublisherPreSignURLRequest struct {
+	BaseRequest
+	ExecutionID string
+	JobID       string
+}
+
+type ManagedPublisherPreSignURLResponse struct {
+	BaseResponse
+	ExecutionID  string
+	JobID        string
+	PreSignedURL string
+}

--- a/pkg/node/compute.go
+++ b/pkg/node/compute.go
@@ -240,6 +240,7 @@ func NewComputeNode(
 	if err != nil {
 		return nil, err
 	}
+	cfg.DependencyInjector.LazyPublisherProvider.SetProvider(connectionManager)
 
 	// First we attempt to start the legacy connection manager to maintain backward compatibility
 	// with older orchestrator nodes. If it fails, or we receive an upgrade available message, we

--- a/pkg/node/factories.go
+++ b/pkg/node/factories.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/executor"
 	executor_util "github.com/bacalhau-project/bacalhau/pkg/executor/util"
 	baccrypto "github.com/bacalhau-project/bacalhau/pkg/lib/crypto"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/policy"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
@@ -75,7 +76,7 @@ func NewStandardExecutorsFactory(cfg types.EngineConfig) ExecutorsFactory {
 		})
 }
 
-func NewStandardPublishersFactory(cfg types.Bacalhau) PublishersFactory {
+func NewStandardPublishersFactory(cfg types.Bacalhau, nclPublisherProvider ncl.PublisherProvider) PublishersFactory {
 	return PublishersFactoryFunc(
 		func(
 			ctx context.Context,
@@ -83,6 +84,7 @@ func NewStandardPublishersFactory(cfg types.Bacalhau) PublishersFactory {
 			pr, err := publisher_util.NewPublisherProvider(
 				ctx,
 				cfg,
+				nclPublisherProvider,
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/node/factories.go
+++ b/pkg/node/factories.go
@@ -76,16 +76,15 @@ func NewStandardExecutorsFactory(cfg types.EngineConfig) ExecutorsFactory {
 		})
 }
 
-func NewStandardPublishersFactory(cfg types.Bacalhau, nclPublisherProvider ncl.PublisherProvider) PublishersFactory {
+func NewStandardPublishersFactory(
+	cfg types.Bacalhau,
+	nclPublisherProvider ncl.PublisherProvider,
+) PublishersFactory {
 	return PublishersFactoryFunc(
 		func(
 			ctx context.Context,
 			nodeConfig NodeConfig) (publisher.PublisherProvider, error) {
-			pr, err := publisher_util.NewPublisherProvider(
-				ctx,
-				cfg,
-				nclPublisherProvider,
-			)
+			pr, err := publisher_util.NewPublisherProvider(ctx, cfg, nclPublisherProvider)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/bacerrors"
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	baccrypto "github.com/bacalhau-project/bacalhau/pkg/lib/crypto"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/policy"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/validate"
 	"github.com/bacalhau-project/bacalhau/pkg/licensing"
@@ -95,14 +96,18 @@ type NodeDependencyInjector struct {
 	ExecutorsFactory        ExecutorsFactory
 	PublishersFactory       PublishersFactory
 	AuthenticatorsFactory   AuthenticatorsFactory
+	LazyPublisherProvider   *ncl.LazyPublisherProvider
 }
 
-func NewStandardNodeDependencyInjector(cfg types.Bacalhau, userKey *baccrypto.UserKey) NodeDependencyInjector {
+func NewStandardNodeDependencyInjector(
+	cfg types.Bacalhau, userKey *baccrypto.UserKey) NodeDependencyInjector {
+	lazyPublisherProvider := ncl.NewLazyPublisherProvider()
 	return NodeDependencyInjector{
 		StorageProvidersFactory: NewStandardStorageProvidersFactory(cfg),
 		ExecutorsFactory:        NewStandardExecutorsFactory(cfg.Engines),
-		PublishersFactory:       NewStandardPublishersFactory(cfg),
+		PublishersFactory:       NewStandardPublishersFactory(cfg, lazyPublisherProvider),
 		AuthenticatorsFactory:   NewStandardAuthenticatorsFactory(userKey),
+		LazyPublisherProvider:   lazyPublisherProvider,
 	}
 }
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -101,13 +101,13 @@ type NodeDependencyInjector struct {
 
 func NewStandardNodeDependencyInjector(
 	cfg types.Bacalhau, userKey *baccrypto.UserKey) NodeDependencyInjector {
-	lazyPublisherProvider := ncl.NewLazyPublisherProvider()
+	lazyNclPublisherProvider := ncl.NewLazyPublisherProvider()
 	return NodeDependencyInjector{
 		StorageProvidersFactory: NewStandardStorageProvidersFactory(cfg),
 		ExecutorsFactory:        NewStandardExecutorsFactory(cfg.Engines),
-		PublishersFactory:       NewStandardPublishersFactory(cfg, lazyPublisherProvider),
+		PublishersFactory:       NewStandardPublishersFactory(cfg, lazyNclPublisherProvider),
 		AuthenticatorsFactory:   NewStandardAuthenticatorsFactory(userKey),
-		LazyPublisherProvider:   lazyPublisherProvider,
+		LazyPublisherProvider:   lazyNclPublisherProvider,
 	}
 }
 
@@ -412,6 +412,9 @@ func mergeDependencyInjectors(injector NodeDependencyInjector, defaultInjector N
 	}
 	if injector.AuthenticatorsFactory == nil {
 		injector.AuthenticatorsFactory = defaultInjector.AuthenticatorsFactory
+	}
+	if injector.LazyPublisherProvider == nil {
+		injector.LazyPublisherProvider = defaultInjector.LazyPublisherProvider
 	}
 	return injector
 }

--- a/pkg/publisher/s3managed/publisher.go
+++ b/pkg/publisher/s3managed/publisher.go
@@ -2,39 +2,147 @@ package s3managed
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
 
+	"github.com/bacalhau-project/bacalhau/pkg/lib/envelope"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/gzip"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/models/messages"
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+	s3helper "github.com/bacalhau-project/bacalhau/pkg/s3"
+	"github.com/rs/zerolog/log"
 )
 
 type PublisherParams struct {
 	NCLPublisherProvider ncl.PublisherProvider
+	NodeInfoProvider     models.BaseNodeInfoProvider
+	LocalDir             string
+	URLUploader          URLUploader
+}
+
+type Publisher struct {
+	localDir             string
+	uploader             URLUploader
+	nclPublisherProvider ncl.PublisherProvider
+}
+
+func NewPublisher(params PublisherParams) *Publisher {
+	return &Publisher{
+		localDir:             params.LocalDir,
+		uploader:             params.URLUploader,
+		nclPublisherProvider: params.NCLPublisherProvider,
+	}
+}
+
+// This publisher is considered always installed from the compute node's perspective,
+// as it's the orchestrator that is reponsible for providing pre-signed URLs for this publisher.
+// If the orchestrator does not have the managed S3 publisher installed,
+// it will reject jobs that use it before sending them to the compute nodes.
+func (p Publisher) IsInstalled(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (p Publisher) ValidateJob(ctx context.Context, j models.Job) error {
+	spec := j.Task().Publisher
+	if !spec.IsType(models.PublisherS3Managed) {
+		return s3helper.NewS3PublisherError(s3helper.BadRequestErrorCode,
+			fmt.Sprintf("invalid publisher type. expected %s, but received: %s",
+				models.PublisherS3Managed, spec.Type))
+	}
+	return nil
+}
+
+func (p Publisher) PublishResult(ctx context.Context, execution *models.Execution, resultPath string) (models.SpecConfig, error) {
+	log.Ctx(ctx).Debug().
+		Str("execution_id", execution.ID).
+		Str("job_id", execution.Job.ID).
+		Msg("Publishing results to managed S3 bucket using pre-signed URL")
+
+	// Get the pre-signed URL for uploading the result file
+	preSignedURL, err := p.getUploadURL(ctx, execution)
+	if err != nil {
+		return models.SpecConfig{}, fmt.Errorf("failed to get pre-signed URL: %w", err)
+	}
+
+	// Archive and compress the results
+	targetFile, err := os.CreateTemp(p.localDir, "bacalhau-execution-result-*.tar.gz")
+	if err != nil {
+		return models.SpecConfig{}, err
+	}
+	defer targetFile.Close()
+	defer os.Remove(targetFile.Name())
+
+	err = gzip.Compress(resultPath, targetFile)
+	if err != nil {
+		return models.SpecConfig{}, err
+	}
+
+	// Reset file to read from beginning
+	_, err = targetFile.Seek(0, io.SeekStart)
+	if err != nil {
+		return models.SpecConfig{}, err
+	}
+
+	// Upload the result file using the pre-signed URL
+	if err := p.uploader.Upload(ctx, preSignedURL, targetFile); err != nil {
+		return models.SpecConfig{}, fmt.Errorf("failed to upload result file: %w", err)
+	}
+
+	log.Ctx(ctx).Info().
+		Str("execution_id", execution.ID).
+		Str("job_id", execution.Job.ID).
+		Str("result_path", resultPath).
+		Msg("published result to managed S3 bucket")
+
+	return models.SpecConfig{
+		Type: models.StorageSourceS3Managed,
+		Params: SourceSpec{
+			JobID:       execution.Job.ID,
+			ExecutionID: execution.ID,
+		}.ToMap(),
+	}, nil
+}
+
+// getUploadURL retrieves a pre-signed URL for uploading the result file.
+// The URL is provided by the orchestrator via an NCL Publisher
+func (p Publisher) getUploadURL(ctx context.Context, execution *models.Execution) (string, error) {
+	// Use the NCL publisher provider to get the upload URL
+	nclMessagePublisher, err := p.nclPublisherProvider.GetPublisher()
+	if err != nil {
+		return "", fmt.Errorf("failed to get NCL publisher: %w", err)
+	}
+	if nclMessagePublisher == nil {
+		return "", fmt.Errorf("NCL publisher is not set")
+	}
+
+	message := envelope.NewMessage(messages.ManagedPublisherPreSignURLRequest{
+		JobID:       execution.Job.ID,
+		ExecutionID: execution.ID,
+	}).
+		WithMetadataValue(envelope.KeyMessageType, messages.ManagedPublisherPreSignURLRequestType)
+
+	response, err := nclMessagePublisher.Request(ctx, ncl.NewPublishRequest(message))
+	if err != nil {
+		return "", fmt.Errorf("failed to request pre-signed URL: %w", err)
+	}
+
+	responseMessage, ok := response.Payload.(*messages.ManagedPublisherPreSignURLResponse)
+	if !ok {
+		return "", envelope.NewErrUnexpectedPayloadType("ManagedPublisherPreSignURLResponse", reflect.TypeOf(message.Payload).String())
+	}
+
+	log.Ctx(ctx).Debug().
+		Str("execution_id", responseMessage.ExecutionID).
+		Str("job_id", responseMessage.JobID).
+		Str("url", responseMessage.PreSignedURL).
+		Msg("Received pre-signed URL for managed S3 publisher")
+
+	return responseMessage.PreSignedURL, nil
 }
 
 // Compile-time check that publisher implements the correct interface:
 var _ publisher.Publisher = (*Publisher)(nil)
-
-type Publisher struct {
-}
-
-func (p Publisher) IsInstalled(ctx context.Context) (bool, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (p Publisher) ValidateJob(ctx context.Context, j models.Job) error {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (p Publisher) PublishResult(ctx context.Context, execution *models.Execution, resultPath string) (models.SpecConfig, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func NewPublisher(params PublisherParams) *Publisher {
-	return &Publisher{}
-}
-
-// Register

--- a/pkg/publisher/s3managed/publisher.go
+++ b/pkg/publisher/s3managed/publisher.go
@@ -1,0 +1,40 @@
+package s3managed
+
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/publisher"
+)
+
+type PublisherParams struct {
+	NCLPublisherProvider ncl.PublisherProvider
+}
+
+// Compile-time check that publisher implements the correct interface:
+var _ publisher.Publisher = (*Publisher)(nil)
+
+type Publisher struct {
+}
+
+func (p Publisher) IsInstalled(ctx context.Context) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p Publisher) ValidateJob(ctx context.Context, j models.Job) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p Publisher) PublishResult(ctx context.Context, execution *models.Execution, resultPath string) (models.SpecConfig, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func NewPublisher(params PublisherParams) *Publisher {
+	return &Publisher{}
+}
+
+// Register

--- a/pkg/publisher/s3managed/result_transformer.go
+++ b/pkg/publisher/s3managed/result_transformer.go
@@ -1,0 +1,47 @@
+package s3managed
+
+import (
+	"context"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/s3"
+)
+
+// ResultTransformer transforms execution results from S3 managed publisher to S3 pre-signed URLs.
+type ResultTransformer struct {
+	urlGenerator *PreSignedURLGenerator
+}
+
+// NewResultTransformer creates a new ResultTransformer.
+func NewResultTransformer(urlGenerator *PreSignedURLGenerator) *ResultTransformer {
+	return &ResultTransformer{
+		urlGenerator: urlGenerator,
+	}
+}
+
+// Transform checks if the result is from a managed S3 publisher job
+// and transforms it to use a pre-signed URL.
+func (t *ResultTransformer) Transform(ctx context.Context, spec *models.SpecConfig) error {
+	// Skip transformation if not a managed S3 publisher
+	if spec.Type != models.PublisherS3Managed {
+		return nil
+	}
+
+	sourceSpec, err := DecodeSourceSpec(spec)
+	if err != nil {
+		return err
+	}
+
+	preSignedURL, err := t.urlGenerator.GeneratePresignedGetURL(ctx, sourceSpec.JobID, sourceSpec.ExecutionID)
+	if err != nil {
+		return err
+	}
+
+	spec.Type = models.StorageSourceS3PreSigned
+	spec.Params = s3.PreSignedResultSpec{
+		SourceSpec:   s3.SourceSpec{},
+		PreSignedURL: preSignedURL,
+		Managed:      true,
+	}.ToMap()
+	return nil
+}

--- a/pkg/publisher/s3managed/types.go
+++ b/pkg/publisher/s3managed/types.go
@@ -1,0 +1,50 @@
+package s3managed
+
+import (
+	"fmt"
+
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/s3"
+	"github.com/fatih/structs"
+	"github.com/mitchellh/mapstructure"
+)
+
+type SourceSpec struct {
+	JobID       string `json:"job_id"`
+	ExecutionID string `json:"execution_id"`
+}
+
+func (c SourceSpec) ToMap() map[string]any {
+	return structs.Map(c)
+}
+
+func (c SourceSpec) Validate() error {
+	if c.JobID == "" {
+		return s3.NewS3InputSourceError(s3.BadRequestErrorCode, "invalid storage params: job id cannot be empty")
+	}
+	if c.ExecutionID == "" {
+		return s3.NewS3InputSourceError(s3.BadRequestErrorCode, "invalid storage params: execution id cannot be empty")
+	}
+
+	return nil
+}
+
+func DecodeSourceSpec(spec *models.SpecConfig) (SourceSpec, error) {
+	if !spec.IsType(models.StorageSourceS3Managed) {
+		return SourceSpec{}, s3.NewS3InputSourceError(
+			s3.BadRequestErrorCode,
+			fmt.Sprintf("invalid storage source type. expected %s but received: %s", models.StorageSourceS3Managed, spec.Type))
+	}
+
+	inputParams := spec.Params
+	if inputParams == nil {
+		return SourceSpec{}, s3.NewS3InputSourceError(s3.BadRequestErrorCode, "invalid storage source params. cannot be nil")
+	}
+
+	var c SourceSpec
+	if err := mapstructure.Decode(spec.Params, &c); err != nil {
+		return c, err
+	}
+
+	return c, c.Validate()
+}

--- a/pkg/publisher/s3managed/url_generator.go
+++ b/pkg/publisher/s3managed/url_generator.go
@@ -1,0 +1,125 @@
+package s3managed
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/bacalhau-project/bacalhau/pkg/config/types"
+	s3helper "github.com/bacalhau-project/bacalhau/pkg/s3"
+	"github.com/rs/zerolog/log"
+)
+
+type PreSignedURLGeneratorParams struct {
+	ClientProvider  *s3helper.ClientProvider
+	PublisherConfig *types.S3ManagedPublisher
+}
+
+// PreSignedURLGenerator is responsible for generating pre-signed URLs for the managed S3 publisher.
+type PreSignedURLGenerator struct {
+	clientProvider  *s3helper.ClientProvider
+	publisherConfig *types.S3ManagedPublisher
+}
+
+func NewPreSignedURLGenerator(params PreSignedURLGeneratorParams) *PreSignedURLGenerator {
+	return &PreSignedURLGenerator{
+		clientProvider:  params.ClientProvider,
+		publisherConfig: params.PublisherConfig,
+	}
+}
+
+// From the orchestrator's point of view the managed publisher is installed if the S3 client is available
+// and mandatory configuration properties are set.
+func (p *PreSignedURLGenerator) IsInstalled() bool {
+	return p.clientProvider.IsInstalled() &&
+		p.publisherConfig != nil &&
+		p.publisherConfig.BucketName != ""
+}
+
+func (p *PreSignedURLGenerator) GeneratePreSignedPutURL(
+	ctx context.Context,
+	jobID string,
+	executionID string,
+) (string, error) {
+	if jobID == "" || executionID == "" {
+		return "", fmt.Errorf("jobID and executionID must be provided")
+	}
+
+	// Create key with prefix if available
+	key := fmt.Sprintf("%s/%s.tar.gz", jobID, executionID)
+	if p.publisherConfig.KeyPrefix != "" {
+		prefix := strings.TrimSuffix(p.publisherConfig.KeyPrefix, "/")
+		key = fmt.Sprintf("%s/%s", prefix, key)
+	}
+
+	// TODO: Use default expiration if not configured
+	expiration := p.publisherConfig.PreSignedURLExpiration.AsTimeDuration()
+
+	client := p.clientProvider.GetClient(p.publisherConfig.Endpoint, p.publisherConfig.Region)
+
+	// Create PUT request
+	// Do not provide a body because we do not have the full execution result file.
+	request := &s3.PutObjectInput{
+		Bucket: &p.publisherConfig.BucketName,
+		Key:    &key,
+	}
+
+	log.Ctx(ctx).Debug().
+		Str("job_id", jobID).
+		Str("execution_id", executionID).
+		Str("bucket", p.publisherConfig.BucketName).
+		Str("key", key).
+		Msgf("Generating pre-signed PUT URL for S3 object")
+
+	resp, err := client.PresignClient().PresignPutObject(ctx, request, s3.WithPresignExpires(expiration))
+	if err != nil {
+		return "", err
+	}
+
+	return resp.URL, nil
+}
+
+// GeneratePresignedGetURL creates a pre-signed URL for downloading an S3 object.
+func (p *PreSignedURLGenerator) GeneratePresignedGetURL(
+	ctx context.Context,
+	jobID string,
+	executionID string,
+) (string, error) {
+	if jobID == "" || executionID == "" {
+		return "", fmt.Errorf("jobID and executionID must be provided")
+	}
+
+	// Create key with prefix if available
+	key := fmt.Sprintf("%s/%s.tar.gz", jobID, executionID)
+	if p.publisherConfig.KeyPrefix != "" {
+		prefix := strings.TrimSuffix(p.publisherConfig.KeyPrefix, "/")
+		key = fmt.Sprintf("%s/%s", prefix, key)
+	}
+
+	// Use configured expiration time
+	expiration := p.publisherConfig.PreSignedURLExpiration.AsTimeDuration()
+
+	client := p.clientProvider.GetClient(p.publisherConfig.Endpoint, p.publisherConfig.Region)
+
+	// Create GET request for downloading the result
+	request := &s3.GetObjectInput{
+		Bucket: &p.publisherConfig.BucketName,
+		Key:    &key,
+	}
+
+	log.Ctx(ctx).Debug().
+		Str("job_id", jobID).
+		Str("execution_id", executionID).
+		Str("bucket", p.publisherConfig.BucketName).
+		Str("key", key).
+		Msgf("Generating pre-signed GET URL for S3 object")
+
+	// Generate pre-signed URL for GET operation
+	resp, err := client.PresignClient().PresignGetObject(ctx, request, s3.WithPresignExpires(expiration))
+	if err != nil {
+		return "", err
+	}
+
+	return resp.URL, nil
+}

--- a/pkg/publisher/s3managed/url_request_handler.go
+++ b/pkg/publisher/s3managed/url_request_handler.go
@@ -1,0 +1,49 @@
+package s3managed
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/bacalhau-project/bacalhau/pkg/lib/envelope"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
+	"github.com/bacalhau-project/bacalhau/pkg/models/messages"
+	"github.com/rs/zerolog/log"
+)
+
+type PreSignedURLRequestHandler struct {
+	urlGenerator *PreSignedURLGenerator
+}
+
+func NewPreSignedURLRequestHandler(urlGenerator *PreSignedURLGenerator) *PreSignedURLRequestHandler {
+	return &PreSignedURLRequestHandler{
+		urlGenerator: urlGenerator,
+	}
+}
+
+func (rh *PreSignedURLRequestHandler) HandleRequest(ctx context.Context, message *envelope.Message) (*envelope.Message, error) {
+	request, ok := message.Payload.(*messages.ManagedPublisherPreSignURLRequest)
+	if !ok {
+		return nil, envelope.NewErrUnexpectedPayloadType("ManagedPublisherPreSignURLRequest", reflect.TypeOf(message.Payload).String())
+	}
+	if request.JobID == "" || request.ExecutionID == "" {
+		return nil, envelope.NewErrBadMessage("JobID and ExecutionID must be provided")
+	}
+
+	log.Ctx(ctx).Debug().
+		Str("job_id", request.JobID).
+		Str("execution_id", request.ExecutionID).
+		Msg("Receivead a request to generate pre-signed URL for S3 managed publisher")
+
+	url, err := rh.urlGenerator.GeneratePreSignedPutURL(ctx, request.JobID, request.ExecutionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate pre-signed PUT URL: %w", err)
+	}
+	return envelope.NewMessage(messages.ManagedPublisherPreSignURLResponse{
+		JobID:        request.JobID,
+		ExecutionID:  request.ExecutionID,
+		PreSignedURL: url,
+	}).WithMetadataValue(envelope.KeyMessageType, messages.ManagedPublisherPreSignURLResponseType), nil
+}
+
+var _ ncl.RequestHandler = (*PreSignedURLRequestHandler)(nil)

--- a/pkg/publisher/s3managed/url_uploader.go
+++ b/pkg/publisher/s3managed/url_uploader.go
@@ -1,0 +1,134 @@
+package s3managed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Upload uploads a file to the specified URL
+type URLUploader interface {
+	Upload(ctx context.Context, url string, file *os.File) error
+}
+
+const (
+	PreSignedURLUploadRetryCount = 5
+)
+
+type S3PreSignedURLUploader struct {
+	httpClient *http.Client
+	retryCount int
+}
+
+// NewS3PreSignedURLUploader creates a new uploader that uses pre-signed URLs to upload files to S3.
+func NewS3PreSignedURLUploader(httpClient *http.Client) URLUploader {
+	return &S3PreSignedURLUploader{
+		httpClient: httpClient,
+		retryCount: PreSignedURLUploadRetryCount,
+	}
+}
+
+func (u *S3PreSignedURLUploader) Upload(ctx context.Context, url string, file *os.File) error {
+	return u.uploadWithRetry(ctx, url, file, u.retryCount)
+}
+
+func (u *S3PreSignedURLUploader) uploadWithPreSignedURL(
+	ctx context.Context,
+	file *os.File,
+	presignedURL string,
+) error {
+	// Get file info for logging
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to get file stats: %w", err)
+	}
+
+	// Log the upload attempt
+	log.Ctx(ctx).Debug().
+		Str("file", file.Name()).
+		Int64("size", fileInfo.Size()).
+		Msg("Uploading file to S3 using pre-signed URL")
+
+	// Create PUT request using the pre-signed URL
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, presignedURL, file)
+	if err != nil {
+		return fmt.Errorf("failed to create upload request: %w", err)
+	}
+
+	// Set content type and length headers for the upload
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = fileInfo.Size()
+
+	// Perform the upload
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to upload file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("upload failed with status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (u *S3PreSignedURLUploader) uploadWithRetry(
+	ctx context.Context,
+	url string,
+	file *os.File,
+	retryCount int,
+) error {
+	var lastErr error
+	for attempt := 0; attempt <= retryCount; attempt++ {
+		if attempt > 0 {
+			// Wait before retrying, with exponential backoff
+			backoff := attempt - 1
+			if backoff < 0 {
+				backoff = 0
+			}
+			backoffTime := time.Duration(1<<backoff) * time.Second
+			if backoffTime > 30*time.Second {
+				backoffTime = 30 * time.Second
+			}
+
+			log.Ctx(ctx).Debug().
+				Str("file", file.Name()).
+				Int("attempt", attempt).
+				Int("maxRetries", retryCount).
+				Dur("backoffTime", backoffTime).
+				Err(lastErr).
+				Msg("Retrying upload after failure")
+
+			select {
+			case <-time.After(backoffTime):
+				// Continue after backoff
+			case <-ctx.Done():
+				// Context cancelled, abort retries
+				return ctx.Err()
+			}
+		}
+
+		// Attempt upload
+		err := u.uploadWithPreSignedURL(ctx, file, url)
+		if err == nil {
+			// Success
+			if attempt > 0 {
+				log.Ctx(ctx).Debug().
+					Str("file", file.Name()).
+					Int("attempt", attempt+1).
+					Msg("Upload succeeded after retries")
+			}
+			return nil
+		}
+
+		// Save error for potential retry
+		lastErr = err
+	}
+
+	return fmt.Errorf("failed to upload after %d attempts: %w", retryCount+1, lastErr)
+}

--- a/pkg/publisher/util/utils.go
+++ b/pkg/publisher/util/utils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bacalhau-project/bacalhau/pkg/config/types"
 	ipfs_client "github.com/bacalhau-project/bacalhau/pkg/ipfs"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/ncl"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/provider"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
 	"github.com/bacalhau-project/bacalhau/pkg/publisher"
@@ -23,6 +24,7 @@ import (
 func NewPublisherProvider(
 	ctx context.Context,
 	cfg types.Bacalhau,
+	nclPublisherProvider ncl.PublisherProvider,
 ) (publisher.PublisherProvider, error) {
 	storagePath, err := cfg.ResultsStorageDir()
 	if err != nil {

--- a/pkg/s3/result_signer.go
+++ b/pkg/s3/result_signer.go
@@ -63,6 +63,7 @@ func (signer *ResultSigner) Transform(ctx context.Context, spec *models.SpecConf
 	spec.Params = PreSignedResultSpec{
 		SourceSpec:   sourceSpec,
 		PreSignedURL: resp.URL,
+		Managed:      false,
 	}.ToMap()
 	return nil
 }

--- a/pkg/s3/types.go
+++ b/pkg/s3/types.go
@@ -42,13 +42,17 @@ func (c SourceSpec) ToMap() map[string]interface{} {
 type PreSignedResultSpec struct {
 	SourceSpec
 	PreSignedURL string
+	Managed      bool
 }
 
 func (c PreSignedResultSpec) Validate() error {
 	if c.PreSignedURL == "" {
 		return NewS3DownloaderError(BadRequestErrorCode, "invalid s3 signed storage params: signed url cannot be empty")
 	}
-	return c.SourceSpec.Validate()
+	if !c.Managed {
+		return c.SourceSpec.Validate()
+	}
+	return nil
 }
 
 func (c PreSignedResultSpec) ToMap() map[string]interface{} {

--- a/pkg/transport/nclprotocol/compute/manager.go
+++ b/pkg/transport/nclprotocol/compute/manager.go
@@ -560,3 +560,6 @@ func (cm *ConnectionManager) GetPublisher() (ncl.Publisher, error) {
 	}
 	return cm.dataPlane.Requester, nil
 }
+
+// ConnectionManager should implement ncl.PublisherProvider
+var _ ncl.PublisherProvider = (*ConnectionManager)(nil)

--- a/pkg/transport/nclprotocol/compute/manager.go
+++ b/pkg/transport/nclprotocol/compute/manager.go
@@ -550,3 +550,13 @@ func (cm *ConnectionManager) GetHealth() nclprotocol.ConnectionHealth {
 func (cm *ConnectionManager) getState() nclprotocol.ConnectionState {
 	return cm.GetHealth().CurrentState
 }
+
+// GetRequester returns the publisher used for data plane requests.
+func (cm *ConnectionManager) GetPublisher() (ncl.Publisher, error) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	if cm.dataPlane == nil {
+		return nil, nil
+	}
+	return cm.dataPlane.Requester, nil
+}

--- a/pkg/transport/nclprotocol/orchestrator/manager.go
+++ b/pkg/transport/nclprotocol/orchestrator/manager.go
@@ -27,9 +27,10 @@ type ComputeManager struct {
 	config Config
 
 	// Core components
-	natsConn   *nats.Conn    // NATS connection
-	responder  ncl.Responder // Handles control plane requests
-	dataPlanes sync.Map      // map[string]*DataPlane
+	natsConn           *nats.Conn    // NATS connection
+	responder          ncl.Responder // Handles control plane requests
+	dataPlaneResponder ncl.Responder // Handles requests from compute nodes
+	dataPlanes         sync.Map      // map[string]*DataPlane
 
 	// Node management
 	nodeManager nodes.Manager // Tracks node state and health
@@ -73,6 +74,11 @@ func (cm *ComputeManager) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Set up data plane responder for compute nodes
+	if err = cm.setupDataPlaneResponder(ctx); err != nil {
+		return err
+	}
+
 	// Register for node state changes
 	cm.nodeManager.OnConnectionStateChange(cm.handleConnectionStateChange)
 
@@ -113,6 +119,34 @@ func (cm *ComputeManager) setupControlPlane(ctx context.Context) error {
 		cm.responder.Listen(ctx, messages.ShutdownNoticeRequestMessageType,
 			ncl.RequestHandlerFunc(cm.handleShutdownRequest)),
 	)
+}
+
+func (cm *ComputeManager) setupDataPlaneResponder(ctx context.Context) error {
+	var err error
+
+	// Create responder for control messages
+	cm.dataPlaneResponder, err = ncl.NewResponder(cm.natsConn, ncl.ResponderConfig{
+		Name:              "orchestrator-data-plane-responder",
+		MessageRegistry:   cm.config.MessageRegistry,
+		MessageSerializer: cm.config.MessageSerializer,
+		Subject:           nclprotocol.NatsSubjectOrchestratorInRequests(),
+	})
+	if err != nil {
+		return fmt.Errorf("create data plane responder: %w", err)
+	}
+	return nil
+}
+
+// RegisterDataPlaneHandlers registers the handlers for data plane messages.
+// It accepts ctx, messageType, and handler function.
+func (cm *ComputeManager) RegisterDataPlaneHandlers(
+	ctx context.Context,
+	messageType string,
+	handler ncl.RequestHandler) error {
+	if cm.dataPlaneResponder == nil {
+		return fmt.Errorf("data plane responder not initialized")
+	}
+	return cm.dataPlaneResponder.Listen(ctx, messageType, handler)
 }
 
 // Stop gracefully shuts down the manager and all compute node connections.

--- a/pkg/transport/nclprotocol/orchestrator/manager.go
+++ b/pkg/transport/nclprotocol/orchestrator/manager.go
@@ -137,9 +137,8 @@ func (cm *ComputeManager) setupDataPlaneResponder(ctx context.Context) error {
 	return nil
 }
 
-// RegisterDataPlaneHandlers registers the handlers for data plane messages.
-// It accepts ctx, messageType, and handler function.
-func (cm *ComputeManager) RegisterDataPlaneHandlers(
+// RegisterDataPlaneHandler registers a handler for data plane messages.
+func (cm *ComputeManager) RegisterDataPlaneHandler(
 	ctx context.Context,
 	messageType string,
 	handler ncl.RequestHandler) error {

--- a/pkg/transport/nclprotocol/registry.go
+++ b/pkg/transport/nclprotocol/registry.go
@@ -30,6 +30,10 @@ func CreateMessageRegistry() (*envelope.Registry, error) {
 		reg.Register(messages.HeartbeatResponseType, messages.HeartbeatResponse{}),
 		reg.Register(messages.NodeInfoUpdateResponseType, messages.UpdateNodeInfoResponse{}),
 		reg.Register(messages.ShutdownNoticeResponseType, messages.ShutdownNoticeResponse{}),
+
+		// Managed publisher messages
+		reg.Register(messages.ManagedPublisherPreSignURLRequestType, messages.ManagedPublisherPreSignURLRequest{}),
+		reg.Register(messages.ManagedPublisherPreSignURLResponseType, messages.ManagedPublisherPreSignURLResponse{}),
 	)
 	return reg, err
 }

--- a/pkg/transport/nclprotocol/subjects.go
+++ b/pkg/transport/nclprotocol/subjects.go
@@ -8,6 +8,10 @@ func NatsSubjectOrchestratorInCtrl() string {
 	return "bacalhau.global.compute.*.out.ctrl"
 }
 
+func NatsSubjectOrchestratorInRequests() string {
+	return "bacalhau.global.compute.*.out.requests"
+}
+
 func NatsSubjectOrchestratorInMsgs(computeNodeID string) string {
 	return fmt.Sprintf("bacalhau.global.compute.%s.out.msgs", computeNodeID)
 }
@@ -22,6 +26,10 @@ func NatsSubjectComputeInMsgs(computeNodeID string) string {
 
 func NatsSubjectComputeOutCtrl(computeNodeID string) string {
 	return fmt.Sprintf("bacalhau.global.compute.%s.out.ctrl", computeNodeID)
+}
+
+func NatsSubjectComputeOutRequests(computeNodeID string) string {
+	return fmt.Sprintf("bacalhau.global.compute.%s.out.requests", computeNodeID)
 }
 
 func NatsSubjectComputeOutMsgs(computeNodeID string) string {


### PR DESCRIPTION
## Overview
This PR implements a managed S3 publisher for Bacalhau, which allows compute nodes to securely publish execution results to S3 without requiring AWS credentials to be distributed to every compute node. Only the orchestrator needs to have access to the S3 bucket in which the results are stored. Compute nodes use pre-signed URLs to upload results to the orchestrator S3 bucket.

A new Publisher has been added to the Job Spec
```yaml
tasks:
  - name: main
    publisher:
      type: s3managed
```
At the moment it does not have any additional parameters.

Orchestrator can be setup to use the new publisher by providing the following configuration in the `publishers` section of the configuration file.

In YAML file
```yaml
Publishers:
    Types:
        S3Managed:
            BucketName: my-bucket
            KeyPrefix: devstack
            Region: us-east-2
            Endpoint: s3.us-east-2.amazonaws.com
            PreSignedURLExpiration: "10m"
```
In CLI
```shell
bacalhau ...
-c Publishers.Types.S3Managed.BucketName="my-bucket" \
-c Publishers.Types.S3Managed.KeyPrefix="devstack" \
-c Publishers.Types.S3Managed.Region="us-east-2" \
-c Publishers.Types.S3Managed.PreSignedURLExpiration="10m"
```