### PR TITLE
fix: create release tag before publishing

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -156,12 +156,21 @@ jobs:
             exit 1
           fi
 
+      - name: Create release tag
+        id: create-tag
+        run: |
+          gh api \
+            --method POST \
+            "/repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${NEXT_TAG}" \
+            -f sha="${GITHUB_SHA}"
+
       - name: Create draft release
         id: create-release
         run: |
           gh release create "${NEXT_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --target "${GITHUB_SHA}" \
+            --verify-tag \
             --title "${NEXT_TAG}" \
             --generate-notes \
             --draft
@@ -202,6 +211,13 @@ jobs:
         if: steps.publish.outcome == 'success'
         run: gh release edit "${NEXT_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
 
-      - name: Remove failed draft release
-        if: failure() && steps.create-release.outcome == 'success'
-        run: gh release delete "${NEXT_TAG}" --repo "${GITHUB_REPOSITORY}" --cleanup-tag --yes || true
+      - name: Remove failed draft release and tag
+        if: failure() && steps.create-tag.outcome == 'success'
+        run: |
+          gh release delete "${NEXT_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --cleanup-tag \
+            --yes || \
+          gh api \
+            --method DELETE \
+            "/repos/${GITHUB_REPOSITORY}/git/refs/tags/${NEXT_TAG}" || true


### PR DESCRIPTION
## Summary
- create the release tag at the tested `main` SHA before creating the draft
- require the draft release to use the verified tag
- clean up both the draft and tag after any publication failure

This fixes `HTTP 422: No ref found for: v1.9.2` when dispatching the binary/image workflow.

## Verification
- `actionlint .github/workflows/weekly-release.yml`
- focused pre-commit hooks
- prior release run completed every validation gate successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bacalhau-project/codesmith/bacalhau/pr/5373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787079899&installation_id=147527310&pr_number=5373&repository=bacalhau-project%2Fbacalhau&return_to=https%3A%2F%2Fgithub.com%2Fbacalhau-project%2Fbacalhau%2Fpull%2F5373&signature=a6304e829c6620b0669bcb46531a0478f43875e33d502ea00b38a9bb3d0e7ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release creation by ensuring the release tag is created and verified before publishing.
  * Enhanced failure cleanup to remove both the draft release and its associated tag when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->