### PR TITLE
fix(security): build with Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bacalhau-project/bacalhau
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BTBurke/k8sresource v1.2.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.26.5
+go 1.26.6
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 use (
 	.

--- a/pkg/executor/wasm/funcs/http/client/go.mod
+++ b/pkg/executor/wasm/funcs/http/client/go.mod
@@ -1,3 +1,3 @@
 module github.com/bacalhau-project/bacalhau/pkg/executor/wasm/funcs/http/client
 
-go 1.26.5
+go 1.26.6

--- a/pkg/executor/wasm/funcs/http/testdata/src/go.mod
+++ b/pkg/executor/wasm/funcs/http/testdata/src/go.mod
@@ -1,6 +1,6 @@
 module http-test
 
-go 1.26.5
+go 1.26.6
 
 require github.com/bacalhau-project/bacalhau/pkg/executor/wasm/funcs/http/client v0.0.0
 

--- a/test_integration/go.mod
+++ b/test_integration/go.mod
@@ -1,6 +1,6 @@
 module bacalhau/integration_tests
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
## Summary

- bump the repository and workspace toolchain from Go 1.26.5 to 1.26.6
- update all workspace module Go directives together
- remediate CVE-2026-39821 in release binaries

## Verification

- `BACALHAU_DIR=... go test -tags=unit -p 1 ./pkg/... ./cmd/...`
- Linux amd64 candidate binary reports `go1.26.6`
- `govulncheck -mode=binary -scan=symbol` no longer reports CVE-2026-39821

The first parallel local run hit two NATS state collisions; both failing tests passed individually and the sequential CI-scoped rerun passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bacalhau-project/codesmith/bacalhau/pr/5435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791167526&installation_model_id=427922&pr_number=5435&repository=bacalhau-project%2Fbacalhau&return_to=https%3A%2F%2Fgithub.com%2Fbacalhau-project%2Fbacalhau%2Fpull%2F5435&signature=4628908742d19c724b7efc75f2865aec9f3ae40b43a6c581fcf04c58bddd4e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain requirement to version 1.26.6 across the main project and test modules.
  * No dependency changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->