### PR TITLE
fix(webui): keep compatible dependency updates

### DIFF
--- a/webui/lib/api/generated/client/types.gen.ts
+++ b/webui/lib/api/generated/client/types.gen.ts
@@ -151,8 +151,6 @@ type MethodFn = <
 
 type SseFn = <
   TData = unknown,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _TError = unknown,
   ThrowOnError extends boolean = false,
   TResponseStyle extends ResponseStyle = 'fields',
 >(

--- a/webui/lib/api/generated/core/types.gen.ts
+++ b/webui/lib/api/generated/core/types.gen.ts
@@ -94,8 +94,7 @@ export interface Config {
 /**
  * Arbitrary metadata passed through the `meta` request option.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ClientMeta {}
+export type ClientMeta = Record<string, unknown>;
 
 type IsExactlyNeverOrNeverUndefined<T> = [T] extends [never]
   ? true

--- a/webui/package.json
+++ b/webui/package.json
@@ -22,7 +22,7 @@
     "@radix-ui/react-tabs": "^1.1.21",
     "@radix-ui/react-toast": "^1.2.23",
     "@radix-ui/react-tooltip": "^1.2.16",
-    "axios": "^1.18.1",
+    "axios": "^1.19.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.27.0",
@@ -47,7 +47,7 @@
     "eslint-config-next": "^16.2.12",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
-    "postcss": "^8.5.23",
+    "postcss": "^8.5.25",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3"

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -2547,15 +2547,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "axios@npm:1.18.1"
+"axios@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "axios@npm:1.19.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
+    form-data: "npm:^4.0.6"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
+  checksum: 10c0/559fe7d51291787def61566a3db78b87510c8faf9c8a8c006d9d8b933808628ff0d8eca7756b40ae25e07da96d946c68c1ffba3da9075ed0b5d3661801d76869
   languageName: node
   linkType: hard
 
@@ -3672,7 +3672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5":
+"form-data@npm:^4.0.6":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -5124,14 +5124,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.23":
-  version: 8.5.23
-  resolution: "postcss@npm:8.5.23"
+"postcss@npm:^8.5.25":
+  version: 8.5.25
+  resolution: "postcss@npm:8.5.25"
   dependencies:
     nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
+  checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
   languageName: node
   linkType: hard
 
@@ -6198,7 +6198,7 @@ __metadata:
     "@types/react-syntax-highlighter": "npm:^15"
     "@typescript-eslint/eslint-plugin": "npm:^8.65.0"
     "@typescript-eslint/parser": "npm:^8.65.0"
-    axios: "npm:^1.18.1"
+    axios: "npm:^1.19.0"
     class-variance-authority: "npm:^0.7.0"
     clsx: "npm:^2.1.1"
     eslint: "npm:^9.39.5"
@@ -6208,7 +6208,7 @@ __metadata:
     lucide-react: "npm:^1.27.0"
     next: "npm:^16.2.12"
     next-themes: "npm:^0.4.6"
-    postcss: "npm:^8.5.23"
+    postcss: "npm:^8.5.25"
     prettier: "npm:^3.9.6"
     react: "npm:^19"
     react-dom: "npm:^19"


### PR DESCRIPTION
Replaces #5389 with the compatible WebUI dependency updates.

- updates Axios to 1.19.0 and PostCSS to 8.5.25
- retains ESLint 9 because eslint-config-next/react tooling is not compatible with ESLint 10
- removes stale generated-code lint suppressions so the WebUI lint gate is clean

Local verification:
- `corepack yarn lint`
- `corepack yarn build`
- `go test ./webui/...`
- `go test -tags=unit ./pkg/... ./cmd/...`
- `uvx pre-commit run --all-files`

The Docker daemon is unavailable locally; the hosted container check remains the release confirmation boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bacalhau-project/codesmith/bacalhau/pr/5392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788478061&installation_model_id=427922&pr_number=5392&repository=bacalhau-project%2Fbacalhau&return_to=https%3A%2F%2Fgithub.com%2Fbacalhau-project%2Fbacalhau%2Fpull%2F5392&signature=cb2e664245fe6fe3a869e62af32fa8e801370a40a45bce2a6e5243541f25e484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying networking and styling tools to newer versions.
  * No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->