### PR TITLE
fix: smoke-test friction (version parse, dev-compat, no-profile API)

### DIFF
--- a/cmd/util/api.go
+++ b/cmd/util/api.go
@@ -52,8 +52,8 @@ func NewAPIClientManager(cmd *cobra.Command, cfg types.Bacalhau) *APIClientManag
 		log.Debug().Err(err).Msg("Failed to load profile")
 	}
 
-	// Priority: explicit --api-host/--api-port flags > profile > default
-	// This ensures CLI flags always take precedence over profiles
+	// Priority: explicit --api-host/--api-port flags > profile > default localhost
+	// This ensures CLI flags always take precedence over profiles.
 	if apiEndpointExplicitlySet(cfg.API) {
 		// Use explicit --api-host/--api-port flags if provided
 		cm.baseURL, _ = ConstructAPIEndpoint(cfg.API)
@@ -64,9 +64,15 @@ func NewAPIClientManager(cmd *cobra.Command, cfg types.Bacalhau) *APIClientManag
 		cm.profileName = name
 		cm.baseURL = p.Endpoint
 		log.Debug().Str("profile", name).Str("endpoint", p.Endpoint).Msg("Using profile for API connection")
+	} else {
+		// Neither explicit flags nor a profile — fall back to the config
+		// defaults (127.0.0.1:1234). This makes local health checks like
+		// `bacalhau agent alive` work out of the box against a co-located
+		// node without requiring `bacalhau profile save` first. HTTP calls
+		// still fail naturally if no server is listening.
+		cm.baseURL, _ = ConstructAPIEndpoint(cfg.API)
+		log.Debug().Str("endpoint", cm.baseURL).Msg("No profile configured; falling back to default localhost endpoint")
 	}
-	// If neither explicit flags nor profile are set, baseURL will be empty
-	// and client calls will fail with a clear error message.
 
 	return cm
 }

--- a/pkg/orchestrator/selection/ranking/min_version.go
+++ b/pkg/orchestrator/selection/ranking/min_version.go
@@ -55,7 +55,15 @@ func (s *MinVersionNodeRanker) RankNodes(ctx context.Context, job models.Job, no
 }
 
 func (s *MinVersionNodeRanker) isCompatibleVersion(nodeVersion models.BuildVersionInfo) bool {
-	// we assume development version is always latest and compatible
+	// Treat any Major=0 Minor=0 (e.g. v0.0.0, v0.0.0-xxxxxxx, v0.0.0-smoke,
+	// v0.0.0-<sha>) as a development build and always compatible. Production
+	// builds are versioned v1+ so this cannot mistakenly admit a real release
+	// with an incompatible minimum.
+	if nodeVersion.Major == "0" && nodeVersion.Minor == "0" {
+		return true
+	}
+	// Backward compatibility: match the exact Development sentinel if someone
+	// set only GitVersion without populating Major/Minor.
 	if s.match(nodeVersion, developmentVersion) {
 		return true
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,15 +51,24 @@ func Get() *models.BuildVersionInfo {
 		log.Fatal().Err(err).Msg("Could not build client information")
 	}
 
-	s, err := semver.NewVersion(GITVERSION)
+	gitVersion := GITVERSION
+	s, err := semver.NewVersion(gitVersion)
 	if err != nil {
-		log.Fatal().Msgf("Could not parse GITVERSION during build - %s", GITVERSION)
+		// A malformed ldflags-injected version (e.g. "smoke-test" instead of a
+		// semver) used to log.Fatal here, which took down the whole process at
+		// startup. Downgrade to a warning and fall back to the Development
+		// sentinel end-to-end — including GitVersion itself, since other
+		// callers (pkg/publicapi/server.go, analytics) re-parse GitVersion
+		// directly and would otherwise fail the same way.
+		log.Warn().Msgf("Could not parse GITVERSION %q as semver; falling back to %s", gitVersion, DevelopmentGitVersion)
+		s = Development
+		gitVersion = DevelopmentGitVersion
 	}
 
 	versionInfo := &models.BuildVersionInfo{
 		Major:      strconv.FormatInt(s.Major(), 10),
 		Minor:      strconv.FormatInt(s.Minor(), 10),
-		GitVersion: GITVERSION,
+		GitVersion: gitVersion,
 		GitCommit:  revision,
 		BuildDate:  revisionTime,
 		GOOS:       runtime.GOOS,

--- a/test/smoke/docker-compose.yml
+++ b/test/smoke/docker-compose.yml
@@ -1,0 +1,67 @@
+# Minimal smoke-test compose: orchestrator + single compute, using local binary.
+# Teardown: docker compose -f test/smoke/docker-compose.yml down -v --remove-orphans
+
+x-bacalhau: &bacalhau
+  # debian:stable-slim + apt-get curl at startup for HTTP healthchecks.
+  image: debian:stable-slim
+  networks:
+    - bacalhau
+  environment:
+    BACALHAU_DIR: /tmp/bacalhau
+    BACALHAU_API_HOST: 127.0.0.1
+
+networks:
+  bacalhau: {}
+
+services:
+  orchestrator:
+    <<: *bacalhau
+    container_name: smoke-orchestrator
+    volumes:
+      - ../../bin/linux_amd64/bacalhau:/usr/local/bin/bacalhau:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1
+        exec bacalhau serve --orchestrator \
+          -c orchestrator.host=0.0.0.0 \
+          -c orchestrator.port=4222 \
+          -c api.host=0.0.0.0 \
+          -c api.port=1234 \
+          -c orchestrator.auth.token=smoke-secret \
+          -c compute.auth.token=smoke-secret \
+          -c updateconfig.interval=0s
+    ports:
+      - "1234:1234"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:1234/api/v1/agent/alive"]
+      interval: 2s
+      timeout: 5s
+      retries: 60
+      start_period: 15s
+
+  compute:
+    <<: *bacalhau
+    container_name: smoke-compute
+    depends_on:
+      orchestrator:
+        condition: service_healthy
+    volumes:
+      - ../../bin/linux_amd64/bacalhau:/usr/local/bin/bacalhau:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1
+        exec bacalhau serve --compute \
+          -c compute.orchestrators=nats://orchestrator:4222 \
+          -c compute.auth.token=smoke-secret \
+          -c api.host=0.0.0.0 \
+          -c api.port=1235 \
+          -c updateconfig.interval=0s
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:1235/api/v1/agent/alive"]
+      interval: 2s
+      timeout: 5s
+      retries: 60
+      start_period: 15s


### PR DESCRIPTION
## Summary

Three runtime ergonomics issues surfaced while building a local docker-compose smoke test against a freshly-built binary. All three were blockers that shouldn't stop local development:

### 1. pkg/version — log.Fatal on unparseable GITVERSION

A malformed ldflags value (e.g. \`-X GITVERSION=smoke-test\`) took down the whole process at startup. Downgrade to a warning and fall back to the \`Development\` sentinel **end-to-end, including \`BuildVersionInfo.GitVersion\`** — because \`pkg/publicapi/server.go\` (line 95) and \`pkg/analytics\` re-parse \`GitVersion\` directly and would otherwise re-trip the same fail with a different error message.

### 2. min_version ranker — dev-version compatibility

The node-compat ranker only accepted the exact \`v0.0.0-xxxxxxx\` sentinel as a development build, rejecting valid dev variants like \`v0.0.0-<sha>\` or \`v0.0.0-smoke\` with *"Bacalhau version is incompatible"*. Smoke stacks with locally-built binaries couldn't schedule any jobs.

Treat any \`Major=0 Minor=0\` version as a dev build. Production releases are \`v1+\` so this cannot admit a real release version that fails minimum checks.

### 3. cmd/util/api — fallback for local health checks

\`bacalhau agent alive\` (and other local-only commands) threw:
\`\`\`
Error: failed to create api client: no profile configured. Create one with: bacalhau profile save <name> --endpoint <url>
\`\`\`
even when \`BACALHAU_API_HOST\` was set and the server was on localhost, because \`apiEndpointExplicitlySet\` returned false for config defaults. Compose healthchecks couldn't use the CLI.

Fall back to the config-default endpoint (127.0.0.1:1234 via \`ConstructAPIEndpoint\`) when neither explicit flags nor a profile are present. HTTP calls still fail naturally if no server is listening. The \`ErrNoProfile\` path still fires for callers that construct \`APIClientManager\` directly with an empty \`baseURL\` (test fixtures).

## Reproduction / regression test

Also adds \`test/smoke/docker-compose.yml\` — a minimal orchestrator + compute stack that mounts the locally-built binary and reproduces all three scenarios:

\`\`\`bash
go build -o bin/linux_amd64/bacalhau -ldflags "-X .../version.GITVERSION=smoke-test" .
docker compose -f test/smoke/docker-compose.yml up -d
# submit a docker-run job via REST, verify stdout
docker compose -f test/smoke/docker-compose.yml down -v --remove-orphans
\`\`\`

Before this PR: binary crashes on start, or binary starts but jobs get \`version is incompatible\`, or compose healthchecks fail with \`no profile configured\`.

After this PR: smoke test runs end-to-end, job completes, stdout is \`hello-from-smoke-test\\ndone\\n\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/util/ ./pkg/orchestrator/selection/ranking/ ./pkg/version/\` — all existing tests pass including \`TestAPIClientManagerNoProfile\`
- [x] Smoke test: binary built with intentionally-broken GITVERSION, stack up, healthy, job runs, output matches, teardown clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API endpoint selection now properly falls back to default localhost settings when no explicit configuration is provided.
  * Version parsing errors no longer crash the process; system gracefully falls back to development version.
  * Improved compatibility checking for development-like version formats.

* **Tests**
  * Added smoke test infrastructure with automated service health verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->