### PR TITLE
add job version to swagger schema

### DIFF
--- a/pkg/publicapi/endpoint/orchestrator/job.go
+++ b/pkg/publicapi/endpoint/orchestrator/job.go
@@ -119,6 +119,7 @@ func (e *Endpoint) diffJob(c echo.Context) error {
 //	@Param			id		path		string	true	"ID to get the job for"
 //	@Param			include	query		string	false	"Takes history and executions as options. If empty will not include anything else."
 //	@Param			limit	query		int		false	"Number of history or executions to fetch. Should be used in conjugation with include"
+//	@Param      job_version		query		int		0		"Job version to get. Defaults to 0."
 //	@Success		200		{object}	apimodels.GetJobResponse
 //	@Failure		400		{object}	string
 //	@Failure		500		{object}	string

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -392,6 +392,12 @@ const docTemplate = `{
                         "description": "Number of history or executions to fetch. Should be used in conjugation with include",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Job version to get. Defaults to 0.",
+                        "name": "job_version",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -388,6 +388,12 @@
                         "description": "Number of history or executions to fetch. Should be used in conjugation with include",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Job version to get. Defaults to 0.",
+                        "name": "job_version",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/webui/lib/api/schema/swagger.json
+++ b/webui/lib/api/schema/swagger.json
@@ -388,6 +388,12 @@
                         "description": "Number of history or executions to fetch. Should be used in conjugation with include",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Job version to get. Defaults to 0.",
+                        "name": "job_version",
+                        "in": "query"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Add missing job version to `getJob` param annotation + re-generate swagger with `make generate-swagger`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API and Swagger documentation to include a new optional query parameter, `job_version`, for the job details endpoint. This parameter allows specifying which job version to retrieve, with a default value of 0. No functional changes to the API were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->