### PR TITLE
fix: harden weekly release gates

### DIFF
--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: 'v2.12.2'
         type: string
+      new_from_rev:
+        description: 'Only report lint issues introduced after this git revision'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   analyze:
@@ -21,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: ${{ inputs.new_from_rev != '' && 0 || 1 }}
 
       # Setup Go with caching
       - name: Setup Go
@@ -54,8 +61,10 @@ jobs:
         uses: golangci/golangci-lint-action@v9.3.0
         with:
           version: ${{ inputs.golangci_lint_version }}
-          args: --timeout=5m --verbose
-          only-new-issues: true
+          args: >-
+            --timeout=5m --verbose
+            ${{ inputs.new_from_rev != '' && format('--new-from-rev={0}', inputs.new_from_rev) || '' }}
+          only-new-issues: ${{ inputs.new_from_rev == '' }}
 
       # Summarize results
       - name: Summary

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -20,6 +20,7 @@ jobs:
     name: Release Preflight
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
+      latest_tag: ${{ steps.release.outputs.latest_tag }}
       next_tag: ${{ steps.release.outputs.next_tag }}
       should_release: ${{ steps.release.outputs.should_release }}
     steps:
@@ -59,6 +60,7 @@ jobs:
             echo "Latest stable release is not a semantic version: ${latest_tag}"
             exit 1
           fi
+          echo "latest_tag=${latest_tag}" >> "${GITHUB_OUTPUT}"
 
           latest_sha=$(git rev-list -n 1 "${latest_tag}")
           if [[ "${latest_sha}" == "${GITHUB_SHA}" ]]; then
@@ -85,6 +87,7 @@ jobs:
     with:
       go_version_file: go.work
       golangci_lint_version: v2.12.2
+      new_from_rev: ${{ needs.preflight.outputs.latest_tag }}
 
   unit-tests:
     name: Unit Tests

--- a/pkg/lib/watcher/boltdb/boltdb.go
+++ b/pkg/lib/watcher/boltdb/boltdb.go
@@ -19,8 +19,9 @@ import (
 )
 
 type subscriber struct {
-	notify chan struct{}
-	done   chan struct{}
+	notify   chan struct{}
+	done     chan struct{}
+	doneOnce sync.Once
 }
 
 // EventStore implements the EventStore interface using BoltDB as the underlying storage.
@@ -35,6 +36,7 @@ type EventStore struct {
 
 	subscribers sync.Map // map[*subscriber]struct{}
 	stopGC      chan struct{}
+	closeOnce   sync.Once
 }
 
 func (s *EventStore) createSubscriber() *subscriber {
@@ -51,7 +53,9 @@ func (s *EventStore) removeSubscriber(sub *subscriber) {
 		return
 	}
 	s.subscribers.Delete(sub)
-	close(sub.done) // Signal any pending operations to stop
+	sub.doneOnce.Do(func() {
+		close(sub.done) // Signal any pending operations to stop
+	})
 }
 func (s *EventStore) notifySubscribers() {
 	s.subscribers.Range(func(key, _ interface{}) bool {
@@ -486,12 +490,14 @@ func (s *EventStore) runGC() error {
 
 // Close stops the garbage collection process and purges the cache.
 func (s *EventStore) Close(ctx context.Context) error {
-	close(s.stopGC)
-	s.subscribers.Range(func(key, _ interface{}) bool {
-		s.removeSubscriber(key.(*subscriber))
-		return true
+	s.closeOnce.Do(func() {
+		close(s.stopGC)
+		s.subscribers.Range(func(key, _ interface{}) bool {
+			s.removeSubscriber(key.(*subscriber))
+			return true
+		})
+		s.cache.Purge()
 	})
-	s.cache.Purge()
 	return nil
 }
 

--- a/pkg/lib/watcher/boltdb/boltdb_test.go
+++ b/pkg/lib/watcher/boltdb/boltdb_test.go
@@ -195,6 +195,17 @@ func (s *BoltDBEventStoreTestSuite) TestLongPolling() {
 	s.assertEventsResponse(resp, 0, watcher.AfterSequenceNumberIterator(0))
 }
 
+func (s *BoltDBEventStoreTestSuite) TestCloseWithActiveSubscriberIsIdempotent() {
+	s.store.options.longPollingTimeout = time.Hour
+	respCh, errCh := s.getEventsAsync(watcher.AfterSequenceNumberIterator(0), 10, watcher.EventFilter{})
+
+	s.Require().NoError(s.store.Close(s.ctx))
+	resp := s.assertResponseReceived(respCh, errCh)
+	s.assertEventsResponse(resp, 0, watcher.AfterSequenceNumberIterator(0))
+
+	s.Require().NoError(s.store.Close(s.ctx))
+}
+
 func (s *BoltDBEventStoreTestSuite) TestCheckpoints() {
 	s.Require().NoError(s.store.StoreCheckpoint(s.ctx, "watcher1", 5))
 	s.Require().NoError(s.store.StoreCheckpoint(s.ctx, "watcher2", 10))


### PR DESCRIPTION
## Summary
- make BoltDB watcher subscriber and store shutdown idempotent
- add a regression test for closing with an active long-poll subscriber
- compare scheduled lint findings against the latest stable release tag

## Verification
- `go test -race -tags=unit ./pkg/lib/watcher/boltdb -count=1`
- `go test -tags=unit ./pkg/lib/watcher/boltdb -run TestBoltDBEventStore/TestCloseWithActiveSubscriberIsIdempotent -count=10`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --new-from-rev=v1.9.1 --timeout=5m --verbose`
- `actionlint .github/workflows/_static-analysis.yml .github/workflows/weekly-release.yml`
- focused pre-commit hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bacalhau-project/codesmith/bacalhau/pr/5371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787077602&installation_id=147527310&pr_number=5371&repository=bacalhau-project%2Fbacalhau&return_to=https%3A%2F%2Fgithub.com%2Fbacalhau-project%2Fbacalhau%2Fpull%2F5371&signature=3e0bdf446265d437c33d974ece0c110fd7f9d12703dd8a24ea06d05a6eede6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability for event monitoring, preventing errors when closing active subscriptions or stores multiple times.
  * Ensured waiting subscribers receive a clean, empty response during shutdown.

* **Chores**
  * Improved static analysis workflows to report only issues introduced after a specified release.
  * Weekly release checks now use the latest stable release as the comparison point.

* **Tests**
  * Added coverage for repeated shutdowns while a subscription is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->