### PR TITLE
ci: let gocovmerge install use auto Go toolchain

### DIFF
--- a/.github/workflows/_test_coverage.yml
+++ b/.github/workflows/_test_coverage.yml
@@ -32,6 +32,8 @@ jobs:
           go-version-file: go.work
 
       - name: Install gocovmerge
+        env:
+          GOTOOLCHAIN: auto
         run: go install github.com/wadey/gocovmerge@latest
 
       - name: Create coverage directory


### PR DESCRIPTION
## Summary

`Combine Coverage Reports` has been failing on every PR with:

```
go install github.com/wadey/gocovmerge@latest
...
go: golang.org/x/tools@v0.44.0 requires go >= 1.25.0 (running go 1.24.9)
Error: Process completed with exit code 1.
```

## Root cause

`go install github.com/wadey/gocovmerge@latest` resolves gocovmerge's transitive dep `golang.org/x/tools` at install time. gocovmerge has no committed `go.mod` (it's a 2016 package), so Go builds a synthetic module and MVS picks whatever `x/tools` version is current. `x/tools@v0.44.0` (released recently) raised its minimum Go version to 1.25.

CI's `actions/setup-go@v5` sets `GOTOOLCHAIN=local` by default, which disables Go's auto-toolchain download. So instead of fetching Go 1.25 on demand, install fails.

## Fix

Set `GOTOOLCHAIN=auto` on just the `Install gocovmerge` step. That lets Go download the 1.25 toolchain when `x/tools` demands it, without changing the toolchain policy for any other step.

## Alternatives considered

- Bump `go.work`'s Go version to 1.25 — affects everything; unnecessary scope.
- Pin gocovmerge to its commit SHA — doesn't help; with no `go.mod` the synthetic-module resolution still picks latest `x/tools`.
- Write a temp `go.mod` that pins `x/tools` before install — works but is more machinery than needed.

## Test plan

- [ ] CI green on this PR (especially the `Combine Coverage Reports` job)