### PR TITLE
ci: automate weekly dependency releases on Blacksmith

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,125 +1,240 @@
 version: 2
+
 updates:
-  # Go modules - main project
-  - package-ecosystem: "gomod"
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: "weekly"
-    labels:
-      - "lang/go"
-      - "dependencies"
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/go", "dependencies", "weekly-release"]
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
-      prefix-development: "dev-deps"
-      include: "scope"
+      prefix: deps
+      prefix-development: dev-deps
+      include: scope
     groups:
       go-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
 
-  # Go modules - test_integration
-  - package-ecosystem: "gomod"
+  - package-ecosystem: gomod
     directory: "/test_integration"
     schedule:
-      interval: "weekly"
-    labels:
-      - "lang/go"
-      - "dependencies"
-      - "test"
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/go", "dependencies", "test", "weekly-release"]
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: deps
+      include: scope
     groups:
       go-test-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
 
-  # npm/yarn - webui
-  - package-ecosystem: "npm"
+  - package-ecosystem: gomod
+    directory: "/pkg/executor/wasm/funcs/http/client"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/go", "dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      wasm-client-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: npm
     directory: "/webui"
     schedule:
-      interval: "weekly"
-    labels:
-      - "lang/javascript"
-      - "dependencies"
-      - "webui"
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/javascript", "dependencies", "webui", "weekly-release"]
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: deps
+      include: scope
     groups:
-      npm-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+      webui-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
 
-  # Python/pip - ops
-  - package-ecosystem: "pip"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/python", "dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      root-python-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: pip
     directory: "/ops"
     schedule:
-      interval: "weekly"
-    labels:
-      - "lang/python"
-      - "dependencies"
-      - "ops"
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/python", "dependencies", "weekly-release"]
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: deps
+      include: scope
     groups:
-      pip-ops-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+      ops-python-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
 
-  # Python/pip - root (if requirements.txt exists)
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: "/python"
     schedule:
-      interval: "weekly"
-    labels:
-      - "lang/python"
-      - "dependencies"
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/python", "dependencies", "weekly-release"]
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: deps
+      include: scope
     groups:
-      pip-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+      sdk-python-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
 
-  # GitHub Actions
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: pip
+    directory: "/clients/python"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/python", "dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      api-client-python-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
-    labels:
-      - "lang/github-actions"
-      - "dependencies"
-    open-pull-requests-limit: 3
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["lang/github-actions", "dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
     commit-message:
-      prefix: "ci"
-      include: "scope"
+      prefix: ci
+      include: scope
     groups:
       github-actions-dependencies:
-        patterns:
-          - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/docker/bacalhau-base"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    groups:
+      base-image-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/docker/bacalhau-dind"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    groups:
+      dind-image-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/docker/ignite-image"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    groups:
+      ignite-image-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/pkg/executor/docker/gateway"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    groups:
+      gateway-image-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/docker-compose-deployment"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["dependencies", "weekly-release"]
+    open-pull-requests-limit: 5
+    groups:
+      compose-image-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/test_integration/common_assets/dockerfiles"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "00:00"
+      timezone: America/Los_Angeles
+    labels: ["dependencies", "test", "weekly-release"]
+    open-pull-requests-limit: 5
+    groups:
+      integration-image-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         include:

--- a/.github/workflows/_docker_publish.yml
+++ b/.github/workflows/_docker_publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   publish-docker-images:
     name: Publish to GHCR
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: ${{ inputs.environment }}
     permissions:
       contents: read

--- a/.github/workflows/_s3_publish.yml
+++ b/.github/workflows/_s3_publish.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   publish-to-s3:
     name: Publish to S3
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: ${{ inputs.environment }}  # Use the specified environment
     permissions:
       contents: read

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   analyze:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   run-tests:
     name: Run
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: ${{ inputs.timeout_minutes }}
     environment: ${{ inputs.environment_name }}
     # Define key paths relative to repository root

--- a/.github/workflows/_test_container.yml
+++ b/.github/workflows/_test_container.yml
@@ -56,7 +56,7 @@ on:
 jobs:
   run-tests:
     name: Run
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: ${{ inputs.timeout_minutes }}
     environment: ${{ inputs.environment_name }}
     # Define key paths relative to repository root

--- a/.github/workflows/_test_coverage.yml
+++ b/.github/workflows/_test_coverage.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   combine-coverage:
     name: Report
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,77 @@
+name: Dependabot Auto-Merge
+
+on:
+  workflow_run:
+    workflows: ["PR Checks"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    name: Merge Green Weekly Update
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Validate weekly Dependabot pull request
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${PR_NUMBER}" ]]; then
+            PR_NUMBER=$(gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+              --jq '[.[] | select(.state == "open")][0].number // empty')
+          fi
+
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          pr=$(gh pr view "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json author,isDraft,labels,state,url)
+
+          author=$(jq -r '.author.login' <<< "${pr}")
+          state=$(jq -r '.state' <<< "${pr}")
+          draft=$(jq -r '.isDraft' <<< "${pr}")
+          weekly=$(jq -r '[.labels[].name] | contains(["weekly-release"])' <<< "${pr}")
+
+          if [[ "${author}" != "app/dependabot" || "${state}" != "OPEN" || "${draft}" != "false" || "${weekly}" != "true" ]]; then
+            echo "eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          url=$(jq -r '.url' <<< "${pr}")
+          echo "eligible=true" >> "${GITHUB_OUTPUT}"
+          echo "url=${url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Approve update
+        if: steps.pull-request.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.pull-request.outputs.url }}
+        run: gh pr review "${PR_URL}" --approve --body "Required checks passed; approved for the weekly dependency batch."
+
+      - name: Squash and merge update
+        if: steps.pull-request.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.pull-request.outputs.url }}
+        run: gh pr merge "${PR_URL}" --squash --delete-branch
+
+      - name: Publish updated main
+        if: steps.pull-request.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run main.yml --repo "${GITHUB_REPOSITORY}" --ref main

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,204 @@
+name: Weekly Dependency Release
+
+on:
+  schedule:
+    # Sunday at 23:00 UTC, after the Sunday dependency batch has had time to merge.
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: weekly-dependency-release
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Release Preflight
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      next_tag: ${{ steps.release.outputs.next_tag }}
+      should_release: ${{ steps.release.outputs.should_release }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check dependency batch and calculate patch version
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          open_updates=$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state open \
+            --label weekly-release \
+            --json number,title,url)
+
+          if [[ "$(jq 'length' <<< "${open_updates}")" -ne 0 ]]; then
+            echo "The weekly dependency batch still has open pull requests:"
+            jq -r '.[] | "#\(.number) \(.title) \(.url)"' <<< "${open_updates}"
+            exit 1
+          fi
+
+          latest_tag=$(gh release list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName')
+
+          if [[ ! "${latest_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Latest stable release is not a semantic version: ${latest_tag}"
+            exit 1
+          fi
+
+          latest_sha=$(git rev-list -n 1 "${latest_tag}")
+          if [[ "${latest_sha}" == "${GITHUB_SHA}" ]]; then
+            echo "No changes since ${latest_tag}; skipping release."
+            echo "should_release=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          next_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+          if git ls-remote --exit-code --tags origin "refs/tags/${next_tag}" >/dev/null 2>&1; then
+            echo "Tag already exists: ${next_tag}"
+            exit 1
+          fi
+
+          echo "next_tag=${next_tag}" >> "${GITHUB_OUTPUT}"
+          echo "should_release=true" >> "${GITHUB_OUTPUT}"
+          echo "Weekly release candidate: ${next_tag} at ${GITHUB_SHA}"
+
+  static-analysis:
+    name: Analyze
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    uses: ./.github/workflows/_static-analysis.yml
+    with:
+      go_version_file: go.work
+      golangci_lint_version: v2.12.2
+
+  unit-tests:
+    name: Unit Tests
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    uses: ./.github/workflows/_test.yml
+    with:
+      test_name: weekly-unit-tests
+      test_args: "-tags=unit"
+
+  integration-tests:
+    name: Integration Tests
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    uses: ./.github/workflows/_test.yml
+    with:
+      test_name: weekly-integration-tests
+      test_args: "-tags=integration"
+      install_ipfs: true
+
+  container-tests:
+    name: Container Tests
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    uses: ./.github/workflows/_test_container.yml
+    with:
+      test_name: weekly-container-tests
+      test_working_dir: test_integration
+      build_mode: make
+      binary_output_path: common_assets/bacalhau_bin
+
+  combined-coverage:
+    name: Coverage
+    needs: [preflight, unit-tests, integration-tests]
+    if: needs.preflight.outputs.should_release == 'true'
+    uses: ./.github/workflows/_test_coverage.yml
+    with:
+      coverage_reports: '["weekly-unit-tests", "weekly-integration-tests"]'
+      output_name: weekly-combined
+      retention_days: 30
+
+  release:
+    name: Publish Patch Release
+    needs:
+      - preflight
+      - static-analysis
+      - unit-tests
+      - integration-tests
+      - container-tests
+      - combined-coverage
+    if: needs.preflight.outputs.should_release == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      actions: write
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NEXT_TAG: ${{ needs.preflight.outputs.next_tag }}
+    steps:
+      - name: Verify tested main commit
+        run: |
+          set -euo pipefail
+          main_sha=$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          if [[ "${main_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "main moved during validation: tested=${GITHUB_SHA} current=${main_sha}"
+            exit 1
+          fi
+
+      - name: Create draft release
+        id: create-release
+        run: |
+          gh release create "${NEXT_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "${NEXT_TAG}" \
+            --generate-notes \
+            --draft
+
+      - name: Publish binaries and images
+        id: publish
+        run: |
+          set -euo pipefail
+          dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run release.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${NEXT_TAG}" \
+            -f release_type=release
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            run_id=$(gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow release.yml \
+              --event workflow_dispatch \
+              --commit "${GITHUB_SHA}" \
+              --limit 10 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt >= \"${dispatched_at}\")][0].databaseId // empty")
+            [[ -n "${run_id}" ]] && break
+            sleep 2
+          done
+
+          if [[ -z "${run_id}" ]]; then
+            echo "Unable to find the dispatched release workflow."
+            exit 1
+          fi
+
+          echo "Release workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+          gh run watch "${run_id}" --repo "${GITHUB_REPOSITORY}" --exit-status
+
+      - name: Publish release
+        if: steps.publish.outcome == 'success'
+        run: gh release edit "${NEXT_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+
+      - name: Remove failed draft release
+        if: failure() && steps.create-release.outcome == 'success'
+        run: gh release delete "${NEXT_TAG}" --repo "${GITHUB_REPOSITORY}" --cleanup-tag --yes || true


### PR DESCRIPTION
## Summary
- move CI, binary builds, container publishing, and S3 publishing to Blacksmith 4-vCPU Ubuntu 24.04 runners
- schedule all maintained dependency ecosystems for Sunday updates, including major versions, under a single release label
- approve and squash-merge only labeled Dependabot PRs whose required PR workflow completed successfully
- run the complete test, coverage, and container gates late Sunday before creating the next patch release
- keep releases in draft until binary and container publishing completes; clean up failed drafts and tags

## Schedule
- dependency updates: Sunday 00:00 America/Los_Angeles
- release gate: Sunday 23:00 UTC

## Safety
- broken or open weekly updates block the release
- a moving `main` branch blocks the release
- no changes since the latest stable tag skips the release
- publishing failures remove the draft release and tag

## Validation
- Dependabot JSON schema validation
- `actionlint` with the Blacksmith runner label registered
- shellcheck on new workflow scripts
- YAML lint and parsing
- full `pre-commit run --all-files`
- live commit-to-PR resolution against an open Dependabot PR
- release preflight no-op and next-patch paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated weekly dependency release processing, including validation, testing, coverage checks, and draft-to-published release promotion.
  - Added automatic approval and merging for eligible dependency updates after successful checks.
  - Added safeguards to prevent duplicate releases and ensure the source branch remains unchanged during publishing.

- **Chores**
  - Expanded dependency update coverage and standardized weekly update scheduling.
  - Updated continuous integration workflows to use a consistent execution environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->