### PR TITLE
fix: propagate compute execution errors

### DIFF
--- a/pkg/compute/bidder.go
+++ b/pkg/compute/bidder.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -50,8 +51,7 @@ func (b Bidder) RunBidding(ctx context.Context, execution *models.Execution) err
 	if err != nil {
 		return b.handleError(ctx, execution, err)
 	}
-	b.handleBidResult(ctx, execution, bidResult)
-	return nil
+	return b.handleBidResult(ctx, execution, bidResult)
 }
 
 // doBidding returns a response based on the below semantics. We will only bid if both semantic
@@ -185,7 +185,7 @@ func (b Bidder) handleBidResult(
 	ctx context.Context,
 	execution *models.Execution,
 	result *bidStrategyResponse,
-) {
+) error {
 	var newExecutionValues models.Execution
 	var newExecutionState models.ExecutionStateType
 	var events []*models.Event
@@ -217,12 +217,20 @@ func (b Bidder) handleBidResult(
 			ExpectedStates: []models.ExecutionStateType{models.ExecutionStateNew},
 		},
 	})
-	// TODO: handle error by either gracefully skipping if the execution is no longer in the created state
-	//  or by failing the execution
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("failed to update execution state")
-		return
+		var invalidStateErr store.ErrInvalidExecutionState
+		if errors.As(err, &invalidStateErr) {
+			log.Ctx(ctx).Debug().
+				Err(err).
+				Str("executionID", execution.ID).
+				Str("expectedState", models.ExecutionStateNew.String()).
+				Str("actualState", invalidStateErr.Actual.String()).
+				Msg("skipping execution state update because execution state changed")
+			return nil
+		}
+		return fmt.Errorf("updating bid result for execution %s: %w", execution.ID, err)
 	}
+	return nil
 }
 
 // handleError is a helper function to handle errors in the bidder.

--- a/pkg/compute/bidder_test.go
+++ b/pkg/compute/bidder_test.go
@@ -30,6 +30,15 @@ type BidderSuite struct {
 	bidder               compute.Bidder
 }
 
+type failingExecutionStore struct {
+	store.ExecutionStore
+	err error
+}
+
+func (s failingExecutionStore) UpdateExecutionState(context.Context, store.UpdateExecutionRequest) error {
+	return s.err
+}
+
 func TestBidderSuite(t *testing.T) {
 	suite.Run(t, new(BidderSuite))
 }
@@ -149,4 +158,47 @@ func (s *BidderSuite) TestRunBidding_PendingApproval() {
 	updatedExecution, err := s.mockExecutionStore.GetExecution(ctx, execution.ID)
 	s.Require().NoError(err)
 	s.Equal(models.ExecutionStateAskForBidAccepted, updatedExecution.ComputeState.StateType)
+}
+
+func (s *BidderSuite) TestRunBidding_IgnoresStaleExecutionState() {
+	ctx := context.Background()
+	execution := mock.ExecutionForJob(mock.Job())
+
+	s.mockSemanticStrategy.EXPECT().ShouldBid(ctx, gomock.Any()).
+		Return(bidstrategy.BidStrategyResponse{ShouldBid: false}, nil)
+
+	s.Require().NoError(s.mockExecutionStore.CreateExecution(ctx, *execution))
+	s.Require().NoError(s.mockExecutionStore.UpdateExecutionState(ctx, store.UpdateExecutionRequest{
+		ExecutionID: execution.ID,
+		NewValues: models.Execution{
+			ComputeState: models.NewExecutionState(models.ExecutionStateRunning),
+		},
+		Condition: store.UpdateExecutionCondition{
+			ExpectedStates: []models.ExecutionStateType{models.ExecutionStateNew},
+		},
+	}))
+
+	s.NoError(s.bidder.RunBidding(ctx, execution))
+
+	updatedExecution, err := s.mockExecutionStore.GetExecution(ctx, execution.ID)
+	s.Require().NoError(err)
+	s.Equal(models.ExecutionStateRunning, updatedExecution.ComputeState.StateType)
+}
+
+func (s *BidderSuite) TestRunBidding_PropagatesStoreFailure() {
+	ctx := context.Background()
+	execution := mock.ExecutionForJob(mock.Job())
+	storeErr := errors.New("store unavailable")
+
+	s.mockSemanticStrategy.EXPECT().ShouldBid(ctx, gomock.Any()).
+		Return(bidstrategy.BidStrategyResponse{ShouldBid: false}, nil)
+
+	bidder := compute.NewBidder(compute.BidderParams{
+		SemanticStrategy: []bidstrategy.SemanticBidStrategy{s.mockSemanticStrategy},
+		Store:            failingExecutionStore{err: storeErr},
+	})
+
+	err := bidder.RunBidding(ctx, execution)
+	s.ErrorIs(err, storeErr)
+	s.ErrorContains(err, execution.ID)
 }

--- a/pkg/compute/metrics.go
+++ b/pkg/compute/metrics.go
@@ -29,4 +29,22 @@ var (
 		metric.WithDescription("Duration of a job on the compute node in milliseconds."),
 		metric.WithUnit("ms"),
 	))
+
+	ExecutionBiddingErrors = lo.Must(meter.Int64Counter(
+		"execution_bidding_errors",
+		metric.WithDescription("Number of errors encountered during execution bidding."),
+		metric.WithUnit("1"),
+	))
+
+	ExecutionRunErrors = lo.Must(meter.Int64Counter(
+		"execution_run_errors",
+		metric.WithDescription("Number of errors encountered while starting executions."),
+		metric.WithUnit("1"),
+	))
+
+	ExecutionCancelErrors = lo.Must(meter.Int64Counter(
+		"execution_cancel_errors",
+		metric.WithDescription("Number of errors encountered while cancelling executions."),
+		metric.WithUnit("1"),
+	))
 )

--- a/pkg/compute/watchers/executor_watcher.go
+++ b/pkg/compute/watchers/executor_watcher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/bacalhau-project/bacalhau/pkg/compute"
 	"github.com/bacalhau-project/bacalhau/pkg/lib/watcher"
 	"github.com/bacalhau-project/bacalhau/pkg/models"
@@ -29,15 +31,37 @@ func (h *ExecutionUpsertHandler) HandleEvent(ctx context.Context, event watcher.
 	}
 
 	execution := upsert.Current
+	logger := log.Ctx(ctx).With().
+		Str("executionID", execution.ID).
+		Str("state", execution.ComputeState.StateType.String()).
+		Logger()
+
+	var err error
 	switch execution.ComputeState.StateType {
 	case models.ExecutionStateNew:
-		return h.bidder.RunBidding(ctx, execution)
+		err = h.bidder.RunBidding(ctx, execution)
+		if err != nil {
+			compute.ExecutionBiddingErrors.Add(ctx, 1)
+			logger.Error().Err(err).Msg("failed to run bidding")
+		}
 	case models.ExecutionStateBidAccepted:
-		return h.executor.Run(ctx, execution)
+		err = h.executor.Run(ctx, execution)
+		if err != nil {
+			compute.ExecutionRunErrors.Add(ctx, 1)
+			logger.Error().Err(err).Msg("failed to run execution")
+		}
 	case models.ExecutionStateCancelled:
-		return h.executor.Cancel(ctx, execution)
+		err = h.executor.Cancel(ctx, execution)
+		if err != nil {
+			compute.ExecutionCancelErrors.Add(ctx, 1)
+			logger.Error().Err(err).Msg("failed to cancel execution")
+		}
 	default:
+		return nil
 	}
 
+	if err != nil {
+		return fmt.Errorf("failed to handle execution state %s: %w", execution.ComputeState.StateType, err)
+	}
 	return nil
 }

--- a/pkg/compute/watchers/executor_watcher_test.go
+++ b/pkg/compute/watchers/executor_watcher_test.go
@@ -1,0 +1,59 @@
+//go:build unit || !integration
+
+package watchers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bacalhau-project/bacalhau/pkg/compute"
+	"github.com/bacalhau-project/bacalhau/pkg/lib/watcher"
+	"github.com/bacalhau-project/bacalhau/pkg/models"
+	"github.com/bacalhau-project/bacalhau/pkg/test/mock"
+)
+
+func TestExecutionUpsertHandlerPropagatesExecutorErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		state models.ExecutionStateType
+		setup func(*compute.MockExecutor, *models.Execution, error)
+	}{
+		{
+			name:  "run",
+			state: models.ExecutionStateBidAccepted,
+			setup: func(executor *compute.MockExecutor, execution *models.Execution, expectedErr error) {
+				executor.EXPECT().Run(gomock.Any(), execution).Return(expectedErr)
+			},
+		},
+		{
+			name:  "cancel",
+			state: models.ExecutionStateCancelled,
+			setup: func(executor *compute.MockExecutor, execution *models.Execution, expectedErr error) {
+				executor.EXPECT().Cancel(gomock.Any(), execution).Return(expectedErr)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			executor := compute.NewMockExecutor(ctrl)
+			execution := mock.Execution()
+			execution.ComputeState = models.NewExecutionState(tt.state)
+			expectedErr := errors.New("executor failure")
+			tt.setup(executor, execution, expectedErr)
+
+			handler := NewExecutionUpsertHandler(executor, compute.Bidder{})
+			err := handler.HandleEvent(context.Background(), watcher.Event{
+				Object: models.ExecutionUpsert{Current: execution},
+			})
+
+			require.ErrorIs(t, err, expectedErr)
+			require.ErrorContains(t, err, "failed to handle execution state "+tt.state.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- return non-race bid state update failures to the execution watcher
- treat stale execution-state races as benign and log their actual state
- add operation-specific bidding, run, and cancellation error counters
- wrap executor errors with execution-state context

Reimplements the valid intent of #4850 on current `main`; the original branch no longer compiles and is substantially behind the repository.

## Tests
- new stale-state and store-failure bidder tests
- new watcher run/cancel error propagation tests
- `GOMAXPROCS=2 go test -p 1 -tags unit ./pkg/compute/... -count=1`
- `golangci-lint run --concurrency 2 ./pkg/compute/...`
- `pre-commit run --files ...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bacalhau-project/codesmith/bacalhau/pr/5361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787028701&installation_id=147527310&pr_number=5361&repository=bacalhau-project%2Fbacalhau&return_to=https%3A%2F%2Fgithub.com%2Fbacalhau-project%2Fbacalhau%2Fpull%2F5361&signature=e88771da44d08f26c05c5ee9e7d4df23f828116ab4380aa01cce0e9dc69bc8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale execution states during bidding.
  * Errors from execution state updates and execution processing are now reported with clear context.
  * Added more reliable handling for bidding, startup, run, and cancellation failures.

* **Monitoring**
  * Added metrics to track errors during bidding, execution, and cancellation.
  * Enhanced execution event logging with relevant state and execution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->