### PR TITLE
fix: fetch release lint baseline

### DIFF
--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -27,7 +27,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          fetch-depth: ${{ inputs.new_from_rev != '' && 0 || 1 }}
+          fetch-depth: ${{ inputs.new_from_rev != '' && '0' || '1' }}
+
+      - name: Verify lint baseline
+        if: inputs.new_from_rev != ''
+        env:
+          BASELINE_REF: ${{ inputs.new_from_rev }}
+        run: git rev-parse --verify "${BASELINE_REF}^{commit}"
 
       # Setup Go with caching
       - name: Setup Go


### PR DESCRIPTION
## Summary
- preserve `fetch-depth: 0` as a string in the reusable static-analysis workflow
- verify the requested lint baseline exists before running golangci-lint

This fixes scheduled releases failing with `fatal: bad revision v1.9.1`.

## Verification
- `actionlint .github/workflows/_static-analysis.yml`
- focused pre-commit hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bacalhau-project/codesmith/bacalhau/pr/5372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787078484&installation_id=147527310&pr_number=5372&repository=bacalhau-project%2Fbacalhau&return_to=https%3A%2F%2Fgithub.com%2Fbacalhau-project%2Fbacalhau%2Fpull%2F5372&signature=4b6b1661b912376f2efe8ea5f5371335942c8df83a3aac44379ee300d9b785a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static analysis for baseline comparisons by ensuring the required commit history is available.
  * Added validation to confirm that the specified lint baseline is a valid commit before analysis runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->