### PR TITLE
ci: pin coverage job to Go 1.25 for gocovmerge install

### DIFF
--- a/.github/workflows/_test_coverage.yml
+++ b/.github/workflows/_test_coverage.yml
@@ -29,7 +29,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.work
+          # gocovmerge@latest transitively requires golang.org/x/tools which
+          # bumped its floor to Go 1.25. This job only runs gocovmerge against
+          # coverage files, so it is safe to use a newer Go here than go.work.
+          go-version: '1.25'
 
       - name: Install gocovmerge
         run: go install github.com/wadey/gocovmerge@latest


### PR DESCRIPTION
## Summary

Replaces #5242 with a correct fix.

## Why the previous attempt failed

Setting `GOTOOLCHAIN=auto` on the `go install gocovmerge@latest` step looked right but didn't work. Auto-mode picks the *newer* of the local toolchain and whatever is declared in the module's `toolchain` directive. `gocovmerge` is a 2016 package with no `go.mod` at all — Go treats it as a synthetic module with no toolchain declaration, so auto-mode still used the local 1.24.9.

Job log (#5242 run):
```
env: GOTOOLCHAIN: auto
go: downloading github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
go: downloading golang.org/x/tools v0.44.0
go: toolchain upgrade needed to resolve golang.org/x/tools/cover
##[error]Process completed with exit code 1.
```

## Fix

Pin the `Coverage / Report` job's Go version to `1.25` directly in the `setup-go` step. This job only runs `gocovmerge` against coverage files — it does not need to match `go.work`'s 1.24.9.

## Test plan

- [ ] CI green on this PR, especially `Coverage / Report`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version to 1.25 in the test coverage workflow to ensure consistent and reliable test execution across all builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->