### PR TITLE
ci: repair dependency update container tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,27 +63,6 @@ updates:
           - "minor"
           - "patch"
 
-  # Python/pip - integration/airflow
-  - package-ecosystem: "pip"
-    directory: "/integration/airflow"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "lang/python"
-      - "dependencies"
-      - "integration"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "deps"
-      include: "scope"
-    groups:
-      pip-airflow-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
   # Python/pip - ops
   - package-ecosystem: "pip"
     directory: "/ops"

--- a/test_integration/common_assets/dockerfiles/Dockerfile-JumpboxNode
+++ b/test_integration/common_assets/dockerfiles/Dockerfile-JumpboxNode
@@ -28,7 +28,7 @@ COPY ./ /bacalhau_integration_tests
 COPY ./common_assets/bacalhau_bin /usr/local/bin/bacalhau
 RUN chmod +x /usr/local/bin/bacalhau
 
-# Download the minio cli binary, make it executable, and move it to /usr/local/bin
-RUN curl -o /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc \
-    && chmod +x /tmp/mc \
-    && mv /tmp/mc /usr/local/bin/
+# Download the MinIO CLI, following the release redirect, and validate it at build time.
+RUN curl -fsSL -o /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc \
+    && chmod +x /usr/local/bin/mc \
+    && /usr/local/bin/mc --version


### PR DESCRIPTION
## Summary
- follow the MinIO CLI release redirect and validate the binary during image build
- remove the deleted Airflow integration from Dependabot configuration

## Verification
- pre-commit hooks
- focused Docker Compose S3 managed publisher integration suite
- jumpbox image build and MinIO CLI execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings to streamline scheduled updates.
  * Improved the jumpbox container build by installing the MinIO CLI directly, validating the installation, and preserving executable permissions.
  * Added stricter download handling to help detect failed or incomplete CLI installations during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->